### PR TITLE
Build Codex Git releases with LTO and PGO

### DIFF
--- a/.github/workflows/codex-pgo-training.sh
+++ b/.github/workflows/codex-pgo-training.sh
@@ -1,0 +1,60 @@
+#!/bin/sh
+
+# Keep this workload short and biased toward the local Git operations Codex
+# invokes frequently. The full Git test suite is too slow for each release
+# target and would weight test-harness paths more heavily than status, diff,
+# clone, fetch, and repository maintenance.
+
+set -eu
+
+git_bin="$PWD/bin-wrappers/git"
+training_dir=$(mktemp -d "${TMPDIR:-/tmp}/codex-git-pgo.XXXXXX")
+repo="$training_dir/repo"
+clone="$training_dir/clone"
+
+cleanup () {
+	rm -rf "$training_dir"
+}
+trap cleanup EXIT HUP INT TERM
+
+mkdir -p "$training_dir/home"
+export HOME="$training_dir/home"
+export GIT_CONFIG_NOSYSTEM=1
+export GIT_TERMINAL_PROMPT=0
+
+"$git_bin" clone --quiet --no-local "$PWD" "$repo"
+"$git_bin" -C "$repo" config user.name "Codex Git PGO"
+"$git_bin" -C "$repo" config user.email "codex-git-pgo@openai.com"
+
+i=0
+while test "$i" -lt 256
+do
+	dir="$repo/training/$((i % 16))"
+	mkdir -p "$dir"
+	printf '%s\n' "$i" >"$dir/file-$i"
+	i=$((i + 1))
+done
+
+"$git_bin" -C "$repo" status --porcelain=v2 --branch >/dev/null
+"$git_bin" -C "$repo" status --porcelain=v2 --branch --untracked-files=all >/dev/null
+"$git_bin" -C "$repo" ls-files --others --exclude-standard >/dev/null
+"$git_bin" -C "$repo" add training
+"$git_bin" -C "$repo" diff --cached --stat >/dev/null
+"$git_bin" -C "$repo" commit --quiet -m "add training files"
+
+printf 'changed\n' >>"$repo/training/0/file-0"
+rm "$repo/training/1/file-1"
+mkdir -p "$repo/untracked"
+printf 'new\n' >"$repo/untracked/file"
+
+"$git_bin" -C "$repo" status --porcelain=v2 --branch >/dev/null
+"$git_bin" -C "$repo" diff --stat >/dev/null
+"$git_bin" -C "$repo" diff --name-status >/dev/null
+"$git_bin" -C "$repo" ls-files --stage >/dev/null
+"$git_bin" -C "$repo" log --oneline --decorate -20 >/dev/null
+"$git_bin" -C "$repo" rev-list --objects --all >/dev/null
+"$git_bin" -C "$repo" for-each-ref --format='%(refname) %(objectname)' >/dev/null
+"$git_bin" -C "$repo" repack -ad
+"$git_bin" clone --quiet --no-local "$repo" "$clone"
+"$git_bin" -C "$clone" status --porcelain=v2 --branch >/dev/null
+"$git_bin" -C "$clone" fetch --quiet "$repo"

--- a/.github/workflows/codex-release.yml
+++ b/.github/workflows/codex-release.yml
@@ -69,6 +69,7 @@ jobs:
             binary: /tmp/build/git/bin/git
             file_pattern: Mach-O 64-bit executable arm64
             has_gcm: false
+            lto: thin
             max_tar_bytes: 67108864
           - name: macOS x64
             os: macos-15-intel
@@ -78,6 +79,7 @@ jobs:
             binary: /tmp/build/git/bin/git
             file_pattern: Mach-O 64-bit executable x86_64
             has_gcm: false
+            lto: thin
             max_tar_bytes: 67108864
           # Keep arm64 builds native so release smoke tests can execute them.
           - name: Linux arm64
@@ -88,6 +90,7 @@ jobs:
             binary: /tmp/build/git/bin/git
             file_pattern: ELF 64-bit.*ARM aarch64
             has_gcm: false
+            lto: auto
             max_tar_bytes: 67108864
           - name: Linux x64
             os: ubuntu-22.04
