### PR TITLE
ci: make Codex rebuilds explicit and one-command

### DIFF
--- a/.github/CODEX.md
+++ b/.github/CODEX.md
@@ -17,6 +17,15 @@ are independent topics” after their current tips stop sharing ancestry. This
 is what makes amending, dropping, or replacing an already-published commit
 safe without relying on a runner's local reflogs.
 
+The generated `codex` history contains one explicit two-parent integration
+commit for every active topic, including prerequisites, fast-forwardable
+topics, and empty topics. Prerequisites are integrated before their dependents;
+lexical order only breaks ties among topics that are ready at the same time.
+This order makes the history deterministic but does not add semantic edges to
+the topic graph. When the first topic is empty because its tip equals the base,
+the controller first creates a tree-identical `Begin codex integration` commit
+so that topic can still have two distinct parents.
+
 ## Topic branches and pull requests
 
 Create a topic from `master`, or from the topic it depends on:
@@ -118,35 +127,53 @@ It creates a session below the repository's shared Git directory containing
 the pinned inputs, update manifest, candidate bundle, and conflict report. It
 does not update local or remote refs. The low-level `rewrite`, `stage`, and
 `promote` commands are also available through `Meta/codex`. Use local refresh
-for inspection and conflict recovery. Normal publication starts with the
-Action and finishes through the pinned `publish-run` command described below.
+for inspection and conflict recovery. Normal publication uses `Meta/rebuild`;
+use `Meta/publish <run-id>` only to finish a preparation started through
+GitHub.
 
 ## Refresh `codex`
 
-1. Open **Actions > Refresh codex**.
-2. Choose **Run workflow**, select `codex`, and run it.
-3. When **Rebase topics and assemble codex** succeeds, run the exact command
-   printed in its summary from a clean clone with a current `Meta` worktree:
+From a clean, complete clone with a linked `Meta` worktree, run:
 
-   ```sh
-   Meta/codex publish-run <run-id>
-   ```
+```sh
+Meta/rebuild
+```
 
-   If the clone does not already have that linked worktree, create it once:
+`Meta/rebuild` updates the clean `Meta` worktree to current `origin/meta`,
+dispatches **Refresh codex**, and prints the exact run ID and URL returned by
+GitHub. It reports preparation status, validates the successful artifact,
+pushes the candidate to `codex-staging`, reports staging-CI job progress, and
+performs the atomic promotion only after that exact candidate passes. Leave
+the command running until it reports the published candidate.
 
-   ```sh
-   git fetch origin '+refs/heads/meta:refs/remotes/origin/meta'
-   git worktree add --detach Meta refs/remotes/origin/meta
-   ```
+Create the linked worktree once if it does not exist:
 
-   An existing `Meta` worktree must be clean and at the controller commit shown
-   in the run summary. When `Meta/` is nested in the caller, the helper permits
-   that one linked-worktree directory but rejects every other caller change.
-   Prepared artifacts expire after seven days.
+```sh
+git fetch origin '+refs/heads/meta:refs/remotes/origin/meta'
+git worktree add --detach Meta refs/remotes/origin/meta
+```
 
-Always start a fresh dispatch after a preparation, staging, CI, lease, or
-promotion failure. Do not use **Re-run failed jobs** for those failures: a
-retry must snapshot the current refs and stage a fresh candidate.
+Both the publishing worktree and `Meta` must be clean. When `Meta/` is nested
+in the publishing worktree, the helper permits that linked-worktree directory
+but rejects every other change.
+
+To start preparation in the GitHub UI instead, open **Actions > Refresh
+codex**, select `codex`, and choose **Run workflow**. After **Rebase topics and
+assemble codex** succeeds, finish that exact run from the same kind of clean
+clone:
+
+```sh
+Meta/publish <run-id>
+```
+
+The Action summary prints this command. Prepared artifacts expire after seven
+days. `Meta/publish` stays pinned to the controller used by the selected run;
+it does not update the `Meta` worktree underneath that run.
+
+Start a fresh `Meta/rebuild` after a preparation, staging, CI, lease, or
+promotion failure. The manual alternative is a fresh UI dispatch followed by
+`Meta/publish <run-id>`. Do not use **Re-run failed jobs**: a retry must
+snapshot the current refs and stage a fresh candidate.
 
 The Action:
 
@@ -154,14 +181,15 @@ The Action:
 2. reads the published boundaries from `meta/codex.config`, infers only new or
    explicitly restacked edges, and rebases topics sequentially in dependency
    order, using rerere resolutions learned from the old `codex`;
-3. merges the rewritten maximal tips and freezes the result without building
-   or executing candidate code, and creates a direct child of the pinned
-   `meta` tip that changes only `codex.config`;
+3. integrates every active topic at its rewritten tip with an explicit merge
+   commit and freezes the result without building or executing candidate code,
+   and, when state changed, creates a direct child of the pinned `meta` tip
+   that changes only `codex.config`;
 4. uploads the bundle, pinned input snapshot, update manifest, and canonical
    run metadata as one attempt-specific artifact; and
 5. pushes nothing.
 
-`publish-run` uses the current user's existing `gh` and Git credentials. It
+`Meta/publish` uses the current user's existing `gh` and Git credentials. It
 accepts only a successful `workflow_dispatch` run on `openai/git:codex`, the
 attempt-specific artifact from that run, and the exact reusable controller
 recorded by GitHub for `meta`. It checks the caller SHA against the snapshotted
@@ -171,15 +199,19 @@ ZIP allowlist and bundle heads, and revalidates the complete input snapshot.
 Only then does it record the existing CI run ID and push the exact candidate
 to the fixed `codex-staging` branch. That user-authenticated push starts
 ordinary push CI, including when the candidate changes a workflow file. The
-helper accepts only a newer `main.yml` push run whose branch and SHA exactly
-match the staged candidate, requires that full run and its `config` job to
-succeed, then revalidates the snapshot and atomically updates `meta`, every
-topic, and `codex` with exact leases while deleting `codex-staging`.
+helper binds to a newer `main.yml` push run whose branch and SHA exactly match
+the staged candidate. While it waits, it prints the run URL and reports changes
+in status, completed-job count, and failure count, plus a heartbeat every five
+minutes when those values do not change. After the full run and its unique
+`config` job succeed, it revalidates the snapshot and atomically updates
+`meta`, every topic, and `codex` with exact leases while deleting
+`codex-staging`.
 
-The final push to `codex` starts the existing push-triggered release workflow.
-A release never runs from staging. The ordinary CI workflow may reuse its own
-earlier successful result when the commit or tree is identical; that is CI's
-existing redundancy policy.
+When promotion advances `codex`, the final push starts the existing
+push-triggered release workflow. A canonical no-op reuses the existing
+`codex` and `meta` tips. A release never runs from staging. The ordinary CI
+workflow may reuse its own earlier successful result when the commit or tree
+is identical; that is CI's existing redundancy policy.
 
 Until the final push, `meta`, `codex`, and all topic refs remain unchanged. A
 CI, validation, lease, or promotion failure after staging leaves
@@ -230,36 +262,38 @@ commit for the failed run:
 4. Review the rewritten topic tips, then run the printed `publish-topics`
    command. It rechecks the original snapshot and atomically pushes every
    rewritten topic with an exact lease.
-5. Start a new **Actions > Refresh codex > Run workflow** dispatch to prepare
-   a publishable artifact; then run the printed `publish-run` command to stage,
-   verify, and promote it to `codex`.
+5. Run `Meta/rebuild` to prepare, verify, and publish the repaired graph. The
+   manual alternative is a fresh **Actions > Refresh codex > Run workflow**
+   dispatch followed by its printed `Meta/publish <run-id>` command.
 
 To abandon recovery, run `git rebase --abort` and delete the disposable
 worktree. Do not use `git rebase --quit`, push only the first conflicted topic,
 add `+` to a failed push, or use an unqualified force push. If a lease fails,
 start again from a fresh dispatch.
 
-If maximal topics conflict while the controller assembles `codex`, the topics
-were declared independent by ancestry but are not independent in practice.
-Rebase the conflicting topic and its descendants onto the real prerequisite,
-push that coherent graph, and start a fresh dispatch. Do not fix this by
-merging `codex` into a topic or by maintaining a manual order.
+If topics conflict while the controller assembles `codex`, the graph declared
+them independent at that integration point when they are not independent in
+practice. Rebase the conflicting topic and its descendants onto the real
+prerequisite, push that coherent graph, and start a fresh dispatch. Do not fix
+this by merging `codex` into a topic or by maintaining a manual order.
 
 ## Configure publishing
 
 Publishing needs no repository secret, deploy key, GitHub App, or protected
 environment. It uses the publisher's ordinary credentials:
 
-1. Authenticate `gh` as the publishing user and make sure that account can
-   read Actions runs and artifacts for `openai/git`:
+1. Authenticate `gh` as the publishing user. `Meta/rebuild` needs permission
+   to dispatch Actions; `Meta/publish` needs permission to read the selected
+   run and its artifact:
 
    ```sh
    gh auth status
    ```
 
 2. Configure the canonical `origin` with that user's normal Git credentials.
-   `Meta/codex publish-run` accepts only the standard SSH or HTTPS URL for
-   `openai/git`; it never reads a token from the repository or artifact.
+   `Meta/rebuild` and `Meta/publish` accept only the standard SSH or HTTPS URL
+   for `openai/git`. Neither command reads a token from the repository or
+   artifact.
 3. In the existing **Protect generated Codex branch** ruleset and the
    **Protect Codex controller branch** ruleset, add an **always** bypass for
    each exact human publisher. The checked-in recipes authorize only the
@@ -267,10 +301,15 @@ environment. It uses the publisher's ordinary credentials:
    break-glass actor. Import the `meta` recipe only if that ruleset is absent.
 
 The bypass is intentionally personal and visible. The Action cannot publish;
-it only prepares an immutable artifact. Running `publish-run` is the approval
-and Git records the configured user as the pusher. To add or remove a
-publisher, change the exact `User` actor in both rulesets. Do not replace it
+it only prepares an immutable artifact. Running `Meta/rebuild` or
+`Meta/publish` is the approval, and Git records the configured user as the
+pusher. To add or remove a publisher, change the exact `User` actor in both
+rulesets. Do not replace it
 with a broad repository role or a shared long-lived credential.
