### PR TITLE
ci: make Codex promotion retries idempotent

### DIFF
--- a/.github/workflows/codex-branch.sh
+++ b/.github/workflows/codex-branch.sh
@@ -4199,6 +4199,41 @@ remote_head_oid () {
 		awk -v ref="$ref" '$2 == ref { print $1; exit }'
 }
 
+published_updates_match () (
+	remote=$1
+	updates=$2
+	staging=$3
+	unstable_staging=$(staging_ref codex-unstable-staging)
+	refs=$tmp_dir/published-update-refs
+
+	set -- git ls-remote --refs "$remote" "$staging" "$unstable_staging"
+	while IFS="$tab" read -r ref old new
+	do
+		set -- "$@" "$ref"
+	done <"$updates"
+	"$@" >"$refs" || return 1
+
+	for ref in "$staging" "$unstable_staging"
+	do
+		if awk -v ref="$ref" '$2 == ref { found=1 }
+			END { exit !found }' "$refs"
+		then
+			return 1
+		fi
+	done
+	while IFS="$tab" read -r ref old new
+	do
+		current=$(awk -v ref="$ref" '$2 == ref { print $1; exit }' \
+			"$refs")
+		if is_null_oid "$new"
+		then
+			test -z "$current" || return 1
+		else
+			test "$current" = "$new" || return 1
+		fi
+	done <"$updates"
+)
+
 stage_candidate () {
 	remote=origin
 	staging=codex-staging
@@ -4322,6 +4357,12 @@ promote () {
 	candidate=$(awk -F '\t' '$1 == "refs/heads/codex" { print $3 }' \
 		"$updates")
 	test -n "$candidate" || die "update manifest has no codex candidate"
+	ref=$(staging_ref "$staging")
+	if published_updates_match "$remote" "$updates" "$ref"
+	then
+		say "Codex candidate $candidate was already published; all output refs match and staging is absent."
+		return 0
+	fi
 	printf '%s\n' "$candidate" >"$tmp_dir/promote-result" ||
 		die "could not prepare promotion verification"
 	set -- --inputs "$inputs" --updates "$updates" \

--- a/t/t9905-codex-branch.sh
+++ b/t/t9905-codex-branch.sh
@@ -5301,7 +5301,48 @@ test_expect_success 'enabling unstable creates a strict empty sentinel' '
 			--inputs inputs --updates updates --result result &&
 		git bundle verify candidate.bundle &&
 		git bundle list-heads candidate.bundle >bundle-heads &&
-		test_grep "refs/codex-output/unstable" bundle-heads
+		test_grep "refs/codex-output/unstable" bundle-heads &&
+		sh "$codex_branch" stage --remote origin \
+			--staging codex-staging \
+			--inputs inputs --updates updates &&
+		sh "$codex_branch" stage --remote origin \
+			--staging codex-unstable-staging \
+			--inputs inputs --updates updates &&
+		GIT_TRACE=1 sh "$codex_branch" promote --remote origin \
+			--staging codex-staging \
+			--inputs inputs --updates updates \
+			>promote.out 2>promote.trace &&
+		test_grep "push --atomic --porcelain" promote.trace &&
+		test "$stable" = \
+			"$(git --git-dir=../enable-unstable.git \
+				rev-parse refs/heads/codex)" &&
+		test "$unstable" = \
+			"$(git --git-dir=../enable-unstable.git \
+				rev-parse refs/heads/codex-unstable)" &&
+		test "$meta" = \
+			"$(git --git-dir=../enable-unstable.git \
+				rev-parse refs/heads/meta)" &&
+		test_must_fail git --git-dir=../enable-unstable.git \
+			show-ref --verify refs/heads/codex-staging &&
+		test_must_fail git --git-dir=../enable-unstable.git \
+			show-ref --verify refs/heads/codex-unstable-staging &&
+		snapshot_refs ../enable-unstable.git >published &&
+		GIT_TRACE=1 sh "$codex_branch" promote --remote origin \
+			--staging codex-staging \
+			--inputs inputs --updates updates \
+			>retry.out 2>retry.trace &&
+		! grep -F "push --atomic" retry.trace &&
+		snapshot_refs ../enable-unstable.git >retried &&
+		test_cmp published retried &&
+		git --git-dir=../enable-unstable.git update-ref \
+			refs/heads/codex-unstable "$stable" "$unstable" &&
+		snapshot_refs ../enable-unstable.git >partial &&
+		test_expect_code 1 sh "$codex_branch" promote --remote origin \
+			--staging codex-staging \
+			--inputs inputs --updates updates \
+			>partial.out 2>partial.err &&
+		snapshot_refs ../enable-unstable.git >after-partial &&
+		test_cmp partial after-partial
 	)
 '
 


### PR DESCRIPTION
An atomic Codex promotion can finish on GitHub before the local
publisher observes its success. Retrying the same frozen preview
bootstrap manifest then revalidated stale v1 inputs and reported the
newly published `codex-unstable` output as unmanaged.

Recognize only the exact fully published update manifest with both
staging refs absent, and return success without pushing again. Partial
or diverged ref states still use the existing fail-closed validation.

Validation:

- focused preview enable/retry/divergence regression
- adjacent preview lifecycle and dual-promotion cases `#69-77,#93`
- `git show --check`

<!-- codex-thread: 019fcda8-015a-78c2-ada9-ddb69eff6828 -->