@@ -97,6 +100,7 @@ jobs:
             binary: /tmp/build/git/bin/git
             file_pattern: ELF 64-bit.*x86-64
             has_gcm: false
+            lto: auto
             max_tar_bytes: 67108864
           - name: Windows arm64
             os: windows-11-arm
@@ -106,6 +110,7 @@ jobs:
             binary: /tmp/build/git/clangarm64/bin/git.exe
             file_pattern: PE32\+.*ARM64
             has_gcm: true
+            lto: thin
             max_tar_bytes: 134217728
             sdk_arch: aarch64
             sdk_flavor: full
@@ -122,6 +127,7 @@ jobs:
             binary: /tmp/build/git/mingw64/bin/git.exe
             file_pattern: PE32\+.*x86-64
             has_gcm: true
+            lto: auto
             max_tar_bytes: 134217728
             sdk_arch: x86_64
             sdk_flavor: full
@@ -161,6 +167,11 @@ jobs:
             -c 'user.name=github-actions[bot]' \
             -c 'user.email=41898282+github-actions[bot]@users.noreply.github.com' \
             tag -a "$VERSION" -m "$VERSION"
+
+      - name: Install OpenAI build configuration
+        shell: bash
+        working-directory: dugite-native/git
+        run: cp config.mak.openai config.mak
 
       # Match Dugite Native's compatibility choice for its macOS x64 build.
       - name: Select Xcode 16.4
@@ -257,6 +268,7 @@ jobs:
         working-directory: dugite-native
         env:
           NO_RUST: 1
+          OPENAI_LTO: ${{ matrix.lto }}
           TARGET_PLATFORM: ${{ matrix.target_platform }}
           TARGET_ARCH: ${{ matrix.arch }}
         run: |
@@ -282,6 +294,7 @@ jobs:
         working-directory: dugite-native/git
         env:
           MINGW_DIR: ${{ matrix.mingw_dir }}
+          OPENAI_LTO: ${{ matrix.lto }}
         run: |
           set -euo pipefail
 
@@ -307,6 +320,7 @@ jobs:
           GIT_BINARY: ${{ matrix.binary }}
           FILE_PATTERN: ${{ matrix.file_pattern }}
           HAS_GCM: ${{ matrix.has_gcm }}
+          LTO: ${{ matrix.lto }}
         run: |
           set -euo pipefail
           if test "$TARGET_PLATFORM" = win32
@@ -334,6 +348,7 @@ jobs:
           file "$GIT_BINARY" | tee /tmp/git-file-type
           grep -E "$FILE_PATTERN" /tmp/git-file-type
           strings "$GIT_BINARY" | grep -F "$GITHUB_SHA"
+          grep -F -- "-flto=$LTO" dugite-native/git/GIT-CFLAGS
 
       - name: Smoke-test the native distribution
         shell: bash

--- a/.github/workflows/codex-release.yml
+++ b/.github/workflows/codex-release.yml
@@ -56,7 +56,7 @@ jobs:
     name: ${{ matrix.name }}
     needs: version
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 30
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -70,6 +70,8 @@ jobs:
             file_pattern: Mach-O 64-bit executable arm64
             has_gcm: false
             lto: thin
+            profile_format: LLVM
+            llvm_profdata: xcrun llvm-profdata
             max_tar_bytes: 67108864
           - name: macOS x64
             os: macos-15-intel
@@ -80,6 +82,8 @@ jobs:
             file_pattern: Mach-O 64-bit executable x86_64
             has_gcm: false
             lto: thin
+            profile_format: LLVM
+            llvm_profdata: xcrun llvm-profdata
             max_tar_bytes: 67108864
           # Keep arm64 builds native so release smoke tests can execute them.
           - name: Linux arm64
@@ -91,6 +95,7 @@ jobs:
             file_pattern: ELF 64-bit.*ARM aarch64
             has_gcm: false
             lto: auto
+            profile_format: GCC
             max_tar_bytes: 67108864
           - name: Linux x64
             os: ubuntu-22.04
@@ -101,6 +106,7 @@ jobs:
             file_pattern: ELF 64-bit.*x86-64
             has_gcm: false
             lto: auto
+            profile_format: GCC
             max_tar_bytes: 67108864
           - name: Windows arm64
             os: windows-11-arm