+
+The final push runs from the operator's machine. Actions prepares the candidate
+and CI verifies it, but the operator's existing Git credentials authorize the
+atomic ref update.
 
 The built-in `GITHUB_TOKEN` is not a substitute for the local publisher.
 [GitHub suppresses push-triggered workflows for pushes made with that

--- a/.github/workflows/codex-branch.sh
+++ b/.github/workflows/codex-branch.sh
@@ -25,6 +25,8 @@ die () {
 usage () {
 	cat <<-\EOF
 	usage: codex-branch check-topic <branch>
+	   or: codex-branch rebuild
+	   or: codex-branch publish <run-id>
 	   or: codex-branch initialize [--remote <remote>] [--base <branch>]
 		[--codex <branch>] [--output <path>] [--require-automation]
 	   or: codex-branch refresh [--session <directory>]
@@ -43,7 +45,6 @@ usage () {
 		--inputs <path> --updates <path> [--require-automation]
 	   or: codex-branch promote [--remote <remote>] [--staging <branch>]
 		--inputs <path> --updates <path> [--require-automation]
-	   or: codex-branch publish-run <run-id>
 	   or: codex-branch resolve [--remote <remote>] [--base <branch>]
 		[--codex <branch>] --inputs-oid <oid> [--worktree <path>]
 	   or: codex-branch continue --worktree <path>
@@ -204,6 +205,8 @@ legacy_control_paths_unchanged () (
 		.github/workflows/codex.yml \
 		.github/workflows/codex-branch.sh \
 		codex \
+		publish \
+		rebuild \
 		codex.config \
 		t/t9905-codex-branch.sh
 )
@@ -220,6 +223,8 @@ meta_control_paths_unchanged () (
 		.github/workflows/codex-branch.sh \
 		.github/workflows/main.yml \
 		codex \
+		publish \
+		rebuild \
 		codex.config \
 		t/t9905-codex-branch.sh &&
 	git diff --quiet "$base_oid" "$head_oid" -- \
@@ -1657,8 +1662,8 @@ write_integration_failure () {
 	{
 		say "## No refs were updated"
 		say
-		say "The rewritten maximal topic \`$failed_name\` at \`$failed_oid\`"
-		say "conflicts with the maximal topics already merged into the candidate."
+		say "The rewritten topic \`$failed_name\` at \`$failed_oid\`"
+		say "conflicts with the topics already merged into the candidate."
 		say "Input snapshot: \`$inputs_oid\`."
 		say
 		say "This is an integration conflict, not a stopped rebase. Do not merge"
@@ -1669,7 +1674,7 @@ write_integration_failure () {
 		if test -s "$state/integration-merged"
 		then
 			say
-			say "Maximal topics already merged, in order:"
+			say "Topics already merged, in order:"
 			sed 's/^/- `/' "$state/integration-merged" | sed 's/$/`/'
 		fi
 		if test -n "$(git -C "$worktree" -c core.fsmonitor=false \
@@ -1688,10 +1693,41 @@ merge_topic () {
 	worktree=$1
 	name=$2
 	oid=$3
+	before=$(git -C "$worktree" rev-parse HEAD) ||
+		die "could not resolve the candidate before integrating '$name'"
 	message=$(printf 'Merge %s into codex\n\nIntegrate the current %s topic into the internally distributed codex branch.\n\nCodex-Integration: %s@%s' \
 		"$name" "$name" "$name" "$oid")
 
-	if GIT_AUTHOR_NAME=$bot_name GIT_AUTHOR_EMAIL=$bot_email \
+	if git -C "$worktree" merge-base --is-ancestor "$oid" "$before"
+	then
+		if test "$before" = "$oid"
+		then
+			tree=$(git -C "$worktree" rev-parse "$before^{tree}") ||
+				die "could not resolve the integration base tree"
+			anchor_message=$(printf 'Begin codex integration\n\nCreate a distinct first parent for explicit topic integration commits.\n')
+			anchor=$(printf '%s' "$anchor_message" | \
+				GIT_AUTHOR_NAME=$bot_name GIT_AUTHOR_EMAIL=$bot_email \
+				GIT_COMMITTER_NAME=$bot_name \
+				GIT_COMMITTER_EMAIL=$bot_email \
+				git -C "$worktree" -c commit.gpgSign=false \
+				commit-tree "$tree" -p "$before") ||
+				die "could not create the codex integration base"
+			git -C "$worktree" reset --hard "$anchor" >/dev/null ||
+				die "could not check out the codex integration base"
+			before=$anchor
+		fi
+		tree=$(git -C "$worktree" rev-parse "$before^{tree}") ||
+			die "could not resolve the candidate tree for '$name'"
+		after=$(printf '%s\n' "$message" | \
+			GIT_AUTHOR_NAME=$bot_name GIT_AUTHOR_EMAIL=$bot_email \
+			GIT_COMMITTER_NAME=$bot_name \
+			GIT_COMMITTER_EMAIL=$bot_email \
+			git -C "$worktree" -c commit.gpgSign=false \
+			commit-tree "$tree" -p "$before" -p "$oid") ||
+			die "could not create the explicit integration for '$name'"
+		git -C "$worktree" reset --hard "$after" >/dev/null ||
+			die "could not check out the integration for '$name'"
+	elif GIT_AUTHOR_NAME=$bot_name GIT_AUTHOR_EMAIL=$bot_email \
 		GIT_COMMITTER_NAME=$bot_name GIT_COMMITTER_EMAIL=$bot_email \
 		git -C "$worktree" \
 		-c core.hooksPath=/dev/null \
@@ -1699,58 +1735,124 @@ merge_topic () {
 		-c commit.gpgSign=false \
 		-c rerere.enabled=true \
 		-c rerere.autoupdate=true \
-		merge --no-ff --no-edit --no-gpg-sign -m "$message" "$oid" >&2
+		merge --no-ff --no-log --no-edit --no-gpg-sign \
+		-m "$message" "$oid" >&2
 	then
-		return 0
+		:
+	else
+		git -C "$worktree" rev-parse --verify -q MERGE_HEAD >/dev/null &&
+			test -z "$(git -C "$worktree" -c core.fsmonitor=false ls-files -u)" ||
+			return 1
+		git -C "$worktree" -c core.fsmonitor=false diff --cached --check ||
+			return 1
+		GIT_AUTHOR_NAME=$bot_name GIT_AUTHOR_EMAIL=$bot_email \
+			GIT_COMMITTER_NAME=$bot_name GIT_COMMITTER_EMAIL=$bot_email \
+			git -C "$worktree" \
+			-c core.hooksPath=/dev/null \
+			-c core.fsmonitor=false \
+			-c commit.gpgSign=false \
+			commit --no-edit --no-gpg-sign >&2 || return 1
 	fi
 
-	git -C "$worktree" rev-parse --verify -q MERGE_HEAD >/dev/null &&
-		test -z "$(git -C "$worktree" -c core.fsmonitor=false ls-files -u)" ||
-		return 1
-	git -C "$worktree" -c core.fsmonitor=false diff --cached --check ||
-		return 1
-	GIT_AUTHOR_NAME=$bot_name GIT_AUTHOR_EMAIL=$bot_email \
-		GIT_COMMITTER_NAME=$bot_name GIT_COMMITTER_EMAIL=$bot_email \
-		git -C "$worktree" \
-		-c core.hooksPath=/dev/null \
-		-c core.fsmonitor=false \
-		-c commit.gpgSign=false \
-		commit --no-edit --no-gpg-sign >&2
+	after=$(git -C "$worktree" rev-parse HEAD) ||
+		die "could not resolve the integration commit for '$name'"
+	set -- $(git -C "$worktree" show -s --format=%P "$after")
+	test $# = 2 && test "$1" = "$before" && test "$2" = "$oid" ||
+		die "integration for '$name' is not an explicit two-parent merge"
+	marker=$(git -C "$worktree" show -s \
+		--format='%(trailers:key=Codex-Integration,valueonly)' "$after") ||
+		die "could not inspect the integration marker for '$name'"
+	test "$marker" = "$name@$oid" ||
+		die "integration for '$name' has the wrong marker"
 }
+
+integration_name_recorded () (
+	file=$1
+	name=$2
+	awk -F '\t' -v name="$name" '$1 == name { found=1 }
+		END { exit !found }' "$file"
+)
+
+write_integration_topics () {
+	state=$1
+	base_name=$(state_value "$state" base-name)
+	plan=$state/integration-plan
+	ready=$state/integration-ready
+	merged=$state/integration-topics
+	LC_ALL=C sort -t "$tab" -k1,1 "$state/plan" >"$plan" ||
+		die "could not sort topics for integration"
+	: >"$merged" || die "could not prepare the topic integration order"
+	total=$(wc -l <"$plan" | tr -d ' ')
+	while test "$(wc -l <"$merged" | tr -d ' ')" -lt "$total"
+	do
+		: >"$ready"
+		while IFS="$tab" read -r name old prerequisite old_base prerequisite_tip
+		do
+			integration_name_recorded "$merged" "$name" && continue
+			if test "$prerequisite" != "$base_name" &&
+				! integration_name_recorded "$merged" "$prerequisite"
+			then
+				continue
+			fi
+			oid=$(result_lookup "$state/results" "$name")
+			test -n "$oid" || die "topic '$name' has no rewritten tip"
+			printf '%s\t%s\n' "$name" "$oid" >>"$ready" ||
+				die "could not record ready integration topic '$name'"
+		done <"$plan"
+		test -s "$ready" || die "topic integrations contain a dependency cycle"
+		LC_ALL=C sort -t "$tab" -k1,1 -o "$ready" "$ready" ||
+			die "could not sort ready integration topics"
+		sed -n '1p' "$ready" >>"$merged" ||
+			die "could not extend the topic integration order"
+	done
+}
+
+codex_has_expected_integrations () (
+	state=$1
+	head_oid=$2
+	base_oid=$(state_value "$state" base-oid)
+	expected=$state/expected-integrations
+	actual=$state/actual-integrations
+	: >"$expected"
+	while IFS="$tab" read -r name oid
+	do
+		printf '%s@%s\t%s\tMerge %s into codex\t%s\t%s\t%s\t%s\n' \
+			"$name" "$oid" "$oid" "$name" \
+			"$bot_name" "$bot_email" "$bot_name" "$bot_email" \
+			>>"$expected" || return 1
+	done <"$state/integration-topics"
+	: >"$actual"
+	git rev-list --first-parent --reverse "$base_oid..$head_oid" |
+	while read -r commit
+	do
+		marker=$(git show -s \
+			--format='%(trailers:key=Codex-Integration,valueonly)' \
+			"$commit") || exit 1
+		test -n "$marker" || continue
+		set -- $(git show -s --format=%P "$commit")
+		test $# = 2 || exit 1
+		printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+			"$marker" "$2" "$(git show -s --format=%s "$commit")" \
+			"$(git show -s --format=%an "$commit")" \
+			"$(git show -s --format=%ae "$commit")" \
+			"$(git show -s --format=%cn "$commit")" \
+			"$(git show -s --format=%ce "$commit")" \
+			>>"$actual" || exit 1
+	done || return 1
+	cmp -s "$expected" "$actual"
+)
 
 assemble_candidate () {
 	worktree=$1
 	state=$2
 	base_oid=$(state_value "$state" base-oid)
-	unique=$state/unique-topics
-	maximal=$state/maximal-topics
 	rm -f "$state/integration-failed-name" \
 		"$state/integration-failed-oid" ||
 		die "could not clear old integration state"
 	: >"$state/integration-merged" ||
 		die "could not prepare integration progress"
 
-	awk -F '\t' '!seen[$3]++ { print }' "$state/topic-updates" >"$unique" ||
-		die "could not collect unique topic tips"
-	: >"$maximal" || die "could not prepare maximal topic list"
-	while IFS="$tab" read -r ref old oid
-	do
-		dominated=
-		while IFS="$tab" read -r other_ref other_old other_oid
-		do
-			test "$oid" = "$other_oid" && continue
-			if git merge-base --is-ancestor "$oid" "$other_oid"
-			then
-				dominated=t
-				break
-			fi
-		done <"$unique"
-		if test -z "$dominated"
-		then
-			printf '%s\t%s\n' "${ref#refs/heads/}" "$oid" >>"$maximal" ||
-				die "could not record maximal topic '$ref'"
-		fi
-	done <"$unique"
+	write_integration_topics "$state"
 
 	git -C "$worktree" -c core.fsmonitor=false \
 		-c advice.detachedHead=false switch --detach "$base_oid" >/dev/null ||
@@ -1767,7 +1869,7 @@ assemble_candidate () {
 		fi
 		printf '%s\n' "$name" >>"$state/integration-merged" ||
 			die "could not record integration progress"
-	done <"$maximal"
+	done <"$state/integration-topics"
 
 	while IFS="$tab" read -r ref old oid
 	do
@@ -1776,6 +1878,8 @@ assemble_candidate () {
 	done <"$state/topic-updates"
 	candidate=$(git -C "$worktree" rev-parse HEAD) ||
 		die "could not resolve the codex candidate"
+	codex_has_expected_integrations "$state" "$candidate" ||
+		die "candidate does not contain one canonical integration merge per topic"
 	require_automation=$(state_value "$state" require-automation)
 	if ! test -f "$state/initializing"
 	then
@@ -2160,7 +2264,8 @@ rewrite () {
 	done <"$state/topic-updates"
 	if test -n "$contained" &&
 		test "$(git rev-parse "$candidate^{tree}")" = \
-		"$(git rev-parse "$codex_oid^{tree}")"
+		"$(git rev-parse "$codex_oid^{tree}")" &&
+		codex_has_expected_integrations "$state" "$codex_oid"
 	then
 		candidate=$codex_oid
 	fi
@@ -2254,6 +2359,8 @@ topic_control_paths_unchanged () (
 		.github/workflows/codex-branch.sh \
 		.github/workflows/main.yml \
 		codex \
+		publish \
+		rebuild \
 		codex.config \
 		t/t9905-codex-branch.sh &&
 	git diff --quiet "$base_oid" "$head_oid" -- \
@@ -2482,6 +2589,26 @@ verify_output () {
 		git merge-base --is-ancestor "$new_prerequisite" "$new" ||
 			die "rewrite lost configured dependency '$prerequisite' -> '$name'"
 	done <"$tmp_dir/topic-graph/plan"
+
+	# Reconstruct the canonical integration order independently from the
+	# artifact producer.  The source trees alone cannot prove that every topic
+	# has its own explicit merge, because contained and empty topics make no
+	# tree change.
+	printf '%s\n' "$base_name" >"$tmp_dir/topic-graph/base-name" ||
+		die "could not prepare integration verification"
+	: >"$tmp_dir/topic-graph/results" ||
+		die "could not prepare rewritten topic verification"
+	while IFS="$tab" read -r name old
+	do
+		ref=refs/heads/$name
+		new=$(awk -F '\t' -v ref="$ref" '$1 == ref { print $3 }' \
+			"$updates")
+		test -n "$new" || die "updates contain no rewritten tip for '$name'"
+		result_record "$tmp_dir/topic-graph/results" "$name" "$new"
+	done <"$tmp_dir/topic-graph/topics"
+	write_integration_topics "$tmp_dir/topic-graph"
+	codex_has_expected_integrations "$tmp_dir/topic-graph" "$candidate" ||
+		die "candidate does not contain one canonical integration merge per topic"
 }
 
 push_updates () {
@@ -2663,6 +2790,126 @@ require_openai_git_origin () (
 	done
 )
 
+require_operator_context () {
+	controller_oid=${CODEX_CONTROLLER_OID:-}
+	test -n "$controller_oid" ||
+		die "run this command through a pinned Meta entry point"
+	meta_worktree=${CODEX_META_WORKTREE:-}
+	test -n "$meta_worktree" && test -d "$meta_worktree" ||
+		die "this command requires its pinned Meta worktree"
+	require_full_commit_oid "$controller_oid"
+	test "$(git -C "$meta_worktree" rev-parse --verify HEAD^{commit})" = \
+		"$controller_oid" || die "Meta/HEAD does not match the pinned controller"
+	require_full_repository
+	require_clean_publish_worktrees "$meta_worktree"
+	require_openai_git_origin
+	command -v gh >/dev/null 2>&1 || die "this command requires the GitHub CLI (gh)"
+}
+
+refresh_meta_controller () {
+	git fetch --force origin \
+		'+refs/heads/meta:refs/remotes/origin/meta' >/dev/null ||
+		die "could not refresh the meta controller"
+	current_meta=$(git rev-parse --verify refs/remotes/origin/meta^{commit}) ||
+		die "origin/meta is not a commit"
+	test "$current_meta" != "$controller_oid" || return 0
+
+	say "Updating Meta from $controller_oid to $current_meta."
+	git -C "$meta_worktree" -c advice.detachedHead=false \
+		switch --detach "$current_meta" >/dev/null ||
+		die "could not update the Meta worktree"
+	test -x "$meta_worktree/rebuild" ||
+		die "updated meta does not contain Meta/rebuild"
+	exec "$meta_worktree/rebuild"
+}
+
+read_refresh_run () {
+	gh_command=$1
+	repository=$2
+	run_id=$3
+	output=$4
+	"$gh_command" api --hostname github.com \
+		"repos/$repository/actions/runs/$run_id" --jq \
+		'[.id, .run_attempt, .status, (.conclusion // "-"), .event, .head_branch, .head_sha, .path, .repository.full_name, .html_url] | @tsv' \
+		>"$output" || die "could not inspect Refresh codex run $run_id"
+	test "$(wc -l <"$output" | tr -d ' ')" = 1 ||
+		die "Refresh codex run $run_id returned malformed metadata"
+}
+
+wait_for_refresh_run () (
+	gh_command=$1
+	repository=$2
+	run_id=$3
+	expected_attempt=$4
+	attempt=0
+	previous=
+	while test "$attempt" -lt 180
+	do
+		attempt=$((attempt + 1))
+		read_refresh_run "$gh_command" "$repository" "$run_id" \
+			"$tmp_dir/rebuild-run"
+		IFS="$tab" read -r actual_id run_attempt status conclusion event \
+			branch sha path api_repository url <"$tmp_dir/rebuild-run"
+		test "$actual_id" = "$run_id" &&
+			test "$run_attempt" = "$expected_attempt" &&
+			test "$event" = workflow_dispatch && test "$branch" = codex &&
+			test "$path" = .github/workflows/codex.yml &&
+			test "$api_repository" = "$repository" ||
+			die "run $run_id no longer identifies the dispatched Refresh codex attempt"
+		current=$status:$conclusion
+		if test "$current" != "$previous"
+		then
+			if test "$status" = completed
+			then
+				say "Preparation: $conclusion: $url"
+			else
+				say "Preparation: $status: $url"
+			fi
+			previous=$current
+		fi
+		test "$status" != completed || break
+		sleep 10
+	done
+	test "$status" = completed ||
+		die "Refresh codex run $run_id did not complete before the timeout"
+	test "$conclusion" = success ||
+		die "Refresh codex run $run_id finished with '$conclusion'; start a fresh Meta/rebuild: $url"
+)
+
+rebuild_codex () {
+	test $# = 0 || { usage >&2; exit 129; }
+	require_operator_context
+	command -v unzip >/dev/null 2>&1 || die "Meta/rebuild requires unzip"
+	command -v zipinfo >/dev/null 2>&1 || die "Meta/rebuild requires zipinfo"
+	refresh_meta_controller
+
+	make_tmp_dir
+	repository=openai/git
+	endpoint="repos/$repository/actions/workflows/codex.yml/dispatches"
+	gh api --hostname github.com --method POST \
+		--header 'Accept: application/vnd.github+json' \
+		--header 'X-GitHub-Api-Version: 2026-03-10' \
+		--raw-field ref=codex "$endpoint" --jq \
+		'[.workflow_run_id, .run_url, .html_url] | @tsv' \
+		>"$tmp_dir/dispatch" || die "could not dispatch Refresh codex"
+	test "$(wc -l <"$tmp_dir/dispatch" | tr -d ' ')" = 1 ||
+		die "Refresh codex dispatch returned malformed metadata"
+	IFS="$tab" read -r run_id run_url html_url <"$tmp_dir/dispatch"
+	case "$run_id" in
+	''|*[!0-9]*) die "Refresh codex dispatch returned no numeric run ID" ;;
+	esac
+	test "$run_url" = \
+		"https://api.github.com/repos/$repository/actions/runs/$run_id" &&
+		test "$html_url" = \
+		"https://github.com/$repository/actions/runs/$run_id" ||
+		die "Refresh codex dispatch returned unexpected run URLs"
+	say "Refresh codex run $run_id: $html_url"
+	wait_for_refresh_run gh "$repository" "$run_id" 1
+	CODEX_EXPECTED_RUN_ATTEMPT=1
+	export CODEX_EXPECTED_RUN_ATTEMPT
+	publish_run "$run_id"
+}
+
 artifact_value () (
 	key=$1
 	file=$2
@@ -2718,6 +2965,7 @@ wait_for_staging_ci () (
 	baseline=$4
 	workflow_runs="repos/$repository/actions/workflows/main.yml/runs?branch=codex-staging&event=push&head_sha=$candidate&per_page=100"
 
+	say "Waiting for staging CI for $candidate..."
 	run_id=
 	attempt=0
 	while test "$attempt" -lt 60
@@ -2739,12 +2987,13 @@ wait_for_staging_ci () (
 	status=
 	conclusion=
 	url=
+	previous=
 	while test "$attempt" -lt 180
 	do
 		attempt=$((attempt + 1))
 		"$gh_command" api --hostname github.com \
 			"repos/$repository/actions/runs/$run_id" --jq \
-			'[.id, .event, .head_branch, .head_sha, .path, .status, (.conclusion // ""), .html_url] | @tsv' \
+			'[.id, .event, .head_branch, .head_sha, .path, .status, (.conclusion // "-"), .html_url] | @tsv' \
 			>"$tmp_dir/ci-run" || die "could not inspect staging CI run $run_id"
 		test "$(wc -l <"$tmp_dir/ci-run" | tr -d ' ')" = 1 ||
 			die "staging CI returned malformed run metadata"
@@ -2754,6 +3003,46 @@ wait_for_staging_ci () (
 			test "$branch" = codex-staging && test "$sha" = "$candidate" &&
 			test "$path" = .github/workflows/main.yml ||
 			die "staging CI run $run_id no longer identifies the exact candidate"
+		"$gh_command" api --hostname github.com --paginate --slurp \
+			"repos/$repository/actions/runs/$run_id/jobs?per_page=100" --jq '
+			[.[] | .jobs[]] as $jobs |
+			[
+			  ($jobs | length),
+			  ($jobs | map(select(.status == "completed")) | length),
+			  ($jobs | map(select(
+			    .status == "completed" and
+			    (.conclusion != "success" and
+			     .conclusion != "skipped" and
+			     .conclusion != "neutral")
+			  )) | length)
+			] | @tsv' >"$tmp_dir/ci-jobs" ||
+			die "could not inspect jobs for staging CI run $run_id"
+		test "$(wc -l <"$tmp_dir/ci-jobs" | tr -d ' ')" = 1 ||
+			die "staging CI returned malformed job progress"
+		IFS="$tab" read -r total completed failed <"$tmp_dir/ci-jobs"
+		case "$total:$completed:$failed" in
+		*[!0-9:]*) die "staging CI returned invalid job progress" ;;
+		esac
+		current=$status:$total:$completed:$failed
+		if test "$current" != "$previous"
+		then
+			if test -z "$previous"
+			then
+				say "Staging CI run $run_id: $url"
+			fi
+			if test "$status" = completed
+			then
+				say "Staging CI: $conclusion ($completed/$total jobs complete; $failed failed): $url"
+			else
+				say "Staging CI: $status ($completed/$total jobs complete; $failed failed)"
+			fi
+			previous=$current
+		elif test "$attempt" -gt 1 &&
+			test $(((attempt - 1) % 10)) = 0
+		then
+			minutes=$(((attempt - 1) / 2))
+			say "Staging CI: still $status after $minutes minutes ($completed/$total jobs complete; $failed failed)"
+		fi
 		test "$status" != completed || break
 		sleep 30
 	done
@@ -2762,37 +3051,26 @@ wait_for_staging_ci () (
 	test "$conclusion" = success ||
 		die "CI failed for exact staging SHA $candidate: $url"
 
-	config_conclusion=$("$gh_command" api --hostname github.com \
+	config_conclusion=$("$gh_command" api --hostname github.com --paginate \
 		"repos/$repository/actions/runs/$run_id/jobs?per_page=100" --jq \
-		'[.jobs[] | select(.name == "config") | .conclusion] | if length == 1 then .[0] else "" end') ||
+		'.jobs[] | select(.name == "config") | .conclusion') ||
 		die "could not inspect jobs for staging CI run $run_id"
-	test "$config_conclusion" = success ||
+	test "$(printf '%s\n' "$config_conclusion" | sed '/^$/d' | wc -l | tr -d ' ')" = 1 &&
+		test "$config_conclusion" = success ||
 		die "CI config did not run successfully on codex-staging"
-	say "Full staging CI passed: $url"
+	say "Full staging CI passed."
 )
 
 publish_run () {
 	test $# = 1 || { usage >&2; exit 129; }
 	run_id=$1
 	case "$run_id" in
-	''|*[!0-9]*) die "publish-run requires a numeric Actions run ID" ;;
+	''|*[!0-9]*) die "Meta/publish requires a numeric Actions run ID" ;;
 	esac
 
-	controller_oid=${CODEX_CONTROLLER_OID:-}
-	test -n "$controller_oid" ||
-		die "run publish-run through the pinned Meta/codex entry point"
-	meta_worktree=${CODEX_META_WORKTREE:-}
-	test -n "$meta_worktree" && test -d "$meta_worktree" ||
-		die "publish-run requires its pinned Meta worktree"
-	require_full_commit_oid "$controller_oid"
-	test "$(git -C "$meta_worktree" rev-parse --verify HEAD^{commit})" = \
-		"$controller_oid" || die "Meta/HEAD does not match the pinned controller"
-	require_full_repository
-	require_clean_publish_worktrees "$meta_worktree"
-	require_openai_git_origin
-	command -v gh >/dev/null 2>&1 || die "publish-run requires the GitHub CLI (gh)"
-	command -v unzip >/dev/null 2>&1 || die "publish-run requires unzip"
-	command -v zipinfo >/dev/null 2>&1 || die "publish-run requires zipinfo"
+	require_operator_context
+	command -v unzip >/dev/null 2>&1 || die "Meta/publish requires unzip"
+	command -v zipinfo >/dev/null 2>&1 || die "Meta/publish requires zipinfo"
 
 	make_tmp_dir
 	repository=openai/git
@@ -2809,6 +3087,10 @@ publish_run () {
 	case "$run_attempt" in
 	''|*[!0-9]*) die "Actions run has an invalid attempt" ;;
 	esac
+	expected_run_attempt=${CODEX_EXPECTED_RUN_ATTEMPT:-}
+	test -z "$expected_run_attempt" ||
+		test "$run_attempt" = "$expected_run_attempt" ||
+		die "Actions run $run_id moved from expected attempt $expected_run_attempt to attempt $run_attempt; start a fresh Meta/rebuild"
 	test "$status" = completed && test "$conclusion" = success ||
 		die "Actions run $run_id has not completed successfully"
 	test "$event" = workflow_dispatch && test "$head_branch" = codex &&
@@ -2899,6 +3181,9 @@ publish_run () {
 	verify_output --inputs "$metadata/codex-inputs" \
 		--updates "$metadata/codex-updates" \
 		--result "$metadata/codex-candidate" --require-automation
+	read_refresh_run gh "$repository" "$run_id" "$tmp_dir/run-current"
+	cmp -s "$tmp_dir/run" "$tmp_dir/run-current" ||
+		die "Actions run $run_id changed after artifact validation; start a fresh Meta/rebuild"
 
 	workflow_runs="repos/$repository/actions/workflows/main.yml/runs?branch=codex-staging&event=push&head_sha=$artifact_candidate&per_page=100"
 	baseline=$(gh api --hostname github.com "$workflow_runs" --jq \
@@ -2915,6 +3200,9 @@ publish_run () {
 		--inputs "$metadata/codex-inputs" \
 		--updates "$metadata/codex-updates" --require-automation
 	wait_for_staging_ci gh "$repository" "$artifact_candidate" "$baseline"
+	read_refresh_run gh "$repository" "$run_id" "$tmp_dir/run-after-ci"
+	cmp -s "$tmp_dir/run" "$tmp_dir/run-after-ci" ||
+		die "Actions run $run_id changed while staging CI ran; start a fresh Meta/rebuild"
 	promote --remote origin --staging codex-staging \
 		--inputs "$metadata/codex-inputs" \
 		--updates "$metadata/codex-updates" --require-automation
@@ -3138,6 +3426,8 @@ command=$1
 shift
 case "$command" in
 check-topic) check_topic "$@" ;;
+rebuild) rebuild_codex "$@" ;;
+publish) publish_run "$@" ;;
 initialize) initialize_config "$@" ;;
 refresh) local_refresh "$@" ;;
 rewrite) rewrite "$@" ;;
@@ -3145,7 +3435,7 @@ verify-inputs) verify_inputs "$@" ;;
 verify-output) verify_output "$@" ;;
 stage) stage_candidate "$@" ;;
 promote) promote "$@" ;;
-publish-run) publish_run "$@" ;;
+publish-run) publish_run "$@" ;; # compatibility for previously printed commands
 resolve) resolve_rebase "$@" ;;
 continue) continue_rewrite "$@" ;;
 publish-topics) publish_topics "$@" ;;

--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -93,7 +93,7 @@ jobs:
             echo 'Publish this exact prepared run from a clean local clone:'
             echo
             echo '```sh'
-            echo "Meta/codex publish-run $GITHUB_RUN_ID"
+            echo "Meta/publish $GITHUB_RUN_ID"
             echo '```'
             echo
             echo '| Ref | Old | New |'

--- a/codex
+++ b/codex
@@ -11,7 +11,7 @@ test "$meta_common_dir" = "$caller_common_dir" || {
   echo >&2 'Meta/codex must be a linked worktree of the repository being refreshed'
   exit 1
 }
-for control_path in codex .github/workflows/codex-branch.sh
+for control_path in codex rebuild publish .github/workflows/codex-branch.sh
 do
   expected=$(git -C "$meta_dir" rev-parse "HEAD:$control_path" 2>/dev/null) || {
     echo >&2 "Meta/HEAD does not contain $control_path"

--- a/publish
+++ b/publish
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+set -eu
+
+meta_dir=$(CDPATH= cd "$(dirname "$0")" && pwd)
+exec "$meta_dir/codex" publish "$@"

--- a/rebuild
+++ b/rebuild
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+set -eu
+
+meta_dir=$(CDPATH= cd "$(dirname "$0")" && pwd)
+exec "$meta_dir/codex" rebuild "$@"

--- a/t/t9905-codex-branch.sh
+++ b/t/t9905-codex-branch.sh
@@ -11,6 +11,8 @@ codex_branch=${CODEX_BRANCH:-$TEST_DIRECTORY/../.github/workflows/codex-branch.s
 codex_workflow=${CODEX_WORKFLOW:-$(dirname "$codex_branch")/codex.yml}
 codex_root=$(CDPATH= cd "$(dirname "$codex_branch")/../.." && pwd)
 codex_entrypoint=${CODEX_ENTRYPOINT:-$codex_root/codex}
+codex_rebuild=${CODEX_REBUILD:-$codex_root/rebuild}
+codex_publish=${CODEX_PUBLISH:-$codex_root/publish}
 codex_bot_name='chatgpt-codex-connector[bot]'
 codex_bot_email='199175422+chatgpt-codex-connector[bot]@users.noreply.github.com'
 
@@ -240,6 +242,55 @@ has_same_author () (
 		"$(git show -s --format="%an <%ae>" "$new")"
 )
 
+make_test_integration () (
+	name=$1
+	oid=$2
+	first_parent=$3
+	tree=$4
+	message=$(printf 'Merge %s into codex\n\nIntegrate the current %s topic into the internally distributed codex branch.\n\nCodex-Integration: %s@%s' \
+		"$name" "$name" "$name" "$oid") &&
+	printf '%s\n' "$message" |
+	GIT_AUTHOR_NAME=$codex_bot_name GIT_AUTHOR_EMAIL=$codex_bot_email \
+	GIT_COMMITTER_NAME=$codex_bot_name \
+	GIT_COMMITTER_EMAIL=$codex_bot_email \
+	git -c commit.gpgSign=false commit-tree "$tree" \
+		-p "$first_parent" -p "$oid"
+)
+
+write_test_output_tuple () (
+	valid_meta=$1
+	old_meta=$2
+	valid_candidate=$3
+	candidate=$4
+	valid_updates=$5
+	prefix=$6
+
+	git show "$valid_meta:codex.config" |
+		sed "s/output-tip = $valid_candidate/output-tip = $candidate/" \
+			>"$prefix.config" &&
+	test_grep "output-tip = $candidate" "$prefix.config" &&
+	blob=$(git hash-object -w "$prefix.config") &&
+	index=$PWD/$prefix.index &&
+	rm -f "$index" &&
+	GIT_INDEX_FILE=$index git read-tree "$old_meta^{tree}" &&
+	GIT_INDEX_FILE=$index git update-index --add --cacheinfo \
+		100644,"$blob",codex.config &&
+	tree=$(GIT_INDEX_FILE=$index git write-tree) &&
+	meta=$(printf '%s\n' "meta: test alternate integration history" |
+		GIT_AUTHOR_NAME=$codex_bot_name \
+		GIT_AUTHOR_EMAIL=$codex_bot_email \
+		GIT_COMMITTER_NAME=$codex_bot_name \
+		GIT_COMMITTER_EMAIL=$codex_bot_email \
+		git -c commit.gpgSign=false commit-tree "$tree" -p "$old_meta") &&
+	awk -F "$(printf '\t')" -v OFS="$(printf '\t')" \
+		-v meta="$meta" -v candidate="$candidate" '
+		$1 == "refs/heads/meta" { $3=meta }
+		$1 == "refs/heads/codex" { $3=candidate }
+		{ print }
+	' "$valid_updates" >"$prefix.updates" &&
+	printf '%s\n' "$candidate" >"$prefix.result"
+)
+
 test_expect_success 'topic names use the two-character namespace' '
 	sh "$codex_branch" check-topic tb/codex/release &&
 	test_expect_code 1 sh "$codex_branch" check-topic t/codex/release &&
@@ -259,6 +310,29 @@ test_expect_success 'generated commits use the Codex connector identity' '
 	grep -F "$codex_bot_email" "$codex_branch"
 '
 
+test_expect_success 'convenience wrappers forward to the pinned controller' '
+	test -x "$codex_rebuild" &&
+	test -x "$codex_publish" &&
+	mkdir -p "wrapper forwarding/Meta" &&
+	cp "$codex_rebuild" "wrapper forwarding/Meta/rebuild" &&
+	cp "$codex_publish" "wrapper forwarding/Meta/publish" &&
+	cat >"wrapper forwarding/Meta/codex" <<-\EOF &&
+	#!/bin/sh
+	printf "%s\\n" "$*" >>"$WRAPPER_LOG"
+	exit "${WRAPPER_EXIT:-0}"
+	EOF
+	chmod +x "wrapper forwarding/Meta/codex" &&
+	WRAPPER_LOG="$TRASH_DIRECTORY/wrapper.log" \
+		"$TRASH_DIRECTORY/wrapper forwarding/Meta/rebuild" &&
+	WRAPPER_LOG="$TRASH_DIRECTORY/wrapper.log" \
+		"$TRASH_DIRECTORY/wrapper forwarding/Meta/publish" 4242 &&
+	printf "%s\n" rebuild "publish 4242" >wrapper.expect &&
+	test_cmp wrapper.expect wrapper.log &&
+	WRAPPER_LOG="$TRASH_DIRECTORY/wrapper.log" WRAPPER_EXIT=17 \
+		test_expect_code 17 \
+		"$TRASH_DIRECTORY/wrapper forwarding/Meta/publish" 9999
+'
+
 test_expect_success 'refresh only prepares an immutable local-publish artifact' '
 	! grep -F "codex-topic.yml" "$codex_workflow" &&
 	! grep -E "make -C|t9905-codex-branch.sh" "$codex_workflow" &&
@@ -273,7 +347,7 @@ test_expect_success 'refresh only prepares an immutable local-publish artifact' 
 	test_grep "actions/upload-artifact" "$codex_workflow" &&
 	test_grep "runner.temp }}/codex-run" "$codex_workflow" &&
 	test_grep "GITHUB_RUN_ATTEMPT" "$codex_workflow" &&
-	test_grep "Meta/codex publish-run" "$codex_workflow" &&
+	test_grep "Meta/publish" "$codex_workflow" &&
 	sed -n "/^          path: |$/,/^          if-no-files-found:/p" \
 		"$codex_workflow" |
 	sed -n "s,.*runner.temp }}/\\(codex[^ ]*\\)$,\\1,p" |
@@ -329,6 +403,65 @@ test_expect_success 'topics cannot change the meta branch ruleset' '
 			2>rewrite.err &&
 		test_grep "meta-only controller files" rewrite.err &&
 		snapshot_refs ../control-path.git >after &&
+		test_cmp before after
+	)
+'
+
+test_expect_success 'topics cannot change the convenience wrappers' '
+	git init --bare wrapper-control-path.git &&
+	test_create_repo wrapper-control-path-source &&
+	(
+		cd wrapper-control-path-source &&
+		git remote add origin ../wrapper-control-path.git &&
+		write base shared &&
+		git add shared &&
+		install_rerere_train &&
+		git commit -m base &&
+		git branch codex &&
+		git branch meta &&
+		install_meta_state meta master codex &&
+
+		git switch -c aa/codex/rebuild-control master &&
+		write untrusted rebuild &&
+		git add rebuild &&
+		git commit -m "change rebuild wrapper" &&
+		git push origin master meta codex aa/codex/rebuild-control
+	) &&
+	git clone wrapper-control-path.git wrapper-control-path-runner &&
+	(
+		cd wrapper-control-path-runner &&
+		fetch_all &&
+		snapshot_refs ../wrapper-control-path.git >before &&
+		test_expect_code 1 sh "$codex_branch" rewrite \
+			--remote origin --base master --codex codex \
+			--result result --updates updates \
+			--inputs inputs --failure failure \
+			2>rebuild.err &&
+		test_grep "meta-only controller files" rebuild.err &&
+		snapshot_refs ../wrapper-control-path.git >after &&
+		test_cmp before after
+	) &&
+	git --git-dir=wrapper-control-path.git update-ref -d \
+		refs/heads/aa/codex/rebuild-control &&
+	(
+		cd wrapper-control-path-source &&
+		git switch -c aa/codex/publish-control master &&
+		write untrusted publish &&
+		git add publish &&
+		git commit -m "change publish wrapper" &&
+		git push origin aa/codex/publish-control
+	) &&
+	(
+		cd wrapper-control-path-runner &&
+		fetch_all &&
+		snapshot_refs ../wrapper-control-path.git >before &&
+		test_expect_code 1 sh "$codex_branch" rewrite \
+			--remote origin --base master --codex codex \
+			--result result --updates updates \
+			--inputs inputs --failure failure \
+			2>publish.err &&
+		test_grep "meta-only controller files" publish.err &&
+		snapshot_refs ../wrapper-control-path.git >after &&
 		test_cmp before after
 	)
 '
@@ -394,6 +527,16 @@ test_expect_success 'required automation is the exact isolated trampoline' '
 		git add .github/workflows/extra.yml &&
 		git commit -m "add another workflow" &&
 
+		git switch -c rebuild-control master &&
+		write untrusted rebuild &&
+		git add rebuild &&
+		git commit -m "change rebuild wrapper" &&
+
+		git switch -c publish-control master &&
+		write untrusted publish &&
+		git add publish &&
+		git commit -m "change publish wrapper" &&
+
 		git switch -c cc/codex/feature master &&
 		write feature feature-file &&
 		git add feature-file &&
@@ -410,7 +553,9 @@ test_expect_success 'required automation is the exact isolated trampoline' '
 			bb/codex/control:refs/heads/control-invalid \
 			release-staging:refs/heads/release-invalid \
 			release-credentials:refs/heads/release-credentials-invalid \
-			workflow-extra:refs/heads/workflow-invalid
+			workflow-extra:refs/heads/workflow-invalid \
+			rebuild-control:refs/heads/rebuild-invalid \
+			publish-control:refs/heads/publish-invalid
 	) &&
 
 	git clone automation.git automation-runner &&
@@ -493,6 +638,28 @@ test_expect_success 'required automation is the exact isolated trampoline' '
 		test_grep "protected controller or CI file" control.err &&
 		git --git-dir=../automation.git update-ref -d \
 			refs/heads/bb/codex/control "$control" &&
+
+		for wrapper in rebuild publish
+		do
+			wrapper_oid=$(git --git-dir=../automation.git \
+				rev-parse "refs/heads/$wrapper-invalid") &&
+			git --git-dir=../automation.git update-ref \
+				"refs/heads/bb/codex/$wrapper-control" \
+				"$wrapper_oid" &&
+			fetch_all &&
+			test_expect_code 1 sh "$codex_branch" rewrite \
+				--remote origin --base master --codex codex \
+				--result "$wrapper-result" \
+				--updates "$wrapper-updates" \
+				--inputs "$wrapper-inputs" \
+				--failure "$wrapper-failure" \
+				--require-automation 2>"$wrapper.err" &&
+			test_grep "protected controller or CI file" \
+				"$wrapper.err" &&
+			git --git-dir=../automation.git update-ref -d \
+				"refs/heads/bb/codex/$wrapper-control" \
+				"$wrapper_oid" || return 1
+		done &&
 
 		release=$(git --git-dir=../automation.git \
 			rev-parse refs/heads/release-invalid) &&
@@ -596,7 +763,7 @@ test_expect_success 'rewrite rebases one root topic onto current master' '
 	)
 '
 
-test_expect_success 'rewrite preserves dependencies and merges maximal tips in name order' '
+test_expect_success 'rewrite keeps canonical integrations when merge.log is enabled' '
 	git init --bare graph.git &&
 	test_create_repo graph-source &&
 	(
@@ -644,6 +811,7 @@ test_expect_success 'rewrite preserves dependencies and merges maximal tips in n
 		test "$old_a" = "$(git rev-parse "$old_b^")" &&
 		git config user.name "Configured Local User" &&
 		git config user.email "configured-local-user@example.com" &&
+		git config merge.log true &&
 
 		(
 			unset GIT_COMMITTER_NAME GIT_COMMITTER_EMAIL &&
@@ -673,22 +841,47 @@ test_expect_success 'rewrite preserves dependencies and merges maximal tips in n
 		has_same_author "$old_b" "$new_b" &&
 		has_same_author "$old_c" "$new_c" &&
 
-		last_merge=$(git rev-parse "$candidate") &&
-		first_merge=$(git rev-parse "$last_merge^") &&
+		git rev-list --first-parent --reverse "$master..$candidate" \
+			>integration-commits &&
+		test_line_count = 3 integration-commits &&
+		first_merge=$(sed -n "1p" integration-commits) &&
+		second_merge=$(sed -n "2p" integration-commits) &&
+		last_merge=$(sed -n "3p" integration-commits) &&
 		new_meta=$(updated_tip meta updates) &&
 		has_codex_bot_committer "$new_a" &&
 		has_codex_bot_committer "$new_b" &&
 		has_codex_bot_committer "$new_c" &&
 		has_codex_bot_committer "$first_merge" &&
+		has_codex_bot_committer "$second_merge" &&
 		has_codex_bot_committer "$last_merge" &&
 		has_codex_bot_committer "$new_meta" &&
 		has_codex_bot_author "$first_merge" &&
+		has_codex_bot_author "$second_merge" &&
 		has_codex_bot_author "$last_merge" &&
 		has_codex_bot_author "$new_meta" &&
+		test "Merge aa/codex/a into codex" = \
+			"$(git show -s --format=%s "$first_merge")" &&
+		test "Merge bb/codex/b into codex" = \
+			"$(git show -s --format=%s "$second_merge")" &&
+		test "Merge cc/codex/c into codex" = \
+			"$(git show -s --format=%s "$last_merge")" &&
+		test "aa/codex/a@$new_a" = "$(git show -s \
+			--format="%(trailers:key=Codex-Integration,valueonly)" \
+			"$first_merge")" &&
+		test "bb/codex/b@$new_b" = "$(git show -s \
+			--format="%(trailers:key=Codex-Integration,valueonly)" \
+			"$second_merge")" &&
+		test "cc/codex/c@$new_c" = "$(git show -s \
+			--format="%(trailers:key=Codex-Integration,valueonly)" \
+			"$last_merge")" &&
+		test "$master" = "$(git rev-parse "$first_merge^1")" &&
+		test "$first_merge" = "$(git rev-parse "$second_merge^1")" &&
+		test "$second_merge" = "$(git rev-parse "$last_merge^1")" &&
+		test "$new_a" = "$(git rev-parse "$first_merge^2")" &&
+		test "$new_b" = "$(git rev-parse "$second_merge^2")" &&
 		test "$new_c" = "$(git rev-parse "$last_merge^2")" &&
-		test "$new_b" = "$(git rev-parse "$first_merge^2")" &&
-		test "$master" = "$(git rev-parse "$first_merge^")" &&
-		test 2 = "$(git rev-list --count --merges "$master..$candidate")" &&
+		test 3 = "$(git rev-list --count --first-parent --merges \
+			"$master..$candidate")" &&
 
 		sh "$codex_branch" verify-inputs \
 			--remote origin --base master --codex codex inputs &&
@@ -721,6 +914,95 @@ test_expect_success 'rewrite preserves dependencies and merges maximal tips in n
 			refs/heads/aa/codex/a "$old_b" "$old_a" &&
 		test_expect_code 1 sh "$codex_branch" verify-inputs \
 			--remote origin --base master --codex codex inputs
+	)
+'
+
+test_expect_success 'tree-same legacy codex is canonicalized once' '
+	git init --bare legacy-integrations.git &&
+	test_create_repo legacy-integrations-source &&
+	(
+		cd legacy-integrations-source &&
+		git remote add origin ../legacy-integrations.git &&
+		write base shared &&
+		git add shared &&
+		install_rerere_train &&
+		git commit -m base &&
+
+		git switch -c aa/codex/a &&
+		write A a &&
+		git add a &&
+		git commit -m "legacy topic A" &&
+
+		git switch -c bb/codex/b &&
+		write B b &&
+		git add b &&
+		git commit -m "legacy topic B" &&
+
+		git switch -c cc/codex/c master &&
+		write C c &&
+		git add c &&
+		git commit -m "legacy topic C" &&
+
+		git switch -c codex master &&
+		git merge --no-ff bb/codex/b -m "legacy maximal merge B" &&
+		git merge --no-ff cc/codex/c -m "legacy maximal merge C" &&
+		git branch meta master &&
+		install_meta_state meta master codex &&
+		git push origin master meta codex \
+			aa/codex/a bb/codex/b cc/codex/c
+	) &&
+
+	git clone legacy-integrations.git legacy-integrations-runner &&
+	(
+		cd legacy-integrations-runner &&
+		fetch_all &&
+		legacy=$(git rev-parse origin/codex) &&
+		master=$(git rev-parse origin/master) &&
+		old_a=$(git rev-parse origin/aa/codex/a) &&
+		old_b=$(git rev-parse origin/bb/codex/b) &&
+		old_c=$(git rev-parse origin/cc/codex/c) &&
+		sh "$codex_branch" rewrite --remote origin \
+			--base master --codex codex --result result \
+			--updates updates --inputs inputs --failure failure &&
+		candidate=$(cat result) &&
+		test "$legacy" != "$candidate" &&
+		test "$(git rev-parse "$legacy^{tree}")" = \
+			"$(git rev-parse "$candidate^{tree}")" &&
+		git rev-list --first-parent --reverse "$master..$candidate" \
+			>integration-commits &&
+		test_line_count = 3 integration-commits &&
+		first_merge=$(sed -n "1p" integration-commits) &&
+		second_merge=$(sed -n "2p" integration-commits) &&
+		last_merge=$(sed -n "3p" integration-commits) &&
+		test "aa/codex/a@$old_a" = "$(git show -s \
+			--format="%(trailers:key=Codex-Integration,valueonly)" \
+			"$first_merge")" &&
+		test "bb/codex/b@$old_b" = "$(git show -s \
+			--format="%(trailers:key=Codex-Integration,valueonly)" \
+			"$second_merge")" &&
+		test "cc/codex/c@$old_c" = "$(git show -s \
+			--format="%(trailers:key=Codex-Integration,valueonly)" \
+			"$last_merge")" &&
+		set -- git push --atomic --force origin &&
+		while IFS="$(printf "\t")" read -r ref old new
+		do
+			set -- "$@" "$new:$ref" || return 1
+		done <updates &&
+		"$@"
+	) &&
+
+	git clone legacy-integrations.git legacy-integrations-noop &&
+	(
+		cd legacy-integrations-noop &&
+		fetch_all &&
+		published=$(git rev-parse origin/codex) &&
+		snapshot_refs ../legacy-integrations.git >before &&
+		sh "$codex_branch" rewrite --remote origin \
+			--base master --codex codex --result result \
+			--updates updates --inputs inputs --failure failure &&
+		test "$published" = "$(cat result)" &&
+		snapshot_refs ../legacy-integrations.git >after &&
+		test_cmp before after
 	)
 '
 
@@ -941,9 +1223,28 @@ test_expect_success 'a topic already in master still produces a valid bundle' '
 			--base master --codex codex --result result \
 			--updates updates --inputs inputs \
 			--bundle candidate.bundle --failure failure &&
-		test "$(git rev-parse origin/master)" = "$(cat result)" &&
-		git bundle verify candidate.bundle &&
 		candidate=$(cat result) &&
+		master=$(git rev-parse origin/master) &&
+		test "$master" != "$candidate" &&
+		test "$master" = "$(git rev-parse "$candidate^2")" &&
+		anchor=$(git rev-parse "$candidate^1") &&
+		test "$master" = "$(git rev-parse "$anchor^1")" &&
+		test "Begin codex integration" = \
+			"$(git show -s --format=%s "$anchor")" &&
+		test "Merge aa/codex/done into codex" = \
+			"$(git show -s --format=%s "$candidate")" &&
+		test "aa/codex/done@$master" = "$(git show -s \
+			--format="%(trailers:key=Codex-Integration,valueonly)" \
+			"$candidate")" &&
+		test "$(git rev-parse "$master^{tree}")" = \
+			"$(git rev-parse "$candidate^{tree}")" &&
+		test 1 = "$(git rev-list --count --first-parent --merges \
+			"$master..$candidate")" &&
+		has_codex_bot_author "$anchor" &&
+		has_codex_bot_committer "$anchor" &&
+		has_codex_bot_author "$candidate" &&
+		has_codex_bot_committer "$candidate" &&
+		git bundle verify candidate.bundle &&
 		meta=$(updated_tip meta updates) &&
 		test "$candidate" = "$(git bundle list-heads candidate.bundle |
 			awk '\''$2 == "refs/codex-output/candidate" { print $1 }'\'')" &&
@@ -1904,11 +2205,38 @@ test_expect_success 'an empty dependent follows its rewritten equal-tip parent' 
 		sh "$codex_branch" rewrite --remote origin \
 			--base master --codex codex --result result \
 			--updates updates --inputs inputs --failure failure &&
+		candidate=$(cat result) &&
+		master=$(git rev-parse origin/master) &&
 		new_parent=$(updated_tip aa/codex/parent updates) &&
 		new_empty=$(updated_tip bb/codex/empty updates) &&
 		test "$old_empty" != "$new_empty" &&
 		test "$new_parent" = "$new_empty" &&
-		test replacement = "$(git show "$new_empty:parent-file")"
+		test replacement = "$(git show "$new_empty:parent-file")" &&
+		git rev-list --first-parent --reverse "$master..$candidate" \
+			>integration-commits &&
+		test_line_count = 2 integration-commits &&
+		parent_merge=$(sed -n "1p" integration-commits) &&
+		empty_merge=$(sed -n "2p" integration-commits) &&
+		test "Merge aa/codex/parent into codex" = \
+			"$(git show -s --format=%s "$parent_merge")" &&
+		test "Merge bb/codex/empty into codex" = \
+			"$(git show -s --format=%s "$empty_merge")" &&
+		test "aa/codex/parent@$new_parent" = "$(git show -s \
+			--format="%(trailers:key=Codex-Integration,valueonly)" \
+			"$parent_merge")" &&
+		test "bb/codex/empty@$new_empty" = "$(git show -s \
+			--format="%(trailers:key=Codex-Integration,valueonly)" \
+			"$empty_merge")" &&
+		test "$master" = "$(git rev-parse "$parent_merge^1")" &&
+		test "$parent_merge" = "$(git rev-parse "$empty_merge^1")" &&
+		test "$new_parent" = "$(git rev-parse "$parent_merge^2")" &&
+		test "$new_empty" = "$(git rev-parse "$empty_merge^2")" &&
+		test "$(git rev-parse "$parent_merge^{tree}")" = \
+			"$(git rev-parse "$empty_merge^{tree}")" &&
+		has_codex_bot_author "$parent_merge" &&
+		has_codex_bot_committer "$parent_merge" &&
+		has_codex_bot_author "$empty_merge" &&
+		has_codex_bot_committer "$empty_merge"
 	)
 '
 
@@ -2281,7 +2609,7 @@ test_expect_success 'a coherent restack can swap a published dependency' '
 	)
 '
 
