### PR TITLE
ci: allow Codex rebuilds to prepare locally

### DIFF
--- a/.github/CODEX.md
+++ b/.github/CODEX.md
@@ -125,11 +125,12 @@ Meta/codex refresh --require-automation
 
 It creates a session below the repository's shared Git directory containing
 the pinned inputs, update manifest, candidate bundle, and conflict report. It
-does not update local or remote refs. The low-level `rewrite`, `stage`, and
-`promote` commands are also available through `Meta/codex`. Use local refresh
-for inspection and conflict recovery. Normal publication uses `Meta/rebuild`;
-use `Meta/publish <run-id>` only to finish a preparation started through
-GitHub.
+updates the clone's `origin/*` tracking refs, but it does not update local
+branches or refs on GitHub. The low-level `rewrite`, `stage`, and `promote`
+commands are also available through `Meta/codex`. Use local refresh for
+inspection and conflict recovery. Normal publication uses `Meta/rebuild` or
+`Meta/rebuild --local`; use `Meta/publish <run-id>` only to finish a
+preparation started through GitHub.
 
 ## Refresh `codex`
 
@@ -146,12 +147,48 @@ pushes the candidate to `codex-staging`, reports staging-CI job progress, and
 performs the atomic promotion only after that exact candidate passes. Leave
 the command running until it reports the published candidate.
 
+To do the rebase and assembly on your machine instead of in the preparation
+Action, run:
+
+```sh
+Meta/rebuild --local
+```
+
+This skips only the preparation Action. It fetches the current heads from
+GitHub, prepares the topics, integration commits, `codex`, and the next
+`codex.config` state in an isolated temporary repository, then imports and
+verifies the resulting bundle in the publisher clone. The temporary
+repository has its own rerere cache and Git configuration, so an old local
+resolution, hook, or concurrent local preparation cannot leak through shared
+repository state. The command prints the path of a persistent local session
+containing the input snapshot, update manifest, candidate OID, bundle, and any
+conflict report.
+
+`--local` does not skip CI or make a private local-only publication. After
+preparation, it uses the same user-authenticated `codex-staging` push, waits
+for the same fresh `main.yml` run for the exact candidate SHA, and performs
+the same atomic exact-lease promotion to GitHub. Use `Meta/codex refresh
+--require-automation` when you want only a local preview with no server-side
+ref update.
+
 Create the linked worktree once if it does not exist:
 
 ```sh
 git fetch origin '+refs/heads/meta:refs/remotes/origin/meta'
 git worktree add --detach Meta refs/remotes/origin/meta
 ```
+
+If an older `Meta/rebuild` rejects `--local` before it can refresh itself,
+update the existing `Meta` worktree once:
+
+```sh
+git fetch origin '+refs/heads/meta:refs/remotes/origin/meta'
+git -C Meta switch --detach refs/remotes/origin/meta
+Meta/rebuild --local
+```
+
+After that bootstrap, both rebuild forms refresh `Meta` and re-execute the
+new pinned controller automatically.
 
 Both the publishing worktree and `Meta` must be clean. When `Meta/` is nested
 in the publishing worktree, the helper permits that linked-worktree directory
@@ -170,8 +207,9 @@ The Action summary prints this command. Prepared artifacts expire after seven
 days. `Meta/publish` stays pinned to the controller used by the selected run;
 it does not update the `Meta` worktree underneath that run.
 
-Start a fresh `Meta/rebuild` after a preparation, staging, CI, lease, or
-promotion failure. The manual alternative is a fresh UI dispatch followed by
+Start a fresh `Meta/rebuild` or `Meta/rebuild --local`, using the same mode you
+want for the retry, after a preparation, staging, CI, lease, or promotion
+failure. The manual alternative is a fresh UI dispatch followed by
 `Meta/publish <run-id>`. Do not use **Re-run failed jobs**: a retry must
 snapshot the current refs and stage a fresh candidate.
 
@@ -188,6 +226,16 @@ The Action:
 4. uploads the bundle, pinned input snapshot, update manifest, and canonical
    run metadata as one attempt-specific artifact; and
 5. pushes nothing.
+
+With `Meta/rebuild --local`, those preparation steps run in the isolated local
+repository instead. There is no Actions run, server artifact, or run-attempt
+attestation for that phase. The helper instead pins the exact `Meta` commit,
+materializes the controller from that commit, freezes the local session,
+checks the complete GitHub input snapshot, verifies the bundle and generated
+history, and then relies on the same exact-SHA staging CI and ref leases.
+Generated commit OIDs may differ from an Actions preparation because the
+local Git version and commit timestamps may differ; the staged candidate is
+the exact object that CI verifies.
 
 `Meta/publish` uses the current user's existing `gh` and Git credentials. It
 accepts only a successful `workflow_dispatch` run on `openai/git:codex`, the
@@ -225,6 +273,10 @@ every ref it mutates or deletes in the atomic transaction. The generated
 state can therefore never describe a different published generation. A new
 input created in the final fetch-to-push window is handled by the next run.
 
+Both preparation modes use `refs/remotes/origin/master` after fetching the
+current `openai/git` heads. They do not use the caller's local `master`
+branch, which may be absent or stale.
+
 `master` is a read-only input, so Git's push protocol cannot include it as a
 compare-only command in the final ref transaction. The controller verifies it
 immediately before the push and checks it again afterward. If `master` moves
@@ -235,10 +287,12 @@ unchanged ref would require server-side transaction support.
 
 ## Resolve a rebase conflict
 
