### PR TITLE
ci: match symbolic reusable workflow references

### DIFF
--- a/.github/workflows/codex-branch.sh
+++ b/.github/workflows/codex-branch.sh
@@ -2856,7 +2856,7 @@ publish_run () {
 		die "candidate metadata and update manifest disagree"
 
 	controller_matches=$(gh api --hostname github.com "$endpoint" --jq \
-		"[.referenced_workflows[] | select(.path == \"openai/git/.github/workflows/codex.yml@$run_controller\" and .ref == \"refs/heads/meta\" and .sha == \"$run_controller\")] | length") ||
+		"[.referenced_workflows[] | select(.path == \"openai/git/.github/workflows/codex.yml@meta\" and .ref == \"refs/heads/meta\" and .sha == \"$run_controller\")] | length") ||
 		die "could not verify the reusable controller for Actions run $run_id"
 	test "$controller_matches" = 1 ||
 		die "Actions run $run_id was not executed by the pinned meta controller"

--- a/t/t9905-codex-branch.sh
+++ b/t/t9905-codex-branch.sh
@@ -2656,9 +2656,9 @@ test_expect_success PYTHON 'publish-run authenticates the artifact and promotes 
 			case "$*" in
 			*referenced_workflows*)
 				case "$*" in
-				*"openai/git/.github/workflows/codex.yml@$FAKE_CONTROLLER"*\
-				*"refs/heads/meta"*\
-				*".sha == "*"$FAKE_CONTROLLER"*) ;;
+				*"openai/git/.github/workflows/codex.yml@meta"*\
+				*".ref == \"refs/heads/meta\""*\
+				*".sha == \"$FAKE_CONTROLLER\""*) ;;
 				*) exit 95 ;;
 				esac
 				if test "${FAKE_GH_MODE:-}" = wrong-controller
@@ -2783,7 +2783,7 @@ test_expect_success PYTHON 'publish-run authenticates the artifact and promotes 
 			"$support/publish.out" &&
 		! grep -v "^api --hostname github.com " "$support/gh.log" &&
 		test_grep "actions/artifacts/9001/zip" "$support/gh.log" &&
-		test_grep ".github/workflows/codex.yml@$controller" \
+		test_grep ".github/workflows/codex.yml@meta" \
 			"$support/gh.log" &&
 		test_grep "refs/heads/meta" "$support/gh.log" &&
 		test_grep "actions/workflows/main.yml/runs?branch=codex-staging&event=push&head_sha=$candidate&per_page=100" \


### PR DESCRIPTION
Run 30720373028 was prepared by the expected meta controller, but local publication rejected it before staging. GitHub reports the explicit reusable-workflow reference as `codex.yml@meta` and supplies the resolved controller object separately in `sha`; the helper incorrectly expected the object ID in both fields.

Match the observed path while retaining the exact `refs/heads/meta` and controller-SHA checks. Update the end-to-end fixture to model the live API response. This does not change reconstruction or publication behavior.

Tests:
- focused `t9905` publish-run test
- complete `t9905` suite (37/37)
- `sh -n`, `dash -n`, and `git diff --check`

<!-- codex-thread: 019fb902-4685-73c3-866c-26d0c59bc3de -->