### PR TITLE
ci: admit the Codex unstable release guard

### DIFF
--- a/.github/CODEX.md
+++ b/.github/CODEX.md
@@ -2,8 +2,9 @@
 
 `master` stays equivalent to upstream. `codex` is the production integration
 branch distributed with Codex. When enabled, `codex-unstable` starts at that
-exact production commit and adds reviewed preview topics; it never publishes a
-production release. The orphan `meta` branch contains the controller, reusable
+exact production commit and adds reviewed preview topics. Each lane may publish
+an OpenAI Git prerelease, but only from the exact output recorded for that lane
+by the controller. The orphan `meta` branch contains the controller, reusable
 workflows, tests, documentation, and ruleset recipes. Never merge `meta` into
 `master`, `codex`, or `codex-unstable`.
 
@@ -85,6 +86,9 @@ exactly the same contents.
 Enabling and disabling are explicit, local-only operations; dispatching the
 ordinary GitHub Action cannot change whether the lane exists. Once enabled,
 both `Meta/rebuild` and `Meta/rebuild --local` maintain the preview lane.
+When the dual-lane release workflow is active, enabling the lane publishes a
+preview prerelease for the empty sentinel. Its tree matches production, but its
+commit and version are distinct. Deleting the lane publishes nothing.
 
 ## Add a preview topic
 
@@ -109,6 +113,10 @@ queue. Production and preview admission are tracked independently; a single
 controller run can consume one pending merge from each lane. An unreviewed
 preview branch, including a whole preexisting stack of matching branches,
 remains excluded until its own pull request is merged.
+
+The pending preview merge also fails the release-publication check. Its build
+matrix starts only after the controller records and atomically publishes that
+exact `codex-unstable` output.
 
 Production topics may never depend on preview topics. Root preview topics are
 based on `codex`; their prerequisites, when present, must be other enrolled
@@ -417,16 +425,19 @@ revalidates the snapshot and atomically updates `meta`, every enrolled topic,
 deleting both staging refs. A failed preview build cannot publish production;
 a failed production build cannot publish preview.
 
-Every push to `codex` starts the inexpensive release-publication check. The
-expensive build and release jobs proceed only when the triggering SHA is the
-output recorded on the current `meta` branch. A reviewed pull-request merge
-therefore publishes no release; the controller's atomic `codex`/`meta`
-promotion does. The check does not require that SHA to remain the live
-`codex` tip, so a later pending merge cannot suppress a release that the
-controller already triggered. A canonical no-op reuses the existing tips, and
-staging never releases. `codex-unstable` also never releases: the release
-workflow listens only for pushes to `codex`. Ordinary CI may reuse its own
-earlier successful result when the commit or tree is identical.
+Every push to `codex` or `codex-unstable` starts the inexpensive
+release-publication check. The job skips branch-deletion events, maps the exact
+event ref to either `codex.output-tip` or `codex-unstable.output-tip`, and reads
+that value from the current `meta` branch. The expensive build and release jobs
+proceed only when the triggering SHA matches the selected lane's recorded
+output. A reviewed pull-request merge therefore publishes no release; the
+controller's atomic output/state promotion does. The check does not require
+that SHA to remain the live lane tip, so a later pending merge cannot suppress
+a release that the controller already triggered. A canonical no-op reuses the
+existing tips, and neither staging branch releases. An atomic promotion that
+advances both outputs intentionally starts one release matrix per lane.
+Ordinary CI may reuse its own earlier successful result when the commit or tree
+is identical.
 
 Until the final push, `meta`, both generated outputs, and all topic refs remain
 unchanged. A CI, validation, lease, or promotion failure after staging leaves
@@ -565,10 +576,21 @@ admission trampoline. A directly merged topic pull request may change neither
 that trampoline nor `.github/workflows/codex-release.yml`; otherwise it could
 bypass the release guard before the controller runs. Update the enrolled
 automation and release topics through a normal controller rebuild instead.
-The release trigger remains exactly a push to `codex`, and its workflow may
-not mention an environment or the `secrets` context. These checks are not a
-sandbox for untrusted build code: review the release topic and its reusable
-workflows. The controller rejects other topic-controlled workflow changes.
+During migration, the reviewed release trigger may remain exactly `codex`.
+After the canonical topic upgrade, it contains exactly `codex` and
+`codex-unstable`, skips deletion events, and selects the recorded output from
+the exact event ref. Its workflow may not mention an environment or the
+`secrets` context. The controller permits the existing production-only
+publication job to make that one exact upgrade; afterward it again preserves
+the published job byte for byte. These checks are not a sandbox for untrusted
+build code: review the release topic, its reusable workflows, and the preview
+source it builds. The controller rejects other topic-controlled workflow
+changes.
+
+Once the dual-lane guard is published, the controller deliberately rejects a
+return to the production-only trigger. Disabling an empty preview lane stops
+future preview releases and its branch-deletion event publishes nothing, but
+changing the release trigger again requires a controller change first.
 
 Rebased topic commits preserve their original authors. Generated commits and
 rebase committers use
@@ -623,14 +645,26 @@ Deploy these changes in order:
 
 1. Merge the controller, lane-aware trusted admission workflow, and ruleset
    recipe into `meta` without creating a merge commit there.
-2. Update the already-enrolled automation topic, then run
+2. Verify that the already-enrolled automation topic contains the canonical
+   two-lane trampoline, and update the release topic. The release workflow must
+   add the exact `codex-unstable` trigger, skip deleted refs, and map
+   `refs/heads/codex` and `refs/heads/codex-unstable` to their respective
+   recorded output keys.
+3. Run
    `Meta/rebuild --local` once to publish the exact two-lane trampoline while