-The failed run summary says **No refs were updated** and prints a pinned
-`Meta/codex resolve` command. Start from a clean clone that does not already
-have a `Meta` worktree; the printed commands create one at the exact controller
-commit for the failed run:
+A failed Action summary says **No refs were updated** and prints a pinned
+`Meta/codex resolve` command. A failed `Meta/rebuild --local` prints the
+persistent session path and leaves the same conflict report there. In either
+case, follow the exact commands in that report. For Action preparation, start
+from a clean clone that does not already have a `Meta` worktree; the printed
+commands create one at the exact controller commit for the failed run:
 
 1. Run the exact fetch, detached checkout, and `resolve` commands from the
    summary. The helper verifies the original snapshot, creates a disposable
@@ -262,9 +316,10 @@ commit for the failed run:
 4. Review the rewritten topic tips, then run the printed `publish-topics`
    command. It rechecks the original snapshot and atomically pushes every
    rewritten topic with an exact lease.
-5. Run `Meta/rebuild` to prepare, verify, and publish the repaired graph. The
-   manual alternative is a fresh **Actions > Refresh codex > Run workflow**
-   dispatch followed by its printed `Meta/publish <run-id>` command.
+5. Run `Meta/rebuild` or `Meta/rebuild --local` to prepare, verify, and publish
+   the repaired graph. The manual alternative is a fresh **Actions > Refresh
+   codex > Run workflow** dispatch followed by its printed `Meta/publish
+   <run-id>` command.
 
 To abandon recovery, run `git rebase --abort` and delete the disposable
 worktree. Do not use `git rebase --quit`, push only the first conflicted topic,
@@ -284,16 +339,17 @@ environment. It uses the publisher's ordinary credentials:
 
 1. Authenticate `gh` as the publishing user. `Meta/rebuild` needs permission
    to dispatch Actions; `Meta/publish` needs permission to read the selected
-   run and its artifact:
+   run and its artifact. `Meta/rebuild --local` does neither, but it still
+   reads the exact staging-CI run and jobs:
 
    ```sh
    gh auth status
    ```
 
 2. Configure the canonical `origin` with that user's normal Git credentials.
-   `Meta/rebuild` and `Meta/publish` accept only the standard SSH or HTTPS URL
-   for `openai/git`. Neither command reads a token from the repository or
-   artifact.
+   `Meta/rebuild`, `Meta/rebuild --local`, and `Meta/publish` accept only the
+   standard SSH or HTTPS URL for `openai/git`. None reads a token from the
+   repository, local session, or artifact.
 3. In the existing **Protect generated Codex branch** ruleset and the
    **Protect Codex controller branch** ruleset, add an **always** bypass for
    each exact human publisher. The checked-in recipes authorize only the
@@ -301,15 +357,15 @@ environment. It uses the publisher's ordinary credentials:
    break-glass actor. Import the `meta` recipe only if that ruleset is absent.
 
 The bypass is intentionally personal and visible. The Action cannot publish;
-it only prepares an immutable artifact. Running `Meta/rebuild` or
-`Meta/publish` is the approval, and Git records the configured user as the
-pusher. To add or remove a publisher, change the exact `User` actor in both
-rulesets. Do not replace it
-with a broad repository role or a shared long-lived credential.
+it only prepares an immutable artifact. Running `Meta/rebuild`,
+`Meta/rebuild --local`, or `Meta/publish` is the approval, and Git records the
+configured user as the pusher. To add or remove a publisher, change the exact
+`User` actor in both rulesets. Do not replace it with a broad repository role
+or a shared long-lived credential.
 