@@ -111,6 +117,8 @@ jobs:
             file_pattern: PE32\+.*ARM64
             has_gcm: true
             lto: thin
+            profile_format: LLVM
+            llvm_profdata: llvm-profdata
             max_tar_bytes: 134217728
             sdk_arch: aarch64
             sdk_flavor: full
@@ -128,6 +136,7 @@ jobs:
             file_pattern: PE32\+.*x86-64
             has_gcm: true
             lto: auto
+            profile_format: GCC
             max_tar_bytes: 134217728
             sdk_arch: x86_64
             sdk_flavor: full
@@ -261,14 +270,18 @@ jobs:
             dependencies.json >"$updated"
           mv "$updated" dependencies.json
 
-      # Dugite cross-compiles several targets. Keep Git's optional Rust
-      # library disabled until its Makefile can direct Cargo at those targets.
+      # Build an instrumented Git, run a representative local workload, then
+      # rebuild with its profile. Keep Git's optional Rust library disabled
+      # until its Makefile can direct Cargo at these targets.
       - name: Build the Dugite Native distribution
         shell: bash
         working-directory: dugite-native
         env:
           NO_RUST: 1
+          OPENAI_LLVM_PROFDATA: ${{ matrix.llvm_profdata }}
           OPENAI_LTO: ${{ matrix.lto }}
+          OPENAI_PROFILE: BUILD
+          OPENAI_PROFILE_FORMAT: ${{ matrix.profile_format }}
           TARGET_PLATFORM: ${{ matrix.target_platform }}
           TARGET_ARCH: ${{ matrix.arch }}
         run: |
@@ -294,7 +307,9 @@ jobs:
         working-directory: dugite-native/git
         env:
           MINGW_DIR: ${{ matrix.mingw_dir }}
+          OPENAI_LLVM_PROFDATA: ${{ matrix.llvm_profdata }}
           OPENAI_LTO: ${{ matrix.lto }}
+          OPENAI_PROFILE_FORMAT: ${{ matrix.profile_format }}
         run: |
           set -euo pipefail
 
@@ -309,8 +324,8 @@ jobs:
             SKIP_DASHED_BUILT_INS=YesPlease
           )
           jobs="${NUMBER_OF_PROCESSORS:-2}"
-          make -j"$jobs" "${make_args[@]}" all
-          make "${make_args[@]}" DESTDIR=/tmp/build/git strip install
+          make -j"$jobs" "${make_args[@]}" OPENAI_PROFILE=BUILD all
+          make "${make_args[@]}" OPENAI_PROFILE=USE DESTDIR=/tmp/build/git strip install
 
       - name: Verify distribution layout and provenance
         shell: bash
@@ -321,6 +336,7 @@ jobs:
           FILE_PATTERN: ${{ matrix.file_pattern }}
           HAS_GCM: ${{ matrix.has_gcm }}
           LTO: ${{ matrix.lto }}
+          PROFILE_FORMAT: ${{ matrix.profile_format }}
         run: |
           set -euo pipefail
           if test "$TARGET_PLATFORM" = win32
@@ -349,6 +365,12 @@ jobs:
           grep -E "$FILE_PATTERN" /tmp/git-file-type
           strings "$GIT_BINARY" | grep -F "$GITHUB_SHA"
           grep -F -- "-flto=$LTO" dugite-native/git/GIT-CFLAGS
+          if test "$PROFILE_FORMAT" = LLVM
+          then
+            grep -F -- "-fprofile-instr-use=" dugite-native/git/GIT-CFLAGS
+          else
+            grep -F -- "-fprofile-use=" dugite-native/git/GIT-CFLAGS
+          fi
 
       - name: Smoke-test the native distribution
         shell: bash

--- a/.github/workflows/codex-release.yml
+++ b/.github/workflows/codex-release.yml
@@ -79,8 +79,9 @@ jobs:
             file_pattern: Mach-O 64-bit executable x86_64
             has_gcm: false
             max_tar_bytes: 67108864
+          # Keep arm64 builds native so release smoke tests can execute them.
           - name: Linux arm64
-            os: ubuntu-22.04
+            os: ubuntu-22.04-arm
             target_platform: ubuntu
             asset_platform: ubuntu
             arch: arm64
