### PR TITLE
ci: identify rebased commits as the Codex bot

### DIFF
--- a/.github/CODEX.md
+++ b/.github/CODEX.md
@@ -288,7 +288,7 @@ rejects every other topic-controlled workflow change.
 
 Rebased topic commits preserve their original authors. Generated commits and
 rebase committers use
-`ChatGPT Codex Connector <199175422+chatgpt-codex-connector[bot]@users.noreply.github.com>`.
+`chatgpt-codex-connector[bot] <199175422+chatgpt-codex-connector[bot]@users.noreply.github.com>`.
 Generated merge and `meta` state commits use that identity as both author and
 committer. These commits are deliberately unsigned and do not claim verified
 GitHub App authentication. GitHub records the local credential owner as the

--- a/.github/CODEX.md
+++ b/.github/CODEX.md
@@ -272,6 +272,15 @@ and Git records the configured user as the pusher. To add or remove a
 publisher, change the exact `User` actor in both rulesets. Do not replace it
 with a broad repository role or a shared long-lived credential.
 
+The built-in `GITHUB_TOKEN` is not a substitute for the local publisher.
+[GitHub suppresses push-triggered workflows for pushes made with that
+token](https://docs.github.com/en/actions/concepts/security/github_token), so
+it would skip both the exact staging CI run and the final release workflow.
+Giving the shared GitHub Actions App a ruleset bypass would also authorize it
+outside this controller. Moving publication into Actions therefore requires a
+separate, narrowly scoped GitHub App credential; until one is provisioned, the
+local publisher remains the security and audit boundary.
+
 The local helper downloads the artifact through `gh`, but pushes through
 `origin`. Those credentials can theoretically identify different users, so
 the helper prints the authenticated `gh` login before staging. Verify the

--- a/.github/workflows/codex-branch.sh
+++ b/.github/workflows/codex-branch.sh
@@ -10,7 +10,7 @@ script_dir=$(CDPATH= cd "$(dirname "$0")" && pwd)
 script_path=${CODEX_ENTRYPOINT:-$script_dir/$(basename "$0")}
 meta_config_path=codex.config
 tab=$(printf '\t')
-bot_name='ChatGPT Codex Connector'
+bot_name='chatgpt-codex-connector[bot]'
 bot_email='199175422+chatgpt-codex-connector[bot]@users.noreply.github.com'
 
 say () {

--- a/t/t9905-codex-branch.sh
+++ b/t/t9905-codex-branch.sh
@@ -11,7 +11,7 @@ codex_branch=${CODEX_BRANCH:-$TEST_DIRECTORY/../.github/workflows/codex-branch.s
 codex_workflow=${CODEX_WORKFLOW:-$(dirname "$codex_branch")/codex.yml}
 codex_root=$(CDPATH= cd "$(dirname "$codex_branch")/../.." && pwd)
 codex_entrypoint=${CODEX_ENTRYPOINT:-$codex_root/codex}
-codex_bot_name='ChatGPT Codex Connector'
+codex_bot_name='chatgpt-codex-connector[bot]'
 codex_bot_email='199175422+chatgpt-codex-connector[bot]@users.noreply.github.com'
 
 write () {
@@ -1571,6 +1571,7 @@ test_expect_success 'codex rerere history can resolve a topic rebase' '
 		test -n "$new_topic" &&
 		test -n "$new_other" &&
 		test resolved = "$(git show "$new_topic:shared")" &&
+		has_codex_bot_committer "$new_topic" &&
 		manifest_has aa/codex/rerere \
 			"$old_topic" "$new_topic" updates &&
 		manifest_has bb/codex/other \


### PR DESCRIPTION
## Summary

- use `chatgpt-codex-connector[bot]` as the raw author/committer name for generated Codex commits while preserving original topic authors
- cover the automatic rerere continuation path with the same identity assertion
- document why publication remains local: `GITHUB_TOKEN` pushes suppress the push-triggered staging CI and release workflows, while a shared GitHub Actions ruleset bypass would be broader than this controller

This does not add an Action-side publisher. A future unattended publisher should use a dedicated, repository-scoped GitHub App credential.

## Validation

- full `t9905-codex-branch.sh`: 37/37
- post-rebase focused cases: identity, root/dependent rebases, conflict recovery, rerere, and authenticated `publish-run`
- `sh -n`, `dash -n`, `git diff --check`, and per-commit `git show --check`

<!-- codex-thread: 019fb902-4685-73c3-866c-26d0c59bc3de -->