-test_expect_success 'Meta/codex pins both controller files to Meta HEAD' '
+test_expect_success 'Meta/codex pins every controller file to Meta HEAD' '
 	test_create_repo wrapper-pin &&
 	(
 		cd wrapper-pin &&
@@ -2293,11 +2621,15 @@ test_expect_success 'Meta/codex pins both controller files to Meta HEAD' '
 	git -C wrapper-pin worktree add ../wrapper-pin-Meta meta &&
 	mkdir -p wrapper-pin-Meta/.github/workflows &&
 	cp "$codex_entrypoint" wrapper-pin-Meta/codex &&
+	cp "$codex_rebuild" wrapper-pin-Meta/rebuild &&
+	cp "$codex_publish" wrapper-pin-Meta/publish &&
 	cp "$codex_branch" \
 		wrapper-pin-Meta/.github/workflows/codex-branch.sh &&
-	chmod +x wrapper-pin-Meta/codex \
+	chmod +x wrapper-pin-Meta/codex wrapper-pin-Meta/rebuild \
+		wrapper-pin-Meta/publish \
 		wrapper-pin-Meta/.github/workflows/codex-branch.sh &&
-	git -C wrapper-pin-Meta add codex .github/workflows/codex-branch.sh &&
+	git -C wrapper-pin-Meta add codex rebuild publish \
+		.github/workflows/codex-branch.sh &&
 	git -C wrapper-pin-Meta commit -m "install pinned controller" &&
 	(
 		cd wrapper-pin &&
@@ -2312,6 +2644,22 @@ test_expect_success 'Meta/codex pins both controller files to Meta HEAD' '
 	test_grep ".github/workflows/codex-branch.sh must match Meta/HEAD" \
 		dirty-helper.err &&
 	git -C wrapper-pin-Meta restore .github/workflows/codex-branch.sh &&
+	write dirty wrapper-pin-Meta/rebuild &&
+	(
+		cd wrapper-pin &&
+		test_expect_code 1 ../wrapper-pin-Meta/codex \
+			check-topic aa/codex/topic 2>../dirty-rebuild.err
+	) &&
+	test_grep "rebuild must match Meta/HEAD" dirty-rebuild.err &&
+	git -C wrapper-pin-Meta restore rebuild &&
+	write dirty wrapper-pin-Meta/publish &&
+	(
+		cd wrapper-pin &&
+		test_expect_code 1 ../wrapper-pin-Meta/codex \
+			check-topic aa/codex/topic 2>../dirty-publish.err
+	) &&
+	test_grep "publish must match Meta/HEAD" dirty-publish.err &&
+	git -C wrapper-pin-Meta restore publish &&
 	printf "\n# dirty\n" >>wrapper-pin-Meta/codex &&
 	(
 		cd wrapper-pin &&
@@ -2319,6 +2667,69 @@ test_expect_success 'Meta/codex pins both controller files to Meta HEAD' '
 			check-topic aa/codex/topic 2>../dirty-wrapper.err
 	) &&
 	test_grep "codex must match Meta/HEAD" dirty-wrapper.err
+'
+
+test_expect_success 'Meta/rebuild refreshes and executes a newer meta controller' '
+	git init --bare meta-refresh.git &&
+	test_create_repo meta-refresh-source &&
+	(
+		cd meta-refresh-source &&
+		git remote add origin ../meta-refresh.git &&
+		write base tracked &&
+		git add tracked &&
+		git commit -m base &&
+		git branch meta
+	) &&
+	git -C meta-refresh-source worktree add ../meta-refresh-Meta meta &&
+	mkdir -p meta-refresh-Meta/.github/workflows &&
+	cp "$codex_entrypoint" meta-refresh-Meta/codex &&
+	cp "$codex_rebuild" meta-refresh-Meta/rebuild &&
+	cp "$codex_publish" meta-refresh-Meta/publish &&
+	cp "$codex_branch" \
+		meta-refresh-Meta/.github/workflows/codex-branch.sh &&
+	chmod +x meta-refresh-Meta/codex meta-refresh-Meta/rebuild \
+		meta-refresh-Meta/publish \
+		meta-refresh-Meta/.github/workflows/codex-branch.sh &&
+	git -C meta-refresh-Meta add codex rebuild publish \
+		.github/workflows/codex-branch.sh &&
+	git -C meta-refresh-Meta commit -m "install controller A" &&
+	old_controller=$(git -C meta-refresh-Meta rev-parse HEAD) &&
+	git -C meta-refresh-Meta push origin meta &&
+	cat >meta-refresh-Meta/rebuild <<-\EOF &&
+	#!/bin/sh
+	printf "%s\\n" refreshed >"$META_REFRESH_MARKER"
+	exit 23
+	EOF
+	chmod +x meta-refresh-Meta/rebuild &&
+	git -C meta-refresh-Meta add rebuild &&
+	git -C meta-refresh-Meta commit -m "install controller B" &&
+	new_controller=$(git -C meta-refresh-Meta rev-parse HEAD) &&
+	test "$old_controller" != "$new_controller" &&
+	git -C meta-refresh-Meta push origin meta &&
+	git -C meta-refresh-Meta switch --detach "$old_controller" &&
+	mkdir meta-refresh-bin &&
+	real_git=$(command -v git) &&
+	cat >meta-refresh-bin/git <<-\EOF &&
+	#!/bin/sh
+	case "$*" in
+	"remote get-url --all origin"|"remote get-url --push --all origin")
+		printf "%s\\n" https://github.com/openai/git
+		exit 0
+		;;
+	esac
+	exec "$FAKE_REAL_GIT" "$@"
+	EOF
+	chmod +x meta-refresh-bin/git &&
+	(
+		cd meta-refresh-source &&
+		PATH="$TRASH_DIRECTORY/meta-refresh-bin:$PATH" \
+		FAKE_REAL_GIT="$real_git" \
+		META_REFRESH_MARKER="$TRASH_DIRECTORY/meta-refresh.marker" \
+		test_expect_code 23 ../meta-refresh-Meta/rebuild
+	) &&
+	test "$new_controller" = \
+		"$(git -C meta-refresh-Meta rev-parse HEAD)" &&
+	test_grep refreshed meta-refresh.marker
 '
 
 test_expect_success 'rewrite requires codex.config on meta' '
@@ -2497,6 +2908,117 @@ test_expect_success 'verify-output rejects malformed generated meta commits' '
 	)
 '
 