@@ -195,19 +196,13 @@ jobs:
       - name: Install Linux arm64 build dependencies
         if: matrix.target_platform == 'ubuntu' && matrix.arch == 'arm64'
         run: |
-          sudo sed -i "s/^deb/deb [arch=amd64,i386]/g" /etc/apt/sources.list
-          release="$(lsb_release -s -c)"
-          echo "deb [arch=arm64,armhf] http://azure.ports.ubuntu.com/ ${release} main universe multiverse restricted" | sudo tee -a /etc/apt/sources.list
-          echo "deb [arch=arm64,armhf] http://azure.ports.ubuntu.com/ ${release}-updates main universe multiverse restricted" | sudo tee -a /etc/apt/sources.list
-          sudo dpkg --add-architecture arm64
-          sudo apt-get update
           sudo apt-get install -y \
             binutils-aarch64-linux-gnu \
             gcc-aarch64-linux-gnu \
-            libcurl4-gnutls-dev:arm64 \
-            libexpat1-dev:arm64 \
-            libssl-dev:arm64 \
-            zlib1g-dev:arm64
+            libcurl4-gnutls-dev \
+            libexpat1-dev \
+            libssl-dev \
+            zlib1g-dev
 
       # Dugite Native currently pins MinGit 2.53. Keep its build script and
       # dependency schema, but match the runtime to the Git series we compile.
@@ -341,7 +336,6 @@ jobs:
           strings "$GIT_BINARY" | grep -F "$GITHUB_SHA"
 
       - name: Smoke-test the native distribution
-        if: matrix.arch == 'x64' || matrix.target_platform == 'win32'
         shell: bash
         env:
           TARGET_PLATFORM: ${{ matrix.target_platform }}

--- a/config.mak.openai
+++ b/config.mak.openai
@@ -1,0 +1,10 @@
+# OpenAI release build settings.
+#
+# The Codex release workflow copies this file to config.mak before
+# building. Keep release-only optimizations here instead of in the
+# upstream Makefile.
+
+ifdef OPENAI_LTO
+CFLAGS_APPEND += -flto=$(OPENAI_LTO)
+LDFLAGS_APPEND += -flto=$(OPENAI_LTO)
+endif

--- a/config.mak.openai
+++ b/config.mak.openai
@@ -4,7 +4,71 @@
 # building. Keep release-only optimizations here instead of in the
 # upstream Makefile.
 
+OPENAI_PROFILE_DIR := $(CURDIR)
+OPENAI_PROFILE_RAW := $(OPENAI_PROFILE_DIR)/default_%m_%p.profraw
+OPENAI_PROFILE_DATA := $(OPENAI_PROFILE_DIR)/default.profdata
+OPENAI_PROFILE_TRAINING ?= .github/workflows/codex-pgo-training.sh
+OPENAI_LLVM_PROFDATA ?= llvm-profdata
+
 ifdef OPENAI_LTO
 CFLAGS_APPEND += -flto=$(OPENAI_LTO)
 LDFLAGS_APPEND += -flto=$(OPENAI_LTO)
 endif
