### PR TITLE
ci: fix Codex rebuild verification and progress

### DIFF
--- a/.github/workflows/codex-branch.sh
+++ b/.github/workflows/codex-branch.sh
@@ -2596,6 +2596,8 @@ verify_output () {
 	# tree change.
 	printf '%s\n' "$base_name" >"$tmp_dir/topic-graph/base-name" ||
 		die "could not prepare integration verification"
+	printf '%s\n' "$base_oid" >"$tmp_dir/topic-graph/base-oid" ||
+		die "could not prepare integration base verification"
 	: >"$tmp_dir/topic-graph/results" ||
 		die "could not prepare rewritten topic verification"
 	while IFS="$tab" read -r name old
@@ -3003,20 +3005,26 @@ wait_for_staging_ci () (
 			test "$branch" = codex-staging && test "$sha" = "$candidate" &&
 			test "$path" = .github/workflows/main.yml ||
 			die "staging CI run $run_id no longer identifies the exact candidate"
-		"$gh_command" api --hostname github.com --paginate --slurp \
-			"repos/$repository/actions/runs/$run_id/jobs?per_page=100" --jq '
-			[.[] | .jobs[]] as $jobs |
-			[
-			  ($jobs | length),
-			  ($jobs | map(select(.status == "completed")) | length),
-			  ($jobs | map(select(
-			    .status == "completed" and
-			    (.conclusion != "success" and
-			     .conclusion != "skipped" and
-			     .conclusion != "neutral")
-			  )) | length)
-			] | @tsv' >"$tmp_dir/ci-jobs" ||
+		"$gh_command" api --hostname github.com --paginate \
+			"repos/$repository/actions/runs/$run_id/jobs?per_page=100" --jq \
+			'.jobs[] | [.status, (.conclusion // "-")] | @tsv' \
+			>"$tmp_dir/ci-job-rows" ||
 			die "could not inspect jobs for staging CI run $run_id"
+		awk -F '\t' '
+			{
+				total++
+				if ($1 == "completed") {
+					completed++
+					if ($2 != "success" && $2 != "skipped" &&
+					    $2 != "neutral")
+						failed++
+				}
+			}
+			END {
+				printf "%d\t%d\t%d\n", total, completed, failed
+			}
+		' "$tmp_dir/ci-job-rows" >"$tmp_dir/ci-jobs" ||
+			die "could not summarize jobs for staging CI run $run_id"
 		test "$(wc -l <"$tmp_dir/ci-jobs" | tr -d ' ')" = 1 ||
 			die "staging CI returned malformed job progress"
 		IFS="$tab" read -r total completed failed <"$tmp_dir/ci-jobs"

--- a/t/t9905-codex-branch.sh
+++ b/t/t9905-codex-branch.sh
@@ -1191,10 +1191,13 @@ test_expect_success 'rewrite bundle transfers the exact output over pinned input
 			"+refs/codex-output/*:refs/codex-output/*" &&
 		test "$(cat ../bundle-builder/result)" = \
 			"$(git rev-parse refs/codex-output/candidate)" &&
+		git switch --detach refs/codex-output/candidate &&
 		sh "$codex_branch" verify-output \
 			--inputs ../bundle-builder/inputs \
 			--updates ../bundle-builder/updates \
-			--result ../bundle-builder/result
+			--result ../bundle-builder/result \
+			>verify.out 2>verify.err &&
+		test_must_be_empty verify.err
 	)
 '
 
@@ -3192,10 +3195,9 @@ test_expect_success PYTHON 'publish-run authenticates the artifact and promotes 
 		test "$2" = --hostname &&
 		test "$3" = github.com || exit 96
 		shift 3
-		slurp=
 		while test "$1" = --paginate || test "$1" = --slurp
 		do
-			test "$1" != --slurp || slurp=t
+			test "$1" != --slurp || exit 93
 			shift
 		done
 		endpoint=$1
@@ -3287,30 +3289,46 @@ test_expect_success PYTHON 'publish-run authenticates the artifact and promotes 
 				"$FAKE_CANDIDATE" "$status" "$conclusion"
 			;;
 		repos/openai/git/actions/runs/101/jobs?per_page=100)
-			if test -n "$slurp"
-			then
+			case "$*" in
+			*"@tsv"*)
 				count=$(cat "$FAKE_GH_STATE")
 				if test "${FAKE_GH_MODE:-}" = staging-failure
 				then
-					printf "2\\t2\\t1\\n"
+					printf "completed\\tsuccess\\n"
+					printf "completed\\tfailure\\n"
 				elif test "${FAKE_GH_MODE:-}" = post-ci-rerun
 				then
 					case "$count" in
 					1|2|3|4|5|6|7|8|9|10|11)
-						printf "2\\t1\\t0\\n"
+						printf "completed\\tsuccess\\n"
+						printf "in_progress\\t-\\n"
 						;;
-					*) printf "2\\t2\\t0\\n" ;;
+					*)
+						printf "completed\\tsuccess\\n"
+						printf "completed\\tsuccess\\n"
+						;;
 					esac
 				else
 					case "$count" in
-					1|2) printf "2\\t0\\t0\\n" ;;
-					3) printf "2\\t1\\t0\\n" ;;
-					*) printf "2\\t2\\t0\\n" ;;
+					1|2)
+						printf "queued\\t-\\n"
+						printf "queued\\t-\\n"
+						;;
+					3)
+						printf "completed\\tsuccess\\n"
+						printf "in_progress\\t-\\n"
+						;;
+					*)
+						printf "completed\\tsuccess\\n"
+						printf "completed\\tsuccess\\n"
+						;;
 					esac
 				fi
-			else
+				;;
+			*)
 				printf "success\\n"
-			fi
+				;;
+			esac
 			;;
 		user)
 			printf "test-publisher\\n"
@@ -3505,6 +3523,8 @@ test_expect_success PYTHON 'publish-run authenticates the artifact and promotes 
 		test_grep "actions/workflows/main.yml/runs?branch=codex-staging&event=push&head_sha=$candidate&per_page=100" \
 			"$support/gh.log" &&
 		test_grep "actions/runs/101/jobs" "$support/gh.log" &&
+		! grep -F -- "--slurp" "$support/gh.log" &&
+		! grep -F "rewrite state is missing" "$support/publish.err" &&
 		grep -F "Staging CI run 101: https://example/ci/101" \
 			"$support/publish.out" >"$support/staging-url" &&
 		test_line_count = 1 "$support/staging-url" &&


### PR DESCRIPTION
## Summary

- carry the snapshotted master OID into independent integration verification
- collect paginated staging-job rows without combining unsupported `gh api`
  formatting options
- cover ambient-`HEAD` independence and the installed `gh` behavior

## Root cause

`verify-output` rebuilt the topic graph without its base OID. Because the
lookup ran inside a conditional, the missing value warned without aborting and
made integration verification depend on the caller's `HEAD`.

The staging waiter also used `gh api --slurp --jq`, a combination rejected by
the installed GitHub CLI. It now streams one normalized row per job across all
pages and aggregates progress locally.

## Validation

- `t/t9905-codex-branch.sh`: 42/42 passing
- focused bundle-verifier and publisher tests passing
- `sh -n` and `dash -n` on the controller
- `git diff --check`

The failed live attempt changed only `codex-staging`; no primary ref was
published. After this lands, start a fresh `Meta/rebuild`. The new run will
exact-lease replace or recreate staging and require a fresh exact-SHA CI run.

<!-- codex-thread: 019fb902-4685-73c3-866c-26d0c59bc3de -->