-The final push runs from the operator's machine. Actions prepares the candidate
-and CI verifies it, but the operator's existing Git credentials authorize the
-atomic ref update.
+The final push runs from the operator's machine. Preparation runs either in
+Actions or in the isolated local repository; staging CI still runs in Actions.
+The operator's existing Git credentials authorize the atomic ref update.
 
 The built-in `GITHUB_TOKEN` is not a substitute for the local publisher.
 [GitHub suppresses push-triggered workflows for pushes made with that
@@ -320,11 +376,12 @@ outside this controller. Moving publication into Actions therefore requires a
 separate, narrowly scoped GitHub App credential; until one is provisioned, the
 local publisher remains the security and audit boundary.
 
-The local helper downloads the artifact through `gh`, but pushes through
-`origin`. Those credentials can theoretically identify different users, so
-the helper prints the authenticated `gh` login before staging. Verify the
-configured Git identity when changing machines or credentials. A failed CI
-run leaves `codex-staging` for inspection; it exposes no publishing secret.
+For an Actions preparation, the local helper downloads the artifact through
+`gh`, but pushes through `origin`. Those credentials can theoretically
+identify different users, so every publishing path prints the authenticated
+`gh` login before staging. Verify the configured Git identity when changing
+machines or credentials. A failed CI run leaves `codex-staging` for
+inspection; it exposes no publishing secret.
 
 The automation topic is the only topic allowed to change the dispatch
 trampoline. Other topics may change only

--- a/.github/workflows/codex-branch.sh
+++ b/.github/workflows/codex-branch.sh
@@ -25,7 +25,7 @@ die () {
 usage () {
 	cat <<-\EOF
 	usage: codex-branch check-topic <branch>
-	   or: codex-branch rebuild
+	   or: codex-branch rebuild [--local]
 	   or: codex-branch publish <run-id>
 	   or: codex-branch initialize [--remote <remote>] [--base <branch>]
 		[--codex <branch>] [--output <path>] [--require-automation]
@@ -2133,6 +2133,28 @@ initialize_config () {
 	say "review and commit only $meta_config_path on meta before running Refresh codex"
 }
 
+choose_local_rebuild_session () {
+	common_dir=$(git rev-parse --path-format=absolute --git-common-dir) ||
+		die "could not locate the shared repository state"
+	session_parent=$common_dir/codex-refresh
+	mkdir -p "$session_parent" ||
+		die "could not create local refresh storage"
+	attempt=0
+	while test "$attempt" -lt 100
+	do
+		attempt=$((attempt + 1))
+		session_root=$session_parent/session.local.$$.${attempt}
+		if mkdir "$session_root" 2>/dev/null
+		then
+			chmod 700 "$session_root" ||
+				die "could not protect local refresh storage '$session_root'"
+			session=$session_root/artifacts
+			return 0
+		fi
+	done
+	die "could not choose a unique local refresh session path"
+}
+
 local_refresh () {
 	remote=origin
 	base_name=master
@@ -2169,6 +2191,7 @@ local_refresh () {
 		test ! -e "$session" || die "refresh session '$session' already exists"
 		mkdir -p "$session" || die "could not create refresh session '$session'"
 	fi
+	chmod 700 "$session" || die "could not protect refresh session '$session'"
 	set -- --remote "$remote" --base "$base_name" --codex "$codex_name" \
 		--rerere-from "$rerere_name" \
 		--result "$session/codex-candidate" \
@@ -2180,7 +2203,7 @@ local_refresh () {
 	fetch_heads "$remote"
 	rewrite "$@"
 	say "local refresh session: $session"
-	say "no refs were updated; inspect codex-updates and codex.bundle"
+	say "no local branches or remote server refs were updated; inspect codex-updates and codex.bundle"
 }
 
 rewrite () {
@@ -2822,7 +2845,7 @@ refresh_meta_controller () {
 		die "could not update the Meta worktree"
 	test -x "$meta_worktree/rebuild" ||
 		die "updated meta does not contain Meta/rebuild"
-	exec "$meta_worktree/rebuild"
+	exec "$meta_worktree/rebuild" "$@"
 }
 
 read_refresh_run () {
@@ -2879,11 +2902,29 @@ wait_for_refresh_run () (
 )
 
 rebuild_codex () {
-	test $# = 0 || { usage >&2; exit 129; }
+	local_preparation=
+	case $# in
+	0) ;;
+	1)
+		test "$1" = --local || { usage >&2; exit 129; }
+		local_preparation=t
+		;;
+	*) usage >&2; exit 129 ;;
+	esac
 	require_operator_context
-	command -v unzip >/dev/null 2>&1 || die "Meta/rebuild requires unzip"
-	command -v zipinfo >/dev/null 2>&1 || die "Meta/rebuild requires zipinfo"
-	refresh_meta_controller
+	if test -z "$local_preparation"
+	then
+		command -v unzip >/dev/null 2>&1 ||
+			die "Meta/rebuild requires unzip"
+		command -v zipinfo >/dev/null 2>&1 ||
+			die "Meta/rebuild requires zipinfo"
+	fi
+	refresh_meta_controller "$@"
+	if test -n "$local_preparation"
+	then
+		rebuild_codex_locally
+		return
+	fi
 
 	make_tmp_dir
 	repository=openai/git
@@ -3069,6 +3110,176 @@ wait_for_staging_ci () (
 	say "Full staging CI passed."
 )
 
+freeze_local_candidate () {
+	source=$1
+	target=$2
+	mkdir -p "$target" ||
+		die "could not create the frozen local candidate directory"
+	chmod 700 "$target" ||
+		die "could not protect the frozen local candidate directory"
+	for name in codex.bundle codex-candidate codex-inputs codex-updates
+	do
+		test -f "$source/$name" && test ! -L "$source/$name" ||
+			die "local preparation did not produce regular file '$name'"
+		cp "$source/$name" "$target/$name" ||
+			die "could not freeze local candidate file '$name'"
+		chmod 600 "$target/$name" ||
+			die "could not protect frozen local candidate file '$name'"
+	done
+}
+
+verify_candidate_bundle () {
+	bundle=$1
+	candidate=$2
+	updates=$3
+	controller=$4
+
+	git bundle verify "$bundle" >/dev/null ||
+		die "candidate bundle failed verification"
+	git bundle unbundle "$bundle" >"$tmp_dir/bundle-heads" ||
+		die "could not import the candidate bundle"
+	printf '%s refs/codex-output/candidate\n' "$candidate" \
+		>"$tmp_dir/expected-bundle-heads"
+	new_meta=$(awk -F '\t' '$1 == "refs/heads/meta" { print $3 }' \
+		"$updates")
+	test -n "$new_meta" || die "candidate updates contain no meta state"
+	if test "$new_meta" != "$controller"
+	then
+		printf '%s refs/codex-output/meta\n' "$new_meta" \
+			>>"$tmp_dir/expected-bundle-heads"
+	fi
+	LC_ALL=C sort -o "$tmp_dir/bundle-heads" "$tmp_dir/bundle-heads"
+	LC_ALL=C sort -o "$tmp_dir/expected-bundle-heads" \
+		"$tmp_dir/expected-bundle-heads"
+	cmp -s "$tmp_dir/expected-bundle-heads" "$tmp_dir/bundle-heads" ||
+		die "candidate bundle heads do not match the frozen update manifest"
+}
+
+verify_local_candidate () {
+	metadata=$1
+	inputs=$metadata/codex-inputs
+	updates=$metadata/codex-updates
+	result=$metadata/codex-candidate
+	bundle=$metadata/codex.bundle
+
+	test "$(wc -l <"$result" | tr -d ' ')" = 1 ||
+		die "local candidate file must contain exactly one OID"
+	candidate=$(sed -n '1p' "$result")
+	input_controller=$(awk -F '\t' '$1 == "controller" { print $3 }' \
+		"$inputs")
+	test -n "$input_controller" && test "$input_controller" = "$controller_oid" ||
+		die "local candidate input snapshot does not match Meta/HEAD"
+	# Fetch and validate every prerequisite before importing the generated
+	# objects.  The local bundle intentionally excludes the snapshotted
+	# master, codex, and topic tips.
+	verify_inputs --remote origin --base master --codex codex "$inputs"
+	verify_candidate_bundle "$bundle" "$candidate" "$updates" \
+		"$controller_oid"
+	require_full_commit_oid "$candidate"
+	update_candidate=$(awk -F '\t' '$1 == "refs/heads/codex" { print $3 }' \
+		"$updates")
+	test "$candidate" = "$update_candidate" ||
+		die "local candidate and update manifest disagree"
+	verify_output --inputs "$inputs" --updates "$updates" \
+		--result "$result" --require-automation
+}
+
+with_isolated_git_environment () (
+	unset GIT_ALTERNATE_OBJECT_DIRECTORIES GIT_COMMON_DIR \
+		GIT_CONFIG_COUNT GIT_CONFIG_PARAMETERS GIT_CONFIG_SYSTEM \
+		GIT_DIR GIT_INDEX_FILE GIT_NAMESPACE GIT_OBJECT_DIRECTORY \
+		GIT_PREFIX GIT_QUARANTINE_PATH GIT_SHALLOW_FILE \
+		GIT_TEMPLATE_DIR GIT_WORK_TREE
+	GIT_CONFIG_NOSYSTEM=1
+	GIT_CONFIG_SYSTEM=/dev/null
+	GIT_CONFIG_GLOBAL=/dev/null
+	GIT_ATTR_NOSYSTEM=1
+	export GIT_CONFIG_NOSYSTEM GIT_CONFIG_SYSTEM GIT_CONFIG_GLOBAL \
+		GIT_ATTR_NOSYSTEM
+	"$@"
+)
+
+prepare_local_candidate () {
+	make_tmp_dir
+	publisher_top=$(git rev-parse --show-toplevel) ||
+		die "could not locate the publisher worktree"
+	frozen_helper=$tmp_dir/pinned-codex-branch.sh
+	expected_helper=$(git rev-parse \
+		"$controller_oid:.github/workflows/codex-branch.sh" 2>/dev/null) ||
+		die "pinned meta $controller_oid has no controller helper"
+	git cat-file blob \
+		"$controller_oid:.github/workflows/codex-branch.sh" \
+		>"$frozen_helper" || die "could not materialize the pinned controller"
+	test "$(git hash-object "$frozen_helper")" = "$expected_helper" ||
+		die "materialized controller does not match pinned meta $controller_oid"
+	chmod 700 "$frozen_helper" ||
+		die "could not protect the pinned controller helper"
+	prepare_repository=$tmp_dir/local-prepare
+	origin_fetch_url=$(git remote get-url --all origin) ||
+		die "could not read the canonical origin fetch URL"
+	origin_push_url=$(git remote get-url --push --all origin) ||
+		die "could not read the canonical origin push URL"
+	with_isolated_git_environment git clone --shared --no-checkout \
+		"$publisher_top" "$prepare_repository" >/dev/null ||
+		die "could not create the isolated local preparation repository"
+	with_isolated_git_environment git -C "$prepare_repository" \
+		remote set-url origin \
+		"$origin_fetch_url" || die "could not set the preparation fetch URL"
+	with_isolated_git_environment git -C "$prepare_repository" \
+		remote set-url --push origin \
+		"$origin_push_url" || die "could not set the preparation push URL"
+	choose_local_rebuild_session
+	say "Local preparation session: $session"
+	(
+		cd "$prepare_repository" || exit 1
+		with_isolated_git_environment \
+			"$frozen_helper" refresh \
+			--session "$session" --remote origin --base master \
+			--codex codex --rerere-from codex --require-automation
+	) || die "local Codex preparation failed; inspect '$session'"
+	local_candidate_dir=$tmp_dir/local-candidate
+	freeze_local_candidate "$session" "$local_candidate_dir"
+}
+
+stage_and_wait_for_ci () {
+	repository=$1
+	candidate=$2
+	inputs=$3
+	updates=$4
+	workflow_runs="repos/$repository/actions/workflows/main.yml/runs?branch=codex-staging&event=push&head_sha=$candidate&per_page=100"
+	baseline=$(gh api --hostname github.com "$workflow_runs" --jq \
+		'[.workflow_runs[].id] | max // 0') ||
+		die "could not record the staging CI baseline"
+	case "$baseline" in
+	''|*[!0-9]*) die "staging CI baseline is not a numeric run ID" ;;
+	esac
+	publisher=$(gh api --hostname github.com user --jq .login) ||
+		die "could not identify the GitHub CLI user"
+	test -n "$publisher" || die "GitHub CLI returned no authenticated user"
+	say "Publishing the prepared candidate with the credentials for origin."
+	say "GitHub API user: $publisher"
+	stage_candidate --remote origin --staging codex-staging \
+		--inputs "$inputs" --updates "$updates" --require-automation
+	wait_for_staging_ci gh "$repository" "$candidate" "$baseline"
+}
+
+rebuild_codex_locally () {
+	prepare_local_candidate
+	verify_local_candidate "$local_candidate_dir"
+	candidate=$(sed -n '1p' "$local_candidate_dir/codex-candidate")
+	stage_and_wait_for_ci openai/git "$candidate" \
+		"$local_candidate_dir/codex-inputs" \
+		"$local_candidate_dir/codex-updates"
+	require_operator_context
+	verify_local_candidate "$local_candidate_dir"
+	promote --remote origin --staging codex-staging \
+		--inputs "$local_candidate_dir/codex-inputs" \
+		--updates "$local_candidate_dir/codex-updates" \
+		--require-automation
+	say "Published codex candidate $candidate from local preparation session $session."
+	say "Generated commits identify $bot_name <$bot_email>; the push uses your configured origin credentials."
+}
+
 publish_run () {
 	test $# = 1 || { usage >&2; exit 129; }
 	run_id=$1
@@ -3167,25 +3378,8 @@ publish_run () {
 
 	verify_inputs --remote origin --base master --codex codex \
 		"$metadata/codex-inputs"
-	git bundle verify "$metadata/codex.bundle" >/dev/null ||
-		die "candidate bundle failed verification"
-	git bundle unbundle "$metadata/codex.bundle" >"$tmp_dir/bundle-heads" ||
-		die "could not import the candidate bundle"
-	printf '%s refs/codex-output/candidate\n' "$artifact_candidate" \
-		>"$tmp_dir/expected-bundle-heads"
-	new_meta=$(awk -F '\t' '$1 == "refs/heads/meta" { print $3 }' \
-		"$metadata/codex-updates")
-	test -n "$new_meta" || die "candidate updates contain no meta state"
-	if test "$new_meta" != "$run_controller"
-	then
-		printf '%s refs/codex-output/meta\n' "$new_meta" \
-			>>"$tmp_dir/expected-bundle-heads"
-	fi
-	LC_ALL=C sort -o "$tmp_dir/bundle-heads" "$tmp_dir/bundle-heads"
-	LC_ALL=C sort -o "$tmp_dir/expected-bundle-heads" \
-		"$tmp_dir/expected-bundle-heads"
-	cmp -s "$tmp_dir/expected-bundle-heads" "$tmp_dir/bundle-heads" ||
-		die "candidate bundle heads do not match the frozen update manifest"
+	verify_candidate_bundle "$metadata/codex.bundle" "$artifact_candidate" \
+		"$metadata/codex-updates" "$run_controller"
 	verify_output --inputs "$metadata/codex-inputs" \
 		--updates "$metadata/codex-updates" \
 		--result "$metadata/codex-candidate" --require-automation
@@ -3193,21 +3387,8 @@ publish_run () {
 	cmp -s "$tmp_dir/run" "$tmp_dir/run-current" ||
 		die "Actions run $run_id changed after artifact validation; start a fresh Meta/rebuild"
 
-	workflow_runs="repos/$repository/actions/workflows/main.yml/runs?branch=codex-staging&event=push&head_sha=$artifact_candidate&per_page=100"
-	baseline=$(gh api --hostname github.com "$workflow_runs" --jq \
-		'[.workflow_runs[].id] | max // 0') || die "could not record the staging CI baseline"
-	case "$baseline" in
-	''|*[!0-9]*) die "staging CI baseline is not a numeric run ID" ;;
-	esac
-	publisher=$(gh api --hostname github.com user --jq .login) ||
-		die "could not identify the GitHub CLI user"
-	test -n "$publisher" || die "GitHub CLI returned no authenticated user"
-	say "Publishing the prepared candidate with the credentials for origin."
-	say "GitHub API user: $publisher"
-	stage_candidate --remote origin --staging codex-staging \
-		--inputs "$metadata/codex-inputs" \
-		--updates "$metadata/codex-updates" --require-automation
-	wait_for_staging_ci gh "$repository" "$artifact_candidate" "$baseline"
+	stage_and_wait_for_ci "$repository" "$artifact_candidate" \
+		"$metadata/codex-inputs" "$metadata/codex-updates"
 	read_refresh_run gh "$repository" "$run_id" "$tmp_dir/run-after-ci"
 	cmp -s "$tmp_dir/run" "$tmp_dir/run-after-ci" ||
 		die "Actions run $run_id changed while staging CI ran; start a fresh Meta/rebuild"

--- a/t/t9905-codex-branch.sh
+++ b/t/t9905-codex-branch.sh
@@ -325,8 +325,11 @@ test_expect_success 'convenience wrappers forward to the pinned controller' '
 	WRAPPER_LOG="$TRASH_DIRECTORY/wrapper.log" \
 		"$TRASH_DIRECTORY/wrapper forwarding/Meta/rebuild" &&
 	WRAPPER_LOG="$TRASH_DIRECTORY/wrapper.log" \
+		"$TRASH_DIRECTORY/wrapper forwarding/Meta/rebuild" --local &&
+	WRAPPER_LOG="$TRASH_DIRECTORY/wrapper.log" \
 		"$TRASH_DIRECTORY/wrapper forwarding/Meta/publish" 4242 &&
-	printf "%s\n" rebuild "publish 4242" >wrapper.expect &&
+	printf "%s\n" rebuild "rebuild --local" "publish 4242" \
+		>wrapper.expect &&
 	test_cmp wrapper.expect wrapper.log &&
 	WRAPPER_LOG="$TRASH_DIRECTORY/wrapper.log" WRAPPER_EXIT=17 \
 		test_expect_code 17 \
@@ -336,7 +339,8 @@ test_expect_success 'convenience wrappers forward to the pinned controller' '
 test_expect_success 'refresh only prepares an immutable local-publish artifact' '
 	! grep -F "codex-topic.yml" "$codex_workflow" &&
 	! grep -E "make -C|t9905-codex-branch.sh" "$codex_workflow" &&
-	! grep -E "clone --shared|parallel worker" "$codex_branch" &&
+	! grep -F "parallel worker" "$codex_branch" &&
+	test_grep "clone --shared --no-checkout" "$codex_branch" &&
 	! grep -E "CODEX_BRANCH_TOKEN|CODEX_BRANCH_MANAGER_TOKEN|CODEX_DEPLOY_KEY|secret-broker|id-token" \
 		"$codex_workflow" &&
 	! grep -F "environment: codex-publish" "$codex_workflow" &&
@@ -2700,7 +2704,7 @@ test_expect_success 'Meta/rebuild refreshes and executes a newer meta controller
 	git -C meta-refresh-Meta push origin meta &&
 	cat >meta-refresh-Meta/rebuild <<-\EOF &&
 	#!/bin/sh
-	printf "%s\\n" refreshed >"$META_REFRESH_MARKER"
+	printf "refreshed %s\\n" "$*" >"$META_REFRESH_MARKER"
 	exit 23
 	EOF
 	chmod +x meta-refresh-Meta/rebuild &&
@@ -2728,11 +2732,11 @@ test_expect_success 'Meta/rebuild refreshes and executes a newer meta controller
 		PATH="$TRASH_DIRECTORY/meta-refresh-bin:$PATH" \
 		FAKE_REAL_GIT="$real_git" \
 		META_REFRESH_MARKER="$TRASH_DIRECTORY/meta-refresh.marker" \
-		test_expect_code 23 ../meta-refresh-Meta/rebuild
+		test_expect_code 23 ../meta-refresh-Meta/rebuild --local
 	) &&
 	test "$new_controller" = \
 		"$(git -C meta-refresh-Meta rev-parse HEAD)" &&
-	test_grep refreshed meta-refresh.marker
+	test_grep "refreshed --local" meta-refresh.marker
 '
 
 test_expect_success 'rewrite requires codex.config on meta' '
@@ -3046,6 +3050,16 @@ test_expect_success PYTHON 'publish-run authenticates the artifact and promotes 
 		git commit -m "publish-run master" &&
 		git branch meta master &&
 		install_meta_state meta master codex &&
+		git worktree add ../publish-run-controller meta &&
+		cp "$codex_entrypoint" ../publish-run-controller/codex &&
+		cp "$codex_rebuild" ../publish-run-controller/rebuild &&
+		cp "$codex_publish" ../publish-run-controller/publish &&
+		chmod +x ../publish-run-controller/codex \
+			../publish-run-controller/rebuild \
+			../publish-run-controller/publish &&
+		git -C ../publish-run-controller add codex rebuild publish &&
+		git -C ../publish-run-controller commit -m \
+			"install pinned controller entry points" &&
 		git push origin master meta codex aa/codex/automation
 	) &&
 
@@ -3152,6 +3166,54 @@ test_expect_success PYTHON 'publish-run authenticates the artifact and promotes 
 		cat >"$support/bin/git" <<-\EOF &&
 		#!/bin/sh
 		printf "%s\\n" "$*" >>"$FAKE_GIT_LOG"
+		if test -n "${FAKE_LOCAL_PREP_ORIGIN:-}" && test "$1" = -C
+		then
+			case "$2" in
+			*/local-prepare)
+				if test "$3" = remote && test "$4" = set-url &&
+					test "$5" = origin
+				then
+					exec "$FAKE_REAL_GIT" -C "$2" remote set-url \
+						origin "$FAKE_LOCAL_PREP_ORIGIN"
+				elif test "$3" = remote && test "$4" = set-url &&
+					test "$5" = --push && test "$6" = origin
+				then
+					exec "$FAKE_REAL_GIT" -C "$2" remote set-url \
+						--push origin "$FAKE_LOCAL_PREP_ORIGIN"
+				fi
+				;;
+			esac
+		fi
+		if test "${FAKE_ASSERT_BUNDLE_IMPORT:-}" = 1 &&
+			test "$1" = bundle && test "$2" = verify
+		then
+			bundle_candidate=$("$FAKE_REAL_GIT" bundle list-heads "$3" |
+				sed -n "s/ refs\\/codex-output\\/candidate\$//p") ||
+				exit 92
+			test -n "$bundle_candidate" || exit 92
+			if test ! -f "$FAKE_BUNDLE_ABSENT_MARKER"
+			then
+				! "$FAKE_REAL_GIT" cat-file -e \
+					"$bundle_candidate^{commit}" 2>/dev/null || exit 91
+				printf "%s\\n" "$bundle_candidate" \
+					>"$FAKE_BUNDLE_ABSENT_MARKER"
+			else
+				test "$bundle_candidate" = \
+					"$(sed -n "1p" "$FAKE_BUNDLE_ABSENT_MARKER")" ||
+					exit 91
+			fi
+		fi
+		if test "${FAKE_ASSERT_BUNDLE_IMPORT:-}" = 1 &&
+			test "$1" = bundle && test "$2" = unbundle
+		then
+			"$FAKE_REAL_GIT" "$@" || exit
+			bundle_candidate=$(sed -n "1p" \
+				"$FAKE_BUNDLE_ABSENT_MARKER")
+			"$FAKE_REAL_GIT" cat-file -e \
+				"$bundle_candidate^{commit}" || exit 90
+			: >"$FAKE_BUNDLE_IMPORTED_MARKER"
+			exit 0
+		fi
 		case "$*" in
 		"remote get-url --all origin")
 			printf "%s\\n" https://github.com/openai/git
@@ -3257,6 +3319,13 @@ test_expect_success PYTHON 'publish-run authenticates the artifact and promotes 
 			esac
 			;;
 		repos/openai/git/actions/runs/101)
+			ci_candidate=$FAKE_CANDIDATE
+			if test "${FAKE_DYNAMIC_CANDIDATE:-}" = 1
+			then
+				ci_candidate=$("$FAKE_REAL_GIT" \
+					--git-dir="$FAKE_LOCAL_PREP_ORIGIN" \
+					rev-parse refs/heads/codex-staging) || exit 98
+			fi
 			count=$(cat "$FAKE_GH_STATE" 2>/dev/null || :)
 			count=${count:-0}
 			count=$((count + 1))
@@ -3286,7 +3355,7 @@ test_expect_success PYTHON 'publish-run authenticates the artifact and promotes 
 				;;
 			esac
 			printf "101\\tpush\\tcodex-staging\\t%s\\t.github/workflows/main.yml\\t%s\\t%s\\thttps://example/ci/101\\n" \
-				"$FAKE_CANDIDATE" "$status" "$conclusion"
+				"$ci_candidate" "$status" "$conclusion"
 			;;
 		repos/openai/git/actions/runs/101/jobs?per_page=100)
 			case "$*" in
