### PR TITLE
ci: extend Codex merge queue timeout

### DIFF
--- a/.github/rulesets/codex-branch.json
+++ b/.github/rulesets/codex-branch.json
@@ -34,7 +34,7 @@
     {
       "type": "merge_queue",
       "parameters": {
-        "check_response_timeout_minutes": 30,
+        "check_response_timeout_minutes": 60,
         "grouping_strategy": "ALLGREEN",
         "max_entries_to_build": 1,
         "max_entries_to_merge": 1,


### PR DESCRIPTION
Use a 60-minute merge-queue status-check timeout so the slow CI tail has room to report a conclusion without weakening the singleton admission queue.