### PR TITLE
ci: build Codex Git from dugite fork

### DIFF
--- a/.github/workflows/codex-release.yml
+++ b/.github/workflows/codex-release.yml
@@ -136,8 +136,8 @@ jobs:
       - name: Check out Dugite Native
         uses: actions/checkout@v6
         with:
-          repository: desktop/dugite-native
-          ref: f97e50add48cdcff053a69d95aa343a4a4a258c2
+          repository: dreynaud-oai/dugite-native
+          ref: b6f4473557acb85433fdf9deffe0854a34fd9cc5
           path: dugite-native
           fetch-depth: 0
           persist-credentials: false


### PR DESCRIPTION
The pinned Dugite Native revision edits its generated Makefile during Linux cross-builds. Git detects that tracked edit and emits a `.dirty` version, which caused the Linux arm64 Codex release artifact to fail version validation.

Point the release workflow at `dreynaud-oai/dugite-native` commit `b6f4473557acb85433fdf9deffe0854a34fd9cc5`, now on the fork's main branch. That commit passes `STRIP` directly to `make`, avoiding the tracked-file edit while preserving the cross-strip behavior.