+test_expect_success 'verify-output rejects alternate integration histories' '
+	git init --bare integration-output.git &&
+	test_create_repo integration-output-source &&
+	(
+		cd integration-output-source &&
+		git remote add origin ../integration-output.git &&
+		write base shared &&
+		git add shared &&
+		install_rerere_train &&
+		git commit -m base &&
+		git branch codex &&
+
+		git switch -c aa/codex/a &&
+		write A a &&
+		git add a &&
+		git commit -m "output topic A" &&
+
+		git switch -c bb/codex/b &&
+		write B b &&
+		git add b &&
+		git commit -m "output topic B" &&
+
+		git switch -c cc/codex/c master &&
+		write C c &&
+		git add c &&
+		git commit -m "output topic C" &&
+
+		git switch master &&
+		git branch meta &&
+		install_meta_state meta master codex &&
+		git push origin master meta codex \
+			aa/codex/a bb/codex/b cc/codex/c
+	) &&
+
+	git clone integration-output.git integration-output-runner &&
+	(
+		cd integration-output-runner &&
+		fetch_all &&
+		sh "$codex_branch" rewrite --remote origin \
+			--base master --codex codex --result valid.result \
+			--updates valid.updates --inputs inputs --failure failure &&
+		sh "$codex_branch" verify-output --inputs inputs \
+			--updates valid.updates --result valid.result &&
+
+		base=$(git rev-parse origin/master) &&
+		topic_a=$(updated_tip aa/codex/a valid.updates) &&
+		topic_b=$(updated_tip bb/codex/b valid.updates) &&
+		topic_c=$(updated_tip cc/codex/c valid.updates) &&
+		old_meta=$(git rev-parse origin/meta) &&
+		valid_meta=$(updated_tip meta valid.updates) &&
+		valid_candidate=$(cat valid.result) &&
+		valid_tree=$(git rev-parse "$valid_candidate^{tree}") &&
+
+		missing_b=$(printf "%s\n" "Legacy maximal merge B" |
+			GIT_AUTHOR_NAME=$codex_bot_name \
+			GIT_AUTHOR_EMAIL=$codex_bot_email \
+			GIT_COMMITTER_NAME=$codex_bot_name \
+			GIT_COMMITTER_EMAIL=$codex_bot_email \
+			git -c commit.gpgSign=false commit-tree \
+				"$topic_b^{tree}" -p "$base" -p "$topic_b") &&
+		missing=$(printf "%s\n" "Legacy maximal merge C" |
+			GIT_AUTHOR_NAME=$codex_bot_name \
+			GIT_AUTHOR_EMAIL=$codex_bot_email \
+			GIT_COMMITTER_NAME=$codex_bot_name \
+			GIT_COMMITTER_EMAIL=$codex_bot_email \
+			git -c commit.gpgSign=false commit-tree \
+				"$valid_tree" -p "$missing_b" -p "$topic_c") &&
+		test "$valid_tree" = "$(git rev-parse "$missing^{tree}")" &&
+		write_test_output_tuple "$valid_meta" "$old_meta" \
+			"$valid_candidate" "$missing" valid.updates missing &&
+		test_expect_code 1 sh "$codex_branch" verify-output \
+			--inputs inputs --updates missing.updates \
+			--result missing.result >missing.out 2>missing.err &&
+		test_grep "one canonical integration merge per topic" missing.err &&
+
+		c_merge=$(make_test_integration cc/codex/c "$topic_c" \
+			"$base" "$topic_c^{tree}") &&
+		ac_tree=$(git merge-tree --write-tree "$c_merge" "$topic_a") &&
+		a_merge=$(make_test_integration aa/codex/a "$topic_a" \
+			"$c_merge" "$ac_tree") &&
+		acb_tree=$(git merge-tree --write-tree "$a_merge" "$topic_b") &&
+		reordered=$(make_test_integration bb/codex/b "$topic_b" \
+			"$a_merge" "$acb_tree") &&
+		test "$valid_tree" = "$(git rev-parse "$reordered^{tree}")" &&
+		write_test_output_tuple "$valid_meta" "$old_meta" \
+			"$valid_candidate" "$reordered" valid.updates reordered &&
+		test_expect_code 1 sh "$codex_branch" verify-output \
+			--inputs inputs --updates reordered.updates \
+			--result reordered.result >reordered.out 2>reordered.err &&
+		test_grep "one canonical integration merge per topic" reordered.err &&
+
+		before_c=$(git rev-parse "$valid_candidate^1") &&
+		forged_message=$(printf "Merge cc/codex/c into codex\n\nIntegrate the current cc/codex/c topic into the internally distributed codex branch.\n\nCodex-Integration: cc/codex/c@%s" \
+			"$topic_b") &&
+		forged=$(printf "%s\n" "$forged_message" |
+			GIT_AUTHOR_NAME=$codex_bot_name \
+			GIT_AUTHOR_EMAIL=$codex_bot_email \
+			GIT_COMMITTER_NAME=$codex_bot_name \
+			GIT_COMMITTER_EMAIL=$codex_bot_email \
+			git -c commit.gpgSign=false commit-tree "$valid_tree" \
+				-p "$before_c" -p "$topic_c") &&
+		test "$valid_tree" = "$(git rev-parse "$forged^{tree}")" &&
+		write_test_output_tuple "$valid_meta" "$old_meta" \
+			"$valid_candidate" "$forged" valid.updates forged &&
+		test_expect_code 1 sh "$codex_branch" verify-output \
+			--inputs inputs --updates forged.updates \
+			--result forged.result >forged.out 2>forged.err &&
+		test_grep "one canonical integration merge per topic" forged.err
+	)
+'
+
 test_expect_success PYTHON 'publish-run authenticates the artifact and promotes its exact candidate' '
 	git init --bare publish-run.git &&
 	test_create_repo publish-run-source &&