-   preserving the production release guard and stable merge-queue settings.
-3. Update the existing **Protect generated unstable Codex branch** ruleset
+   upgrading the release guard and preserving stable merge-queue settings.
+4. Update the existing **Protect generated unstable Codex branch** ruleset
    from its recipe, including its separate required check and serial queue.
-4. Run `Meta/rebuild --local --enable-unstable` to create the protected,
-   strictly-ahead preview target without enrolling any preexisting topic.
-5. Open reviewed `*-unstable` pull requests against `codex-unstable`, merge
+5. If `codex.config` is still version 1 and `codex-unstable` does not exist,
+   run `Meta/rebuild --local --enable-unstable` to create the protected,
+   strictly-ahead preview target without enrolling any preexisting topic. If
+   version 2 state and the preview branch already exist, skip this step and use
+   the ordinary rebuild from step 3; `--enable-unstable` must not be repeated.
+6. Open reviewed `*-unstable` pull requests against `codex-unstable`, merge
    them through its queue, and run the controller to publish each generation.
 
-Do not merge a preview pull request until all four setup steps are complete.
+Before handing a preview release to a consumer, verify that the production and
+preview release checks each selected their lane-specific SHA from the promoted
+`codex.config`, and that each prerelease targets that exact commit. Do not merge
+a preview pull request until the controller and topic updates, rebuild,
+ruleset update, and any required lane creation are complete.

--- a/.github/workflows/codex-admission.yml
+++ b/.github/workflows/codex-admission.yml
@@ -307,9 +307,64 @@ jobs:
           grep -Fxq \
             "    if: needs.publication.outputs.published == 'true'" \
             <<<"$release" &&