@@ -3347,25 +3416,37 @@ test_expect_success PYTHON 'publish-run authenticates the artifact and promotes 
 		chmod +x "$support/bin/sleep" &&
 
 		git worktree add --detach Meta "$controller" &&
+		local_origin=$(cd ../publish-run.git && pwd) &&
 		git status --porcelain >"$support/nested-status" &&
 		test_line_count = 1 "$support/nested-status" &&
 		test_grep "?? Meta/" "$support/nested-status" &&
 		run_prepared () {
 			artifact=$1 &&
 			shift &&
+			active_controller=$(git -C Meta rev-parse HEAD) &&
 			rm -f "$support/gh.state" &&
 			rm -f "$support/gh.state.after-ci" &&
 			env PATH="$support/bin:$PATH" GH_HOST=attacker.example \
-				CODEX_CONTROLLER_OID="$controller" \
+				CODEX_CONTROLLER_OID="$active_controller" \
 				CODEX_META_WORKTREE="$PWD/Meta" \
 				FAKE_REAL_GIT="$real_git" \
 				FAKE_GIT_LOG="$support/git.log" \
 				FAKE_GH_LOG="$support/gh.log" \
 				FAKE_GH_STATE="$support/gh.state" \
 				FAKE_ARTIFACT_ZIP="$artifact" \
-				FAKE_CONTROLLER="$controller" \
+				FAKE_CONTROLLER="$active_controller" \
 				FAKE_OLD_CODEX="$old_codex" \
 				FAKE_CANDIDATE="$candidate" \
+				FAKE_DYNAMIC_CANDIDATE="${FAKE_DYNAMIC_CANDIDATE:-}" \
+				FAKE_LOCAL_PREP_ORIGIN="$local_origin" \
+				FAKE_ASSERT_BUNDLE_IMPORT="${FAKE_ASSERT_BUNDLE_IMPORT:-}" \
+				FAKE_BUNDLE_ABSENT_MARKER="$support/bundle-absent" \
+				FAKE_BUNDLE_IMPORTED_MARKER="$support/bundle-imported" \
+				FAKE_HOOK_MARKER="$support/inherited-hook-ran" \
+				FAKE_ZIP_MARKER="${FAKE_ZIP_MARKER:-}" \
+				GIT_CONFIG_COUNT="${FAKE_GIT_CONFIG_COUNT:-0}" \
+				GIT_CONFIG_KEY_0=core.hooksPath \
+				GIT_CONFIG_VALUE_0="$support/hooks" \
 				FAKE_MULTIPLE_PUSHURLS="${FAKE_MULTIPLE_PUSHURLS:-}" \
 				FAKE_GH_MODE="${FAKE_GH_MODE:-}" \
 				sh "$codex_branch" "$@"
@@ -3546,6 +3627,98 @@ test_expect_success PYTHON 'publish-run authenticates the artifact and promotes 
 			test "$new" = "$(git --git-dir=../publish-run.git \
 				rev-parse "$ref")" || return 1
 		done <"$support/codex-updates" &&
+		test_must_fail git --git-dir=../publish-run.git show-ref --verify \
+			refs/heads/codex-staging &&
+
+		# Local preparation must use its isolated repository, not the
+		# rerere cache, hooks, temporary refs, or ZIP tooling in the
+		# publisher clone.
+		# Advance master only on the remote so it also has to import
+		# a genuinely new candidate from the local bundle.
+		git fetch --force origin \
+			"+refs/heads/meta:refs/remotes/origin/meta" &&
+		git -C Meta -c advice.detachedHead=false switch --detach \
+			refs/remotes/origin/meta &&
+		(
+			cd ../publish-run-source &&
+			git switch master &&
+			write advanced local-master-update &&
+			git add local-master-update &&
+			git commit -m "advance master for local preparation" &&
+			git push origin master
+		) &&
+		advanced_master=$(git --git-dir=../publish-run.git \
+			rev-parse refs/heads/master) &&
+		snapshot_refs ../publish-run.git >"$support/before-local" &&
+		common_dir=$(git rev-parse --path-format=absolute \
+			--git-common-dir) &&
+		mkdir -p "$common_dir/rr-cache" "$support/hooks" &&
+		write preserved "$common_dir/rr-cache/publisher-sentinel" &&
+		cp "$common_dir/rr-cache/publisher-sentinel" \
+			"$support/publisher-sentinel.before" &&
+		cat >"$support/hooks/post-checkout" <<-\EOF &&
+		#!/bin/sh
+		: >"$FAKE_HOOK_MARKER"
+		exit 89
+		EOF
+		chmod +x "$support/hooks/post-checkout" &&
+		cat >"$support/bin/unzip" <<-\EOF &&
+		#!/bin/sh
+		: >"$FAKE_ZIP_MARKER"
+		exit 89
+		EOF
+		cp "$support/bin/unzip" "$support/bin/zipinfo" &&
+		chmod +x "$support/bin/unzip" "$support/bin/zipinfo" &&
+		rm -f "$support/bundle-absent" \
+			"$support/bundle-imported" \
+			"$support/inherited-hook-ran" \
+			"$support/zip-tool-ran" &&
+		: >"$support/gh.log" &&
+		FAKE_DYNAMIC_CANDIDATE=1 \
+		FAKE_ASSERT_BUNDLE_IMPORT=1 \
+		FAKE_GIT_CONFIG_COUNT=1 \
+		FAKE_ZIP_MARKER="$support/zip-tool-ran" \
+			run_prepared "$support/good.zip" rebuild --local \
+			>"$support/local.out" 2>"$support/local.err" &&
+		local_candidate=$(git --git-dir=../publish-run.git \
+			rev-parse refs/heads/codex) &&
+		test "$local_candidate" != "$candidate" &&
+		test "$advanced_master" = "$(git --git-dir=../publish-run.git \
+			rev-parse refs/heads/master)" &&
+		test_grep "Local preparation session:" "$support/local.out" &&
+		test_grep "Published codex candidate $local_candidate from local preparation session" \
+			"$support/local.out" &&
+		! grep -F "Refresh codex run" "$support/local.out" &&
+		! grep -F "actions/workflows/codex.yml/dispatches" \
+			"$support/gh.log" &&
+		! grep -F "/artifacts" "$support/gh.log" &&
+		test_grep "actions/workflows/main.yml/runs?branch=codex-staging&event=push&head_sha=$local_candidate" \
+			"$support/gh.log" &&
+		test_grep "actions/runs/101/jobs" "$support/gh.log" &&
+		test "$local_candidate" = "$(cat "$support/bundle-absent")" &&
+		test_path_is_file "$support/bundle-imported" &&
+		test_path_is_missing "$support/inherited-hook-ran" &&
+		test_path_is_missing "$support/zip-tool-ran" &&
+		test_cmp "$support/publisher-sentinel.before" \
+			"$common_dir/rr-cache/publisher-sentinel" &&
+		local_session=$(sed -n \
+			"s/^Local preparation session: //p" \
+			"$support/local.out") &&
+		test -n "$local_session" &&
+		test_line_count = 1 "$support/bundle-absent" &&
+		for name in codex.bundle codex-candidate codex-inputs codex-updates
+		do
+			test_path_is_file "$local_session/$name" || return 1
+		done &&
+		test_path_is_missing "$local_session/codex-run" &&
+		while IFS="$(printf "\t")" read -r ref old new
+		do
+			test "$new" = "$(git --git-dir=../publish-run.git \
+				rev-parse "$ref")" || return 1
+		done <"$local_session/codex-updates" &&
+		test_must_fail git show-ref --verify \
+			refs/codex-output/candidate &&
+		test_must_fail git show-ref --verify refs/codex-output/meta &&
 		test_must_fail git --git-dir=../publish-run.git show-ref --verify \
 			refs/heads/codex-staging
 	)