@@ -2647,11 +3169,37 @@ test_expect_success PYTHON 'publish-run authenticates the artifact and promotes 
 		cat >"$support/bin/gh" <<-\EOF &&
 		#!/bin/sh
 		printf "%s\\n" "$*" >>"$FAKE_GH_LOG"
+		if test "$1" = api && test "$2" = --hostname &&
+			test "$3" = github.com && test "$4" = --method
+		then
+			test "$5" = POST || exit 96
+			case "$*" in
+			*"--header X-GitHub-Api-Version: 2026-03-10"*\
+			*"--raw-field ref=codex"*\
+			*"repos/openai/git/actions/workflows/codex.yml/dispatches"*) ;;
+			*) exit 95 ;;
+			esac
+			test "${FAKE_GH_MODE:-}" != dispatch-error || exit 94
+			if test "${FAKE_GH_MODE:-}" = dispatch-malformed
+			then
+				printf "4242\\thttps://api.github.com/repos/openai/git/actions/runs/9999\\thttps://github.com/openai/git/actions/runs/4242\\n"
+			else
+				printf "4242\\thttps://api.github.com/repos/openai/git/actions/runs/4242\\thttps://github.com/openai/git/actions/runs/4242\\n"
+			fi
+			exit
+		fi
 		test "$1" = api &&
 		test "$2" = --hostname &&
 		test "$3" = github.com || exit 96