+
+ifeq ("$(OPENAI_PROFILE_FORMAT)","LLVM")
+ifeq ("$(OPENAI_PROFILE)","GEN")
+	BASIC_CFLAGS += -fprofile-instr-generate=$(OPENAI_PROFILE_RAW)
+	BASIC_CFLAGS += -DNO_NORETURN=1
+	export CCACHE_DISABLE = t
+	V = 1
+else
+ifneq ("$(OPENAI_PROFILE)","")
+	BASIC_CFLAGS += -fprofile-instr-use=$(OPENAI_PROFILE_DATA)
+	BASIC_CFLAGS += -Wno-profile-instr-unprofiled -DNO_NORETURN=1
+	export CCACHE_DISABLE = t
+	V = 1
+endif
+endif
+else
+ifeq ("$(OPENAI_PROFILE)","GEN")
+	BASIC_CFLAGS += -fprofile-generate=$(OPENAI_PROFILE_DIR)
+	BASIC_CFLAGS += -DNO_NORETURN=1
+	EXTLIBS += -lgcov
+	export CCACHE_DISABLE = t
+	V = 1
+else
+ifneq ("$(OPENAI_PROFILE)","")
+	BASIC_CFLAGS += -fprofile-use=$(OPENAI_PROFILE_DIR)
+	BASIC_CFLAGS += -fprofile-correction -DNO_NORETURN=1
+	export CCACHE_DISABLE = t
+	V = 1
+endif
+endif
+endif
+
+# Every C object already waits for Git's forced GIT-CFLAGS target. Gate that
+# target so "make strip install" finishes PGO before its normal prerequisites
+# can start compiling with profile-use flags.
+ifeq "$(OPENAI_PROFILE)" "BUILD"
+GIT-CFLAGS: openai-profile
+endif
+
+openai-profile: profile-clean openai-profile-clean
+	$(MAKE) OPENAI_PROFILE=GEN all
+	$(SHELL_PATH) $(OPENAI_PROFILE_TRAINING)
+	$(MAKE) OPENAI_PROFILE= openai-profile-merge
+	$(MAKE) OPENAI_PROFILE=USE all
+
+openai-profile-merge:
+ifeq ("$(OPENAI_PROFILE_FORMAT)","LLVM")
+	$(OPENAI_LLVM_PROFDATA) merge \
+		-output=$(OPENAI_PROFILE_DATA) \
+		$(OPENAI_PROFILE_DIR)/*.profraw
+endif
+
+clean: openai-profile-clean
+
+openai-profile-clean:
+	$(RM) $(OPENAI_PROFILE_DIR)/*.profraw $(OPENAI_PROFILE_DATA)
+
+.PHONY: openai-profile openai-profile-merge openai-profile-clean


### PR DESCRIPTION
## Summary

- run Linux arm64 Codex release builds natively and smoke-test every bundle
- build release artifacts with thin LTO for Clang targets and automatic LTO for GCC targets
- train each release build with a short Codex-shaped PGO workload before the profile-use rebuild

## Why

The current Codex release path inherits Git's default `-O2` build and compiles each artifact once. LTO lets the compiler optimize across translation units; PGO lets the final binary use frequencies from the local Git operations Codex calls most often.

The PGO trainer intentionally avoids Git's full 1,048-script test suite. Git's built-in `PROFILE=BUILD` path runs that suite serially; recent upstream CI spends tens of minutes on full-suite coverage, while the focused local trainer took about 30 seconds. The trainer covers clone, status, untracked discovery, add, diff, commit, log, ref enumeration, repack, and fetch.

## Approach

- Keep release-only flags and make orchestration in `config.mak.openai`, copied into Git's ignored `config.mak` slot by the release workflow.
- Use `-flto=thin` for Clang targets and `-flto=auto` for GCC targets.
- Use LLVM raw profiles plus `llvm-profdata` on Clang targets and gcov profiles on GCC targets.
- Gate `GIT-CFLAGS` on the instrumented build, training workload, merge, and profile-use rebuild so `make strip install` cannot start final compilation before the profile exists.
- Verify final `GIT-CFLAGS` records both LTO and profile-use flags, then smoke-test every distribution.

## Commit structure

1. `ci: run Codex Linux arm64 releases natively`
2. `ci: build Codex Git releases with LTO`
3. `ci: train Codex Git releases with PGO`

## Validation

- clean local macOS arm64 LTO-only build; final `GIT-CFLAGS` contained `-flto=thin` and no profile flag
- clean local macOS arm64 PGO `make strip install`; observed generation, trainer, LLVM profile merge, profile-use rebuild, strip, and install
- installed macOS arm64 binary ran `--version --build-options`; final `GIT-CFLAGS` contained `-flto=thin` and `-fprofile-instr-use=`
- `git show --check` for each commit
- `git diff --check`, workflow YAML parse, and `sh -n .github/workflows/codex-pgo-training.sh`

The workflow now performs a second compilation pass and adds roughly 30 seconds of focused training per target, so its timeout increases from 30 to 60 minutes. This validates the build plumbing and artifact provenance; it does not claim a measured runtime speedup yet. Cross-platform PGO behavior remains for the draft PR matrix to exercise.

<!-- codex-thread: 019f8634-0856-7a52-acfe-4b7ae9e733ee -->