### PR DESCRIPTION
## Summary

- Add `Meta/rebuild --local` to prepare topic rebases and the generated `codex` history in the publisher clone instead of the preparation Action.
- Run that preparation through the exact pinned controller in an isolated temporary repository with private Git configuration, rerere state, and temporary refs.
- Verify and import the frozen local bundle, then reuse the existing exact-SHA `codex-staging` CI gate and atomic exact-lease promotion.
- Keep the default Actions-backed `Meta/rebuild`, `Meta/publish <run-id>`, and preview-only `Meta/codex refresh` behavior intact.
- Document the modes and local trust boundary in `.github/CODEX.md`; the SCM Team Notion guide is updated separately.

## Why

The supported high-level rebuild path always delegated topic rewriting and aggregate assembly to Actions. The low-level local refresh could preview a candidate, but publishing it with the raw staging and promotion commands would skip the staging-CI waiter. That left no supported way to reproduce the full preparation locally while retaining the same publication gates.

`--local` skips only the preparation Action. It still uses GitHub's current `openai/git:master`, pushes the exact candidate to `codex-staging`, waits for a fresh `main.yml` run for that SHA, and publishes all topic, `meta`, and `codex` updates atomically with exact leases.

## Safety and validation

- Materialize and hash-check the helper from the pinned `Meta/HEAD`.
- Isolate local hooks, config, rerere state, and temporary refs from the publisher repository.
- Validate the complete remote input snapshot before importing generated objects.
- Check the allowed bundle heads and generated integration history before staging and again after CI.
- Preserve the existing human-authenticated final push and protected-ref leases.
- Exercise the new path with remote-only `master` advancement, hostile local hook/config/rerere fixtures, disabled ZIP tools, bundle-import checks, exact staging CI, and atomic publication.

Validation:

- `t/t9905-codex-branch.sh`: 42/42 passed
- `sh -n .github/workflows/codex-branch.sh`
- `dash -n .github/workflows/codex-branch.sh`
- `git diff --check`

No live rebuild or protected-ref publication was performed by this patch.

<!-- codex-thread: 019fb902-4685-73c3-866c-26d0c59bc3de -->