-		endpoint=$4
-		shift 4
+		shift 3
+		slurp=
+		while test "$1" = --paginate || test "$1" = --slurp
+		do
+			test "$1" != --slurp || slurp=t
+			shift
+		done
+		endpoint=$1
+		shift
 		case "$endpoint" in
 		repos/openai/git/actions/runs/4242)
 			case "$*" in
@@ -2672,8 +3220,25 @@ test_expect_success PYTHON 'publish-run authenticates the artifact and promotes 
 			*)
 				api_id=4242
 				test "${FAKE_GH_MODE:-}" != wrong-run || api_id=9999
-				printf "%s\\t1\\tcompleted\\tsuccess\\tworkflow_dispatch\\tcodex\\t%s\\t.github/workflows/codex.yml\\topenai/git\\thttps://example/run/4242\\n" \
-					"$api_id" "$FAKE_OLD_CODEX"
+				run_attempt=1
+				status=completed
+				conclusion=success
+				if test "${FAKE_GH_MODE:-}" = post-ci-rerun &&
+					test -f "$FAKE_GH_STATE.after-ci"
+				then
+					run_attempt=2
+				fi
+				case "${FAKE_GH_MODE:-}" in
+				preparation-failure) conclusion=failure ;;
+				preparation-rerun) run_attempt=2 ;;
+				preparation-timeout)
+					status=in_progress
+					conclusion=-
+					;;
+				esac
+				printf "%s\\t%s\\t%s\\t%s\\tworkflow_dispatch\\tcodex\\t%s\\t.github/workflows/codex.yml\\topenai/git\\thttps://example/run/4242\\n" \
+					"$api_id" "$run_attempt" "$status" "$conclusion" \
+					"$FAKE_OLD_CODEX"
 				;;
 			esac
 			;;
