### PR TITLE
ci: update the Codex refresh trampoline

### DIFF
--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -3,9 +3,9 @@ name: Refresh codex
 on: workflow_dispatch
 
 permissions:
+  actions: read
   contents: read
 
 jobs:
   refresh:
     uses: openai/git/.github/workflows/codex.yml@meta
-    secrets: inherit


### PR DESCRIPTION
## Summary

Update the active automation topic to carry the exact dispatch trampoline expected by the stateful `meta` controller:

- keep `workflow_dispatch` on the distributed `codex` branch
- grant only `actions: read` and `contents: read`
- call `openai/git/.github/workflows/codex.yml@meta`
- remove `secrets: inherit`

This branch is a single commit whose parent is the current `tb/codex/automation` tip. Keep the topic linear when landing it.

## Rollout order

Land the controller PR into `meta` first. Then fast-forward or rebase-merge this PR into `tb/codex/automation`. This PR alone does not change the distributed `codex` branch; the trampoline reaches `codex` only through the subsequently approved refresh.

## Validation

The resulting workflow matches the controller's canonical trampoline byte-for-byte. Its parent is live `tb/codex/automation` at `837473d05ed12a94cc8b682063e31159c53b1f1c`.

<!-- codex-thread: 019fb902-4685-73c3-866c-26d0c59bc3de -->