### PR TITLE
maintenance: handle geometric repack tasks with promisor pack(s)

### DIFF
--- a/builtin/gc.c
+++ b/builtin/gc.c
@@ -1649,7 +1649,7 @@ static int geometric_repack_auto_condition(struct gc_config *cfg UNUSED)
 	 * When we'd merge at least two packs with one another we always
 	 * perform the repack.
 	 */
-	if (geometry.split) {
+	if (geometry.split || geometry.promisor_split) {
 		ret = 1;
 		goto out;
 	}

--- a/builtin/gc.c
+++ b/builtin/gc.c
@@ -1593,7 +1593,8 @@ static int maintenance_task_geometric_repack(struct maintenance_run_opts *opts,
 	child.odb_to_close = the_repository->objects;
 
 	strvec_pushl(&child.args, "repack", "-d", "-l", NULL);
-	if (geometry.split < geometry.pack_nr)
+	if (geometry.split < geometry.pack_nr ||
+	    geometry.promisor_split < geometry.promisor_pack_nr)
 		strvec_pushf(&child.args, "--geometric=%d",
 			     geometry.split_factor);
 	else

--- a/t/t5331-pack-objects-stdin.sh
+++ b/t/t5331-pack-objects-stdin.sh
@@ -368,7 +368,8 @@ test_expect_success '--stdin-packs does not perform backfill fetch' '
 	git -C remote config set --local uploadpack.allowfilter 1 &&
 	git -C remote config set --local uploadpack.allowanysha1inwant 1 &&
 
-	git clone --filter=tree:0 "file://$(pwd)/remote" client &&
+	git -c maintenance.auto=false clone --filter=tree:0 \
+		"file://$(pwd)/remote" client &&
 	(
 		cd client &&
 		ls .git/objects/pack/*.promisor | sed "s|.*/||; s/\.promisor$/.pack/" >packs &&

--- a/t/t7900-maintenance.sh
+++ b/t/t7900-maintenance.sh
@@ -659,6 +659,51 @@ test_expect_success 'geometric repacking task' '
 	)
 '
 
+objdir=.git/objects
+packdir=$objdir/pack
+
+pack_promisor () {
+	p="$(echo "$@" | git pack-objects --revs $packdir/pack)" &&
+	touch "$packdir/pack-$p.promisor" &&
+	echo "$p"
+}
+
+test_expect_success 'geometric repacking task handles promisor packs' '
+	test_when_finished "rm -rf repo" &&
+	git init repo &&
+	(
+		cd repo &&
+		git config set maintenance.auto false &&
+		git remote add promisor garbage &&
+		git config set remote.promisor.promisor true &&
+
+		for n in $(test_seq 6)
+		do
+			test_commit $n || return 1
+		done &&
+
+		A="$(pack_promisor 1)" &&
+		B="$(pack_promisor 1..2)" &&
+		C="$(pack_promisor 2..6)" &&
+		git prune-packed &&
+
+		ls $packdir/pack-*.promisor | sort >promisors.before &&
+		GIT_TRACE2_EVENT="$(pwd)/trace2.txt" \
+			git maintenance run --quiet --task=geometric-repack &&
+		ls $packdir/pack-*.promisor | sort >promisors.after &&
+
+		test_subcommand git repack -d -l --geometric=2 \
+			--quiet --write-midx <trace2.txt &&
+
+		test_line_count = 2 promisors.after &&
+
+		printf "$packdir/pack-%s.promisor\n" "$A" "$B" | sort >expect &&
+		comm -23 promisors.before promisors.after >actual &&
+
+		test_cmp expect actual
+	)
+'
+
 test_geometric_repack_needed () {
 	NEEDED="$1"
 	GEOMETRIC_CONFIG="$2" &&

--- a/t/t7900-maintenance.sh
+++ b/t/t7900-maintenance.sh
@@ -759,6 +759,29 @@ test_expect_success 'geometric repacking with --auto' '
 	)
 '
 
+test_expect_success 'geometric repacking with --auto handles promisor packs' '
+	test_when_finished "rm -rf repo" &&
+	git init repo &&
+	(
+		cd repo &&
+		git config set maintenance.auto false &&
+		git remote add promisor garbage &&
+		git config set remote.promisor.promisor true &&
+
+		for n in $(test_seq 6)
+		do
+			test_commit $n || return 1
+		done &&
+
+		pack_promisor 1 >/dev/null &&
+		pack_promisor 1..2 >/dev/null &&
+		pack_promisor 2..6 >/dev/null &&
+		git prune-packed &&
+
+		test_geometric_repack_needed true auto=9000
+	)
+'
+
 test_expect_success 'geometric repacking honors configured split factor' '
 	test_when_finished "rm -rf repo" &&
 	git init repo &&


### PR DESCRIPTION
The geometric-repack maintenance task predates support for keeping
promisor packs in their own geometric progression. After that support
was added in dcc9c7ef47 (builtin/repack: handle promisor packs with
geometric repacking, 2026-01-05), the maintenance task still made two
decisions from the ordinary-pack progression alone:

 - whether an explicit run should use `--geometric` or its
   all-into-one fallback; and

 - whether `--auto` sees enough work to run the task at all.

That can make partial clones rewrite more than necessary. If the
ordinary packs would all be rolled up, the task can choose the
all-into-one path even when the promisor progression would leave a
large pack alone. Likewise, an all-promisor repository can have a
promisor rollup ready while `--auto` sees neither an ordinary split
nor enough loose objects and skips the task.

The first patch makes the repack-mode choice consider both
progressions. It keeps the all-into-one fallback only when neither
progression leaves a pack above its split, so the fallback does not
rewrite packs that geometric repack would have kept.

The second patch makes the `--auto` condition consider
`geometry.promisor_split` alongside `geometry.split`. A non-zero split
on either side means that geometric repack can combine at least two
packs.

Both tests build three promisor packs whose object counts cause the two
smaller packs to roll up while leaving the large pack intact. The
`--auto` test uses a high loose-object threshold, so the promisor split
is the only reason the task runs.

Thanks in advance for your review!