-          grep -Fq 'git/ref/heads/meta' <<<"$release" &&
-          grep -Fq 'codex.output-tip' <<<"$release" ||
-            die 'published codex has no intact controller-only release guard'
+          grep -Fq 'git/ref/heads/meta' <<<"$release" ||
+            die 'published Codex lane has no intact controller-only release guard'
+          release_trigger=$(awk '
+            $0 == "on:" && !found {
+              found = 1
+              active = 1
+            }
+            active && $0 == "" { exit }
+            active {
+              if (seen && $0 !~ /^[[:space:]]/) exit
+              print
+              seen = 1
+            }
+            END { if (!found) exit 1 }
+          ' <<<"$release") ||
+            die 'published Codex lane has no intact controller-only release guard'
+          stable_trigger=$(printf '%s\n' \
+            'on:' '  push:' '    branches:' '      - codex')
+          dual_trigger=$(printf '%s\n' \
+            'on:' '  push:' '    branches:' '      - codex' \
+            '      - codex-unstable')
+          if test "$release_trigger" = "$stable_trigger" &&
+             grep -Fq -- '--get codex.output-tip)' <<<"$release"
+          then
+            : # Accept the production-only guard during the release migration.
+          elif test "$release_trigger" = "$dual_trigger"
+          then
+            release_ref_case=$(awk '
+              $0 == "          case \"$GITHUB_REF\" in" && !found {
+                found = 1
+                active = 1
+              }
+              active { print }
+              active && $0 == "          esac" { complete = 1; exit }
+              END { if (!found || !complete) exit 1 }
+            ' <<<"$release") ||
+              die 'published Codex lane has no intact controller-only release guard'
+            expected_ref_case=$(printf '%s\n' \
+              '          case "$GITHUB_REF" in' \
+              '          refs/heads/codex)' \
+              '            output_key=codex.output-tip' \
+              '            ;;' \
+              '          refs/heads/codex-unstable)' \
+              '            output_key=codex-unstable.output-tip' \
+              '            ;;' \
+              '          *)' \
+              "            printf 'unexpected release ref: %s\\n' \"\$GITHUB_REF\" >&2" \
+              '            exit 1' \
+              '            ;;' \
+              '          esac')
+            test "$release_ref_case" = "$expected_ref_case" &&
+            grep -Fxq '    if: github.event.deleted == false' \
+              <<<"$release" &&
+            grep -Fq -- '--get "$output_key")' <<<"$release" ||
+              die 'published Codex lane has no intact controller-only release guard'
+          else
+            die 'published Codex lane has no intact controller-only release guard'
+          fi
 
           topics=$(api --paginate \
             "repos/$GITHUB_REPOSITORY/branches?per_page=100" \

--- a/.github/workflows/codex-branch.sh
+++ b/.github/workflows/codex-branch.sh
@@ -421,14 +421,10 @@ automation_workflow_matches () {
 		"$tmp_dir/actual-automation.yml"
 }
 
-release_workflow_is_codex_only () {
+extract_release_trigger () {
 	head_oid=$1
+	output=$2
 	make_tmp_dir
-	if ! git cat-file -e \
-		"$head_oid:.github/workflows/codex-release.yml" 2>/dev/null
-	then
-		return 0
-	fi
 	git show "$head_oid:.github/workflows/codex-release.yml" \
 		>"$tmp_dir/codex-release.yml" 2>/dev/null || return 1
 	test "$(grep -c '^on:$' "$tmp_dir/codex-release.yml")" = 1 || return 1
@@ -437,13 +433,20 @@ release_workflow_is_codex_only () {
 			found = 1
 			in_trigger = 1
 		}
-		in_trigger && $0 != "" {
+		in_trigger && $0 == "" { exit }
+		in_trigger {
 			if (seen && $0 !~ /^[[:space:]]/) exit
 			print
 			seen = 1
 		}
 		END { if (!found) exit 1 }
-	' "$tmp_dir/codex-release.yml" >"$tmp_dir/release-trigger" || return 1
+	' "$tmp_dir/codex-release.yml" >"$output"
+}
+
+release_workflow_has_codex_trigger () {
+	head_oid=$1
+	make_tmp_dir
+	extract_release_trigger "$head_oid" "$tmp_dir/release-trigger" || return 1
 	cat >"$tmp_dir/expected-release-trigger" <<-'EOF'
 	on:
 	  push:
@@ -451,7 +454,39 @@ release_workflow_is_codex_only () {
 	      - codex
 	EOF
 	cmp -s "$tmp_dir/expected-release-trigger" \
-		"$tmp_dir/release-trigger" || return 1
+		"$tmp_dir/release-trigger"
+}
+
+release_workflow_has_dual_trigger () {
+	head_oid=$1
+	make_tmp_dir
+	extract_release_trigger "$head_oid" "$tmp_dir/release-trigger" || return 1
+	cat >"$tmp_dir/expected-release-trigger" <<-'EOF'
+	on:
+	  push:
+	    branches:
+	      - codex
+	      - codex-unstable
+	EOF
+	cmp -s "$tmp_dir/expected-release-trigger" \
+		"$tmp_dir/release-trigger"
+}
+
+release_workflow_is_reviewed () {
+	head_oid=$1
+	make_tmp_dir
+	if ! git cat-file -e \
+		"$head_oid:.github/workflows/codex-release.yml" 2>/dev/null
+	then
+		return 0
+	fi
+	if ! release_workflow_has_codex_trigger "$head_oid" &&
+		! release_workflow_has_dual_trigger "$head_oid"
+	then
+		return 1
+	fi
+	git show "$head_oid:.github/workflows/codex-release.yml" \
+		>"$tmp_dir/codex-release.yml" 2>/dev/null || return 1
 	! grep -E \
 		'CODEX_BRANCH_TOKEN|CODEX_BRANCH_MANAGER_TOKEN|CODEX_DEPLOY_KEY|codex-publish|ci-token-gh-installation-token-codex-branch-manager|secret-broker-github-action' \
 		"$tmp_dir/codex-release.yml" >/dev/null &&
@@ -475,6 +510,64 @@ extract_release_job () (
 	' "$workflow" >"$output"
 )
 
+upgrade_release_publication_job () {
+	old_job=$1
+	output=$2
+	test "$(grep -F -x -c '    runs-on: ubuntu-24.04' "$old_job")" = 1 ||
+		return 1
+	test "$(grep -F -x -c '          set -euo pipefail' "$old_job")" = 1 ||
+		return 1
+	test "$(grep -F -x -c \
+		'              --get codex.output-tip)' "$old_job")" = 1 ||
+		return 1
+	awk '
+		$0 == "    runs-on: ubuntu-24.04" {
+			print
+			print "    if: github.event.deleted == false"
+			next
+		}
+		$0 == "          set -euo pipefail" {
+			print
+			print "          case \"$GITHUB_REF\" in"
+			print "          refs/heads/codex)"
+			print "            output_key=codex.output-tip"
+			print "            ;;"
+			print "          refs/heads/codex-unstable)"
+			print "            output_key=codex-unstable.output-tip"
+			print "            ;;"
+			print "          *)"
+			print "            printf \047unexpected release ref: %s\\n\047 \"$GITHUB_REF\" >&2"
+			print "            exit 1"
+			print "            ;;"
+			print "          esac"
+			next
+		}
+		$0 == "              --get codex.output-tip)" {
+			print "              --get \"$output_key\")"
+			next
+		}
+		{ print }
+	' "$old_job" >"$output"
+}
+
+release_publication_job_is_dual () {
+	job=$1
+	test "$(grep -F -x -c \
+		'    if: github.event.deleted == false' "$job")" = 1 &&
+	test "$(grep -F -x -c \
+		'          case "$GITHUB_REF" in' "$job")" = 1 &&
+	test "$(grep -F -x -c \
+		'          refs/heads/codex)' "$job")" = 1 &&
+	test "$(grep -F -x -c \
+		'            output_key=codex.output-tip' "$job")" = 1 &&
+	test "$(grep -F -x -c \
+		'          refs/heads/codex-unstable)' "$job")" = 1 &&
+	test "$(grep -F -x -c \
+		'            output_key=codex-unstable.output-tip' "$job")" = 1 &&
+	test "$(grep -F -x -c \
+		'              --get "$output_key")' "$job")" = 1
+}
+
 release_publication_controls_preserved () (
 	published=$1
 	candidate=$2
@@ -496,8 +589,28 @@ release_publication_controls_preserved () (
 		"$tmp_dir/published-publication" || return 1
 	extract_release_job "$new_workflow" publication \
 		"$tmp_dir/candidate-publication" || return 1
-	cmp -s "$tmp_dir/published-publication" \
-		"$tmp_dir/candidate-publication" || return 1
+	if release_workflow_has_dual_trigger "$published"
+	then
+		release_workflow_has_dual_trigger "$candidate" || return 1
+	fi
+	if release_workflow_has_dual_trigger "$candidate"
+	then
+		if ! cmp -s "$tmp_dir/published-publication" \
+			"$tmp_dir/candidate-publication"
+		then
+			release_workflow_has_codex_trigger "$published" || return 1
+			upgrade_release_publication_job \
+				"$tmp_dir/published-publication" \
+				"$tmp_dir/expected-publication" || return 1
+			cmp -s "$tmp_dir/expected-publication" \
+				"$tmp_dir/candidate-publication" || return 1
+		fi
+		release_publication_job_is_dual \
+			"$tmp_dir/candidate-publication" || return 1
+	else
+		cmp -s "$tmp_dir/published-publication" \
+			"$tmp_dir/candidate-publication" || return 1
+	fi
 	extract_release_job "$old_workflow" version \
 		"$tmp_dir/published-version" || return 1
 	extract_release_job "$new_workflow" version \
@@ -4359,8 +4472,8 @@ verify_unstable_control_paths () (
 		':(glob).github/workflows/*.yml' \
 		':(glob).github/workflows/*.yaml' ||
 		die "codex-unstable changes a GitHub Actions workflow"
-	release_workflow_is_codex_only "$unstable_candidate" ||
-		die "codex-unstable changes the production-only release trigger"
+	release_workflow_is_reviewed "$unstable_candidate" ||
+		die "codex-unstable changes the reviewed release trigger"
 	while IFS="$tab" read -r name old prerequisite old_base prerequisite_tip
 	do
 		is_unstable_topic_name "$name" ||
@@ -4426,8 +4539,8 @@ verify_control_paths () {
 		die "candidate changes a protected controller or CI file"
 	automation_workflow_matches "$candidate" ||
 		die "candidate does not contain the canonical Refresh codex workflow"
-	release_workflow_is_codex_only "$candidate" ||
-		die "candidate release workflow must run only for pushes to codex and must not obtain promotion credentials"
+	release_workflow_is_reviewed "$candidate" ||
+		die "candidate release workflow must use the reviewed Codex branch triggers and must not obtain promotion credentials"
 
 	automation_count=0
 	while IFS="$tab" read -r ref old new

--- a/t/t9905-codex-branch.sh
+++ b/t/t9905-codex-branch.sh
@@ -178,6 +178,21 @@ write_release_workflow () {
 	EOF
 }
 
+write_dual_release_workflow () {
+	cat >"$1" <<-'EOF'
+	name: Codex Git release
+
+	on:
+	  push:
+	    branches:
+	      - codex
+	      - codex-unstable
+
+	permissions:
+	  contents: read
+	EOF
+}
+
 write_guarded_release_workflow () {
 	write_release_workflow codex "$1" &&
 	cat >>"$1" <<-'EOF'
@@ -189,8 +204,86 @@ write_guarded_release_workflow () {
 	    outputs:
 	      published: ${{ steps.verify.outputs.published }}
 	    steps:
-	      - id: verify
-	        run: echo publication
+	      - name: Check the published controller output
+	        id: verify
+	        shell: bash
+	        env:
+	          GH_TOKEN: ${{ github.token }}
+	        run: |
+	          set -euo pipefail
+
+	          meta=$(gh api \
+	            "repos/$GITHUB_REPOSITORY/git/ref/heads/meta" \
+	            --jq '.object.sha')
+	          recorded=$(gh api \
+	            "repos/$GITHUB_REPOSITORY/contents/codex.config?ref=$meta" \
+	            -H 'Accept: application/vnd.github.raw+json' |
+	            git config --no-includes --file /dev/stdin \
+	              --get codex.output-tip)
+
+	          if test "$GITHUB_SHA" = "$recorded"
+	          then
+	            printf 'published=true\n' >>"$GITHUB_OUTPUT"
+	          else
+	            printf 'published=false\n' >>"$GITHUB_OUTPUT"
+	          fi
+
+	  version:
+	    needs: publication
+	    if: needs.publication.outputs.published == 'true'
+	    runs-on: ubuntu-24.04
+	    steps:
+	      - run: echo version
+	EOF
+}
+
+write_dual_guarded_release_workflow () {
+	write_dual_release_workflow "$1" &&
+	cat >>"$1" <<-'EOF'
+
+	jobs:
+	  publication:
+	    name: Verify controller publication
+	    runs-on: ubuntu-24.04
+	    if: github.event.deleted == false
+	    outputs:
+	      published: ${{ steps.verify.outputs.published }}
+	    steps:
+	      - name: Check the published controller output
+	        id: verify
+	        shell: bash
+	        env:
+	          GH_TOKEN: ${{ github.token }}
+	        run: |
+	          set -euo pipefail
+	          case "$GITHUB_REF" in
+	          refs/heads/codex)
+	            output_key=codex.output-tip
+	            ;;
+	          refs/heads/codex-unstable)
+	            output_key=codex-unstable.output-tip
+	            ;;
+	          *)
+	            printf 'unexpected release ref: %s\n' "$GITHUB_REF" >&2
+	            exit 1
+	            ;;
+	          esac
+
+	          meta=$(gh api \
+	            "repos/$GITHUB_REPOSITORY/git/ref/heads/meta" \
+	            --jq '.object.sha')
+	          recorded=$(gh api \
+	            "repos/$GITHUB_REPOSITORY/contents/codex.config?ref=$meta" \
+	            -H 'Accept: application/vnd.github.raw+json' |
+	            git config --no-includes --file /dev/stdin \
+	              --get "$output_key")
+
+	          if test "$GITHUB_SHA" = "$recorded"
+	          then
+	            printf 'published=true\n' >>"$GITHUB_OUTPUT"
+	          else
+	            printf 'published=false\n' >>"$GITHUB_OUTPUT"
+	          fi
 
 	  version:
 	    needs: publication
@@ -406,14 +499,71 @@ install_admission_gate_gh () {
 	repos/openai/git/contents/.github/workflows/codex-release.yml\?ref=*)
 		if test -n "$raw"
 		then
-			cat <<-'EOF_RELEASE'
-			  publication:
-			    published: ${{ steps.verify.outputs.published }}
-			    needs: publication
-			    if: needs.publication.outputs.published == 'true'
-			    git/ref/heads/meta
-			    codex.output-tip
-			EOF_RELEASE
+			if test "${FAKE_GATE_MODE:-}" = legacy-release
+			then
+				cat <<-'EOF_RELEASE'
+				on:
+				  push:
+				    branches:
+				      - codex
+
+				  publication:
+				    published: ${{ steps.verify.outputs.published }}
+				    needs: publication
+				    if: needs.publication.outputs.published == 'true'
+				    git/ref/heads/meta
+				              --get codex.output-tip)
+				EOF_RELEASE
+			else
+				cat <<-'EOF_RELEASE'
+				on:
+				  push:
+				    branches:
+				      - codex
+				      - codex-unstable
+
+				  publication:
+				    published: ${{ steps.verify.outputs.published }}
+				    needs: publication
+				    if: needs.publication.outputs.published == 'true'
+				    git/ref/heads/meta
+				EOF_RELEASE
+				if test "${FAKE_GATE_MODE:-}" = dual-release-legacy-guard
+				then
+					printf '%s\n' \
+						'              --get codex.output-tip)'
+				else
+					if test "${FAKE_GATE_MODE:-}" != dual-release-no-delete
+					then
+						printf '%s\n' \
+							'    if: github.event.deleted == false'
+					fi
+					cat <<-'EOF_RELEASE'
+				          case "$GITHUB_REF" in
+				          refs/heads/codex)
+				            output_key=codex.output-tip
+				            ;;
+				          refs/heads/codex-unstable)
+				EOF_RELEASE
+					if test "${FAKE_GATE_MODE:-}" = dual-release-wrong-key
+					then
+						printf '%s\n' \
+							'            output_key=codex.output-tip'
+					else
+						printf '%s\n' \
+							'            output_key=codex-unstable.output-tip'
+					fi
+					cat <<-'EOF_RELEASE'
+				            ;;
+				          *)
+				            printf 'unexpected release ref: %s\n' "$GITHUB_REF" >&2
+				            exit 1
+				            ;;
+				          esac
+				              --get "$output_key")
+				EOF_RELEASE
+				fi
+			fi
 		else
 			printf '%s\n' trusted-release
 		fi
@@ -559,6 +709,51 @@ run_admission_gate () {
 		FAKE_GATE_SHARED="$shared" FAKE_GATE_FIRST="$first" \
 		FAKE_GATE_MERGE="$merge" FAKE_GATE_BRANCH="$branch" \
 		bash "$TRASH_DIRECTORY/admission-gate.sh"
+}
+
+install_release_gate_gh () {
+	directory=$1 &&
+	mkdir -p "$directory" &&
+	cat >"$directory/gh" <<-'EOF' &&
+	#!/bin/sh
+
+	set -eu
+	test "$1" = api
+	endpoint=$2
+	case "$endpoint" in
+	repos/openai/git/git/ref/heads/meta)
+		test "${FAKE_RELEASE_MODE:-}" != api-failure
+		printf '%s\n' meta-oid
+		;;
+	repos/openai/git/contents/codex.config\?ref=*)
+		printf '[codex]\n\toutput-tip = %s\n' "$FAKE_RELEASE_STABLE"
+		if test "${FAKE_RELEASE_MODE:-}" != missing-unstable
+		then
+			printf '[codex-unstable]\n\toutput-tip = %s\n' \
+				"$FAKE_RELEASE_UNSTABLE"
+		fi
+		;;
+	*) exit 2 ;;
+	esac
+	EOF
+	chmod +x "$directory/gh"
+}
+
+run_release_gate () {
+	mode=$1 &&
+	ref=$2 &&
+	sha=$3 &&
+	output=$4 &&
+	: >"$output" &&
+	env PATH="$TRASH_DIRECTORY/release-gate-bin:$PATH" \
+		FAKE_RELEASE_MODE="$mode" \
+		FAKE_RELEASE_STABLE=stable-oid \
+		FAKE_RELEASE_UNSTABLE=unstable-oid \
+		GITHUB_OUTPUT="$output" \
+		GITHUB_REF="$ref" \
+		GITHUB_REPOSITORY=openai/git \
+		GITHUB_SHA="$sha" \
+		bash "$TRASH_DIRECTORY/release-gate.sh"
 }
 
 setup_pending_admission () (
@@ -1131,6 +1326,9 @@ test_expect_success 'reviewed admission requires one app-authenticated queue ent
 	test_grep "pull_request)" "$codex_admission_workflow" &&
 	test_grep "merge_group)" "$codex_admission_workflow" &&
 	test_grep "codex.output-tip" "$codex_admission_workflow" &&
+	test_grep "codex-unstable.output-tip" "$codex_admission_workflow" &&
+	test_grep "case \\\"\\\$GITHUB_REF\\\" in" \
+		"$codex_admission_workflow" &&
 	test_grep "refs/heads/gh-readonly-queue/" \
 		"$codex_admission_workflow" &&
 	test_grep "pull-requests: read" "$codex_admission_workflow" &&
@@ -1165,7 +1363,16 @@ test_expect_success 'reviewed admission requires one app-authenticated queue ent
 		test_grep "    needs: publication" "$CODEX_RELEASE_TOPIC" &&
 		test_grep "codex.output-tip" "$CODEX_RELEASE_TOPIC" &&
 		! grep -F "git/ref/heads/codex" "$CODEX_RELEASE_TOPIC" &&
-		test_grep "git/ref/heads/meta" "$CODEX_RELEASE_TOPIC"
+		test_grep "git/ref/heads/meta" "$CODEX_RELEASE_TOPIC" &&
+		if grep -F "codex-unstable" "$CODEX_RELEASE_TOPIC" >/dev/null
+		then
+			test_grep "codex-unstable.output-tip" \
+				"$CODEX_RELEASE_TOPIC" &&
+			test_grep "case \\\"\\\$GITHUB_REF\\\" in" \
+				"$CODEX_RELEASE_TOPIC" &&
+			test_grep "github.event.deleted == false" \
+				"$CODEX_RELEASE_TOPIC"
+		fi
 	fi
 '
 
@@ -1178,6 +1385,8 @@ test_expect_success 'admission workflow executes both pull-request and queue che
 	bash -n "$TRASH_DIRECTORY/admission-gate.sh" &&
 	run_admission_gate success pull_request >pull.out &&
 	test_grep "Approved pull request #42" pull.out &&
+	run_admission_gate legacy-release pull_request >legacy-release.out &&
+	test_grep "Approved pull request #42" legacy-release.out &&
 	run_admission_gate pending pull_request >pending-pull.out &&
 	test_grep "Approved pull request #42" pending-pull.out &&
 	run_admission_gate success merge_group >queue.out &&
@@ -1195,11 +1404,57 @@ test_expect_success 'admission workflow executes both pull-request and queue che
 	done &&
 	test_grep "pending topic" queue-pending.err &&
 	test_grep "unenrolled history" queue-hidden-prerequisite.err &&
+	for mode in dual-release-legacy-guard dual-release-no-delete \
+		dual-release-wrong-key
+	do
+		test_expect_code 1 run_admission_gate "$mode" merge_group \
+			>"$mode.out" 2>"$mode.err" &&
+		test_grep "controller-only release guard" "$mode.err" || return 1
+	done &&
 	test_expect_code 1 \
 		run_admission_gate success pull_request \
 			bb/codex/reviewed-unstable \
 		>unstable-pull.out 2>unstable-pull.err &&
 	test_grep "not eligible for production codex" unstable-pull.err
+'
+
+test_expect_success 'dual-lane release gate selects only the exact published output' '
+	write_dual_guarded_release_workflow \
+		"$TRASH_DIRECTORY/codex-release.yml" &&
+	test_grep "github.event.deleted == false" \
+		"$TRASH_DIRECTORY/codex-release.yml" &&
+	printf "%s\n" "on:" "  push:" "    branches:" "      - codex" \
+		"      - codex-unstable" "" >release-trigger.expect &&
+	sed -n "/^on:$/,/^$/p" "$TRASH_DIRECTORY/codex-release.yml" \
+		>release-trigger.actual &&
+	test_cmp release-trigger.expect release-trigger.actual &&
+	sed -n "/^        run: |\$/,/^  version:/p" \
+		"$TRASH_DIRECTORY/codex-release.yml" |
+	sed "1d; \$d; s/^          //" \
+		>"$TRASH_DIRECTORY/release-gate.sh" &&
+	bash -n "$TRASH_DIRECTORY/release-gate.sh" &&
+	install_release_gate_gh "$TRASH_DIRECTORY/release-gate-bin" &&
+
+	run_release_gate success refs/heads/codex stable-oid stable.out &&
+	printf "published=true\n" >published.expect &&
+	test_cmp published.expect stable.out &&
+	run_release_gate success refs/heads/codex-unstable unstable-oid \
+		unstable.out &&
+	test_cmp published.expect unstable.out &&
+	run_release_gate success refs/heads/codex pending-oid pending.out &&
+	printf "published=false\n" >unpublished.expect &&
+	test_cmp unpublished.expect pending.out &&
+	run_release_gate success refs/heads/codex unstable-oid cross-lane.out &&
+	test_cmp unpublished.expect cross-lane.out &&
+	test_expect_code 1 run_release_gate success refs/heads/master \
+		stable-oid unknown.out &&
+	test_must_be_empty unknown.out &&
+	test_expect_code 1 run_release_gate missing-unstable \
+		refs/heads/codex-unstable unstable-oid missing.out &&
+	test_must_be_empty missing.out &&
+	test_expect_code 1 run_release_gate api-failure refs/heads/codex \
+		stable-oid api.out &&
+	test_must_be_empty api.out
 '
 
 test_expect_success 'an unmerged topic is invisible to an enrolled rebuild' '
@@ -1887,6 +2142,198 @@ test_expect_success 'published release provenance gates cannot be removed' '
 	done
 '
 
+test_expect_success 'release publication guard has one exact dual-lane upgrade' '
+	git init --bare release-upgrade.git &&
+	test_create_repo release-upgrade-source &&
+	(
+		cd release-upgrade-source &&
+		git remote add origin ../release-upgrade.git &&
+		write base shared &&
+		git add shared &&
+		install_rerere_train &&
+		git commit -m "release upgrade base" &&
+		git switch -c aa/codex/release master &&
+		mkdir -p .github/workflows &&
+		write_guarded_release_workflow \
+			.github/workflows/codex-release.yml &&
+		git add .github/workflows/codex-release.yml &&
+		git commit -m "publish stable release guard" &&
+		legacy=$(git rev-parse HEAD) &&
+		git branch codex &&
+		create_unstable_sentinel codex &&
+		git branch meta master &&
+		install_unstable_meta_state meta master codex codex-unstable &&
+
+		git switch -c dual-valid "$legacy" &&
+		write_dual_guarded_release_workflow \
+			.github/workflows/codex-release.yml &&
+		git add .github/workflows/codex-release.yml &&
+		git commit -m "publish dual release guard" &&
+
+		git switch -c dual-old-guard "$legacy" &&
+		awk '\''
+			{ print }
+			$0 == "      - codex" { print "      - codex-unstable" }
+		'\'' .github/workflows/codex-release.yml >release.tmp &&
+		mv release.tmp .github/workflows/codex-release.yml &&
+		git add .github/workflows/codex-release.yml &&
+		git commit -m "trigger preview with stable guard" &&
+
+		git switch -c dual-no-delete dual-valid &&
+		sed "/github.event.deleted == false/d" \
+			.github/workflows/codex-release.yml >release.tmp &&
+		mv release.tmp .github/workflows/codex-release.yml &&
+		git add .github/workflows/codex-release.yml &&
+		git commit -m "release deleted preview refs" &&
+
+		git switch -c dual-wrong-key dual-valid &&
+		sed \
+			"s/output_key=codex-unstable.output-tip/output_key=codex.output-tip/" \
+			.github/workflows/codex-release.yml >release.tmp &&
+		mv release.tmp .github/workflows/codex-release.yml &&
+		git add .github/workflows/codex-release.yml &&
+		git commit -m "read stable state for preview releases" &&
+
+		git push origin master meta codex codex-unstable \
+			dual-valid:aa/codex/release \
+			dual-valid dual-old-guard dual-no-delete dual-wrong-key
+	) &&
+	git clone release-upgrade.git release-upgrade-runner &&
+	(
+		cd release-upgrade-runner &&
+		fetch_all &&
+		snapshot_refs ../release-upgrade.git >before &&
+		sh "$codex_branch" rewrite --remote origin \
+			--base master --codex codex \
+			--result result --updates updates \
+			--inputs inputs --failure failure &&
+		candidate=$(cat result) &&
+		unstable=$(updated_tip codex-unstable updates) &&
+		write_dual_guarded_release_workflow expected-release.yml &&
+		git show "$candidate:.github/workflows/codex-release.yml" \
+			>actual-release.yml &&
+		test_cmp expected-release.yml actual-release.yml &&
+		stable_release=$(git rev-parse \
+			"$candidate:.github/workflows/codex-release.yml") &&
+		unstable_release=$(git rev-parse \
+			"$unstable:.github/workflows/codex-release.yml") &&
+		test "$stable_release" = "$unstable_release" &&
+		snapshot_refs ../release-upgrade.git >after &&
+		test_cmp before after &&
+		for variant in dual-old-guard dual-no-delete dual-wrong-key
+		do
+			oid=$(git rev-parse "origin/$variant") &&
+			git --git-dir=../release-upgrade.git update-ref \
+				refs/heads/aa/codex/release "$oid" &&
+			fetch_all &&
+			snapshot_refs ../release-upgrade.git >"$variant.before" &&
+			test_expect_code 1 sh "$codex_branch" rewrite \
+				--remote origin --base master --codex codex \
+				--result "$variant.result" \
+				--updates "$variant.updates" \
+				--inputs "$variant.inputs" \
+				--failure "$variant.failure" \
+				>"$variant.out" 2>"$variant.err" &&
+			test_grep "controller-only release publication guard" \
+				"$variant.err" &&
+			test_path_is_missing "$variant.result" &&
+			snapshot_refs ../release-upgrade.git >"$variant.after" &&
+			test_cmp "$variant.before" "$variant.after" || return 1
+		done
+	)
+'
+
+test_expect_success 'published dual-lane release guard cannot be changed' '
+	git init --bare release-downgrade.git &&
+	test_create_repo release-downgrade-source &&
+	(
+		cd release-downgrade-source &&
+		git remote add origin ../release-downgrade.git &&
+		write base shared &&
+		git add shared &&
+		install_rerere_train &&
+		git commit -m "release downgrade base" &&
+		git switch -c aa/codex/release master &&
+		mkdir -p .github/workflows &&
+		write_dual_guarded_release_workflow \
+			.github/workflows/codex-release.yml &&
+		git add .github/workflows/codex-release.yml &&
+		git commit -m "publish dual release guard" &&
+		dual=$(git rev-parse HEAD) &&
+		git branch codex &&
+		git branch meta master &&
+		install_meta_state meta master codex &&
+
+		git switch -c post-dual-no-delete "$dual" &&
+		sed "/github.event.deleted == false/d" \
+			.github/workflows/codex-release.yml >release.tmp &&
+		mv release.tmp .github/workflows/codex-release.yml &&
+		git add .github/workflows/codex-release.yml &&
+		git commit -m "remove deleted-ref guard" &&
+
+		git switch -c post-dual-wrong-key "$dual" &&
+		sed \
+			"s/output_key=codex-unstable.output-tip/output_key=codex.output-tip/" \
+			.github/workflows/codex-release.yml >release.tmp &&
+		mv release.tmp .github/workflows/codex-release.yml &&
+		git add .github/workflows/codex-release.yml &&
+		git commit -m "read stable state for preview releases" &&
+
+		git switch -c post-dual-extra-trigger "$dual" &&
+		awk '\''
+			{ print }
+			$0 == "      - codex-unstable" { print "      - master" }
+		'\'' .github/workflows/codex-release.yml >release.tmp &&
+		mv release.tmp .github/workflows/codex-release.yml &&
+		git add .github/workflows/codex-release.yml &&
+		git commit -m "release from an extra branch" &&
+
+		git switch aa/codex/release &&
+		write_guarded_release_workflow \
+			.github/workflows/codex-release.yml &&
+		git add .github/workflows/codex-release.yml &&
+		git commit -m "restore production-only release guard" &&
+		git push origin master meta codex aa/codex/release \
+			post-dual-no-delete post-dual-wrong-key \
+			post-dual-extra-trigger
+	) &&
+	git clone release-downgrade.git release-downgrade-runner &&
+	(
+		cd release-downgrade-runner &&
+		fetch_all &&
+		snapshot_refs ../release-downgrade.git >before &&
+		test_expect_code 1 sh "$codex_branch" rewrite \
+			--remote origin --base master --codex codex \
+			--result result --updates updates \
+			--inputs inputs --failure failure >out 2>err &&
+		test_grep "controller-only release publication guard" err &&
+		test_path_is_missing result &&
+		snapshot_refs ../release-downgrade.git >after &&
+		test_cmp before after &&
+		for variant in post-dual-no-delete post-dual-wrong-key \
+			post-dual-extra-trigger
+		do
+			oid=$(git rev-parse "origin/$variant") &&
+			git --git-dir=../release-downgrade.git update-ref \
+				refs/heads/aa/codex/release "$oid" &&
+			fetch_all &&
+			snapshot_refs ../release-downgrade.git >"$variant.before" &&
+			test_expect_code 1 sh "$codex_branch" rewrite \
+				--remote origin --base master --codex codex \
+				--result "$variant.result" \
+				--updates "$variant.updates" \
+				--inputs "$variant.inputs" \
+				--failure "$variant.failure" \
+				>"$variant.out" 2>"$variant.err" &&
+			test_grep "controller-only release publication guard" \
+				"$variant.err" &&
+			test_path_is_missing "$variant.result" &&
+			snapshot_refs ../release-downgrade.git >"$variant.after" &&
+			test_cmp "$variant.before" "$variant.after" || return 1
+		done
+	)
+'
+
 test_expect_success 'required automation is the exact isolated trampoline' '
 	git init --bare automation.git &&
 	test_create_repo automation-source &&
@@ -2092,7 +2539,7 @@ test_expect_success 'required automation is the exact isolated trampoline' '
 			--result release-result --updates release-updates \
 			--inputs release-inputs --failure release-failure \
 			--require-automation 2>release.err &&
-		test_grep "release workflow must run only for pushes to codex" \
+		test_grep "reviewed Codex branch triggers" \
 			release.err &&
 		git --git-dir=../automation.git update-ref -d \
 			refs/heads/bb/codex/control "$release" &&
@@ -6495,7 +6942,7 @@ test_expect_success 'stable DAG topics cannot hide workflow changes behind a sec
 	)
 '
 
-test_expect_success 'unstable topics cannot redirect or delete the production release workflow' '
+test_expect_success 'unstable topics cannot redirect or delete the shared release workflow' '
 	git init --bare unstable-release.git &&
 	test_create_repo unstable-release-source &&
 	(
@@ -6503,7 +6950,7 @@ test_expect_success 'unstable topics cannot redirect or delete the production re
 		git remote add origin ../unstable-release.git &&
 		write base shared &&
 		mkdir -p .github/workflows &&
-		write_release_workflow codex .github/workflows/codex-release.yml &&
+		write_dual_release_workflow .github/workflows/codex-release.yml &&
 		git add shared .github/workflows/codex-release.yml &&
 		install_rerere_train &&
 		git commit -m base &&
@@ -6513,13 +6960,13 @@ test_expect_success 'unstable topics cannot redirect or delete the production re
 		write_release_workflow codex-unstable \
 			.github/workflows/codex-release.yml &&
 		git add .github/workflows/codex-release.yml &&
-		git commit -m "release untrusted preview builds" &&
+		git commit -m "redirect preview releases" &&
 		git branch codex-unstable &&
 		git branch meta master &&
 		install_unstable_meta_state meta master codex codex-unstable &&
 		git switch -c release-deleted codex &&
 		git rm .github/workflows/codex-release.yml &&
-		git commit -m "delete production release workflow" &&
+		git commit -m "delete shared release workflow" &&
 		git push origin master meta codex codex-unstable \
 			aa/codex/stable bb/codex/release-unstable release-deleted
 	) &&


### PR DESCRIPTION
The enrolled release topic currently has a production-only trigger and a
byte-frozen publication job. That preserves the controller-only release
gate, but it also rejects the one mechanical change needed to publish the
already-enabled `codex-unstable` lane.

Permit one exact migration from the production-only trigger/guard to a
canonical dual-lane form. The new guard skips deletion events, maps the
exact event ref to that lane's recorded output tip, and fails closed for
unknown refs or missing state. Once published, the dual trigger and
publication job are frozen again.

Validation:
- all 108 `t/t9905-codex-branch.sh` cases accounted for
  - 1-69 and 71-108 passed on the 64-core devbox
  - unchanged Linux duplicate-ZIP case 70 passed on macOS
- focused stable/unstable/pending/cross-lane/missing-state/deletion cases
- shell syntax, YAML parse, `git diff --check`
- three independent audits