@@ -2690,11 +3255,62 @@ test_expect_success PYTHON 'publish-run authenticates the artifact and promotes 
 			esac
 			;;
 		repos/openai/git/actions/runs/101)
-			printf "101\\tpush\\tcodex-staging\\t%s\\t.github/workflows/main.yml\\tcompleted\\tsuccess\\thttps://example/ci/101\\n" \
-				"$FAKE_CANDIDATE"
+			count=$(cat "$FAKE_GH_STATE" 2>/dev/null || :)
+			count=${count:-0}
+			count=$((count + 1))
+			printf "%s\\n" "$count" >"$FAKE_GH_STATE"
+			case "${FAKE_GH_MODE:-}" in
+			staging-failure)
+				status=completed
+				conclusion=failure
+				;;
+			post-ci-rerun)
+				if test "$count" -le 11
+				then
+					status=in_progress
+					conclusion=-
+				else
+					status=completed
+					conclusion=success
+					: >"$FAKE_GH_STATE.after-ci"
+				fi
+				;;
+			*)
+				case "$count" in
+				1|2) status=queued; conclusion=- ;;
+				3|4) status=in_progress; conclusion=- ;;
+				*) status=completed; conclusion=success ;;
+				esac
+				;;
+			esac
+			printf "101\\tpush\\tcodex-staging\\t%s\\t.github/workflows/main.yml\\t%s\\t%s\\thttps://example/ci/101\\n" \
+				"$FAKE_CANDIDATE" "$status" "$conclusion"
 			;;
 		repos/openai/git/actions/runs/101/jobs?per_page=100)
-			printf "success\\n"
+			if test -n "$slurp"
+			then
+				count=$(cat "$FAKE_GH_STATE")
+				if test "${FAKE_GH_MODE:-}" = staging-failure
+				then
+					printf "2\\t2\\t1\\n"
+				elif test "${FAKE_GH_MODE:-}" = post-ci-rerun
+				then
+					case "$count" in
+					1|2|3|4|5|6|7|8|9|10|11)
+						printf "2\\t1\\t0\\n"
+						;;
+					*) printf "2\\t2\\t0\\n" ;;
+					esac
+				else
+					case "$count" in
+					1|2) printf "2\\t0\\t0\\n" ;;
+					3) printf "2\\t1\\t0\\n" ;;
+					*) printf "2\\t2\\t0\\n" ;;
+					esac
+				fi
+			else
+				printf "success\\n"
+			fi
 			;;
 		user)
 			printf "test-publisher\\n"
@@ -2706,26 +3322,41 @@ test_expect_success PYTHON 'publish-run authenticates the artifact and promotes 
 		esac
 		EOF
 		chmod +x "$support/bin/gh" &&
+		cat >"$support/bin/sleep" <<-\EOF &&
+		#!/bin/sh
+		exit 0
+		EOF
+		chmod +x "$support/bin/sleep" &&
 
 		git worktree add --detach Meta "$controller" &&
 		git status --porcelain >"$support/nested-status" &&
 		test_line_count = 1 "$support/nested-status" &&
 		test_grep "?? Meta/" "$support/nested-status" &&
-		publish_prepared () {
+		run_prepared () {
 			artifact=$1 &&
+			shift &&
+			rm -f "$support/gh.state" &&
+			rm -f "$support/gh.state.after-ci" &&
 			env PATH="$support/bin:$PATH" GH_HOST=attacker.example \
 				CODEX_CONTROLLER_OID="$controller" \
 				CODEX_META_WORKTREE="$PWD/Meta" \
 				FAKE_REAL_GIT="$real_git" \
 				FAKE_GIT_LOG="$support/git.log" \
 				FAKE_GH_LOG="$support/gh.log" \
+				FAKE_GH_STATE="$support/gh.state" \
 				FAKE_ARTIFACT_ZIP="$artifact" \
 				FAKE_CONTROLLER="$controller" \
 				FAKE_OLD_CODEX="$old_codex" \
 				FAKE_CANDIDATE="$candidate" \
 				FAKE_MULTIPLE_PUSHURLS="${FAKE_MULTIPLE_PUSHURLS:-}" \
 				FAKE_GH_MODE="${FAKE_GH_MODE:-}" \
-				sh "$codex_branch" publish-run 4242
+				sh "$codex_branch" "$@"
+		} &&
+		publish_prepared () {
+			run_prepared "$1" publish-run 4242
+		} &&
+		rebuild_prepared () {
+			run_prepared "$1" rebuild
 		} &&
 		snapshot_refs ../publish-run.git >"$support/before" &&
 
@@ -2744,6 +3375,42 @@ test_expect_success PYTHON 'publish-run authenticates the artifact and promotes 
 		test_grep "origin must have exactly one push URL" \
 			"$support/pushurl.err" &&
 		test_must_be_empty "$support/gh.log" &&
+
+		FAKE_GH_MODE=dispatch-error test_expect_code 1 \
+			rebuild_prepared "$support/good.zip" \
+			>"$support/dispatch-error.out" \
+			2>"$support/dispatch-error.err" &&
+		test_grep "could not dispatch Refresh codex" \
+			"$support/dispatch-error.err" &&
+		FAKE_GH_MODE=dispatch-malformed test_expect_code 1 \
+			rebuild_prepared "$support/good.zip" \
+			>"$support/dispatch-malformed.out" \
+			2>"$support/dispatch-malformed.err" &&
+		test_grep "dispatch returned unexpected run URLs" \
+			"$support/dispatch-malformed.err" &&
+		FAKE_GH_MODE=preparation-failure test_expect_code 1 \
+			rebuild_prepared "$support/good.zip" \
+			>"$support/preparation-failure.out" \
+			2>"$support/preparation-failure.err" &&
+		test_grep "Preparation: failure: https://example/run/4242" \
+			"$support/preparation-failure.out" &&
+		test_grep "finished with .failure." \
+			"$support/preparation-failure.err" &&
+		FAKE_GH_MODE=preparation-rerun test_expect_code 1 \
+			rebuild_prepared "$support/good.zip" \
+			>"$support/preparation-rerun.out" \
+			2>"$support/preparation-rerun.err" &&
+		test_grep "no longer identifies the dispatched Refresh codex attempt" \
+			"$support/preparation-rerun.err" &&
+		FAKE_GH_MODE=preparation-timeout test_expect_code 1 \
+			rebuild_prepared "$support/good.zip" \
+			>"$support/preparation-timeout.out" \
+			2>"$support/preparation-timeout.err" &&
+		test_grep "did not complete before the timeout" \
+			"$support/preparation-timeout.err" &&
+		snapshot_refs ../publish-run.git >"$support/after-dispatch-rejections" &&
+		test_cmp "$support/before" \
+			"$support/after-dispatch-rejections" &&
 
 		FAKE_GH_MODE=wrong-run test_expect_code 1 \
 			publish_prepared "$support/good.zip" \
@@ -2777,12 +3444,60 @@ test_expect_success PYTHON 'publish-run authenticates the artifact and promotes 
 		snapshot_refs ../publish-run.git >"$support/after-rejections" &&
 		test_cmp "$support/before" "$support/after-rejections" &&
 
+		FAKE_GH_MODE=staging-failure test_expect_code 1 \
+			run_prepared "$support/good.zip" publish 4242 \
+			>"$support/staging-failure.out" \
+			2>"$support/staging-failure.err" &&
+		test_grep "Waiting for staging CI for $candidate" \
+			"$support/staging-failure.out" &&
+		test_grep "Staging CI run 101: https://example/ci/101" \
+			"$support/staging-failure.out" &&
+		test_grep "Staging CI: failure (2/2 jobs complete; 1 failed)" \
+			"$support/staging-failure.out" &&
+		test_grep "CI failed for exact staging SHA $candidate" \
+			"$support/staging-failure.err" &&
+		test "$candidate" = "$(git --git-dir=../publish-run.git \
+			rev-parse refs/heads/codex-staging)" &&
+		snapshot_without_staging ../publish-run.git \
+			>"$support/after-staging-failure" &&
+		test_cmp "$support/before" "$support/after-staging-failure" &&
+		git --git-dir=../publish-run.git update-ref -d \
+			refs/heads/codex-staging "$candidate" &&
+
+		FAKE_GH_MODE=post-ci-rerun test_expect_code 1 \
+			run_prepared "$support/good.zip" publish 4242 \
+			>"$support/post-ci-rerun.out" \
+			2>"$support/post-ci-rerun.err" &&
+		grep -F "Staging CI: still in_progress after 5 minutes (1/2 jobs complete; 0 failed)" \
+			"$support/post-ci-rerun.out" \
+			>"$support/staging-heartbeat" &&
+		test_line_count = 1 "$support/staging-heartbeat" &&
+		test_grep "Actions run 4242 changed while staging CI ran" \
+			"$support/post-ci-rerun.err" &&
+		test "$candidate" = "$(git --git-dir=../publish-run.git \
+			rev-parse refs/heads/codex-staging)" &&
+		snapshot_without_staging ../publish-run.git \
+			>"$support/after-post-ci-rerun" &&
+		test_cmp "$support/before" "$support/after-post-ci-rerun" &&
+		git --git-dir=../publish-run.git update-ref -d \
+			refs/heads/codex-staging "$candidate" &&
+
 		: >"$support/gh.log" &&
-		publish_prepared "$support/good.zip" \
+		rebuild_prepared "$support/good.zip" \
 			>"$support/publish.out" 2>"$support/publish.err" &&
+		test_grep "Refresh codex run 4242: https://github.com/openai/git/actions/runs/4242" \
+			"$support/publish.out" &&
+		test_grep "Preparation: success: https://example/run/4242" \
+			"$support/publish.out" &&
 		test_grep "Published codex candidate $candidate from Actions run 4242" \
 			"$support/publish.out" &&
-		! grep -v "^api --hostname github.com " "$support/gh.log" &&
+		test_grep "api --hostname github.com --method POST" \
+			"$support/gh.log" &&
+		test_grep "X-GitHub-Api-Version: 2026-03-10" \
+			"$support/gh.log" &&
+		test_grep "raw-field ref=codex" "$support/gh.log" &&
+		! grep -F "actions/workflows/codex.yml/runs" \
+			"$support/gh.log" &&
 		test_grep "actions/artifacts/9001/zip" "$support/gh.log" &&
 		test_grep ".github/workflows/codex.yml@meta" \
 			"$support/gh.log" &&
@@ -2790,6 +3505,22 @@ test_expect_success PYTHON 'publish-run authenticates the artifact and promotes 
 		test_grep "actions/workflows/main.yml/runs?branch=codex-staging&event=push&head_sha=$candidate&per_page=100" \
 			"$support/gh.log" &&
 		test_grep "actions/runs/101/jobs" "$support/gh.log" &&
+		grep -F "Staging CI run 101: https://example/ci/101" \
+			"$support/publish.out" >"$support/staging-url" &&
+		test_line_count = 1 "$support/staging-url" &&
+		grep -F "Staging CI: queued (0/2 jobs complete; 0 failed)" \
+			"$support/publish.out" >"$support/staging-queued" &&
+		test_line_count = 1 "$support/staging-queued" &&
+		grep -F "Staging CI: in_progress (1/2 jobs complete; 0 failed)" \
+			"$support/publish.out" >"$support/staging-one" &&
+		test_line_count = 1 "$support/staging-one" &&
+		grep -F "Staging CI: in_progress (2/2 jobs complete; 0 failed)" \
+			"$support/publish.out" >"$support/staging-two" &&
+		test_line_count = 1 "$support/staging-two" &&
+		grep -F "Staging CI: success (2/2 jobs complete; 0 failed): https://example/ci/101" \
+			"$support/publish.out" >"$support/staging-success" &&
+		test_line_count = 1 "$support/staging-success" &&
+		test_grep "Full staging CI passed." "$support/publish.out" &&
 		while IFS="$(printf "\t")" read -r ref old new
 		do
 			test "$new" = "$(git --git-dir=../publish-run.git \


### PR DESCRIPTION
## Summary

- Add `Meta/rebuild` as the normal end-to-end operator command and `Meta/publish <run-id>` for a preparation started in GitHub.
- Bind dispatch, artifact, staging CI, and promotion to exact run attempts and report useful preparation, job, and heartbeat progress.
- Generate and independently verify one explicit two-parent integration merge for every active topic, including prerequisites, fast-forwards, already-contained tips, equal-tip aliases, and empty topics.
- Use `chatgpt-codex-connector[bot]` for rewritten and generated commit metadata while retaining the human operator as the authenticated pusher.

## Safety

The Action still executes no candidate code and pushes no refs. Final publication remains on the operator machine because the built-in `GITHUB_TOKEN` cannot safely preserve the push-triggered staging and release gates.

A dry run against the current live `master`, `codex`, and four topic tips produced a candidate whose tree is exactly the current shipped `codex` tree (`85afa6d3b31041e4013c65357821165d381741f9`). The first refresh changes only integration history and generated `meta` state. It does not rewrite any topic tip.

## Validation

- `t/t9905-codex-branch.sh`: 42/42 passed.
- Shell syntax passed under `sh` and `dash`; workflow YAML and ruleset JSON parse cleanly; `git diff --check` passed.
- Coverage includes exact dispatch provenance, rerun races, staging progress, self-refresh, atomic leases, legacy tree-same canonicalization, empty topics, `merge.log=true`, and rejection of missing, reordered, or forged integration histories.

The operator and topic-maintenance guide is updated at [How to maintain the Codex branch in openai/git](https://app.notion.com/p/3af8e50b62b081e1a634d3e544da9778).

<!-- codex-thread: 019fb902-4685-73c3-866c-26d0c59bc3de -->