### PR TITLE
ci: release controller-published Codex unstable commits

### DIFF
--- a/.github/workflows/codex-release.yml
+++ b/.github/workflows/codex-release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - codex
+      - codex-unstable
 
 permissions:
   contents: read
@@ -16,6 +17,7 @@ jobs:
   publication:
     name: Verify controller publication
     runs-on: ubuntu-24.04
+    if: github.event.deleted == false
     outputs:
       published: ${{ steps.verify.outputs.published }}
     steps:
@@ -26,6 +28,18 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
+          case "$GITHUB_REF" in
+          refs/heads/codex)
+            output_key=codex.output-tip
+            ;;
+          refs/heads/codex-unstable)
+            output_key=codex-unstable.output-tip
+            ;;
+          *)
+            printf 'unexpected release ref: %s\n' "$GITHUB_REF" >&2
+            exit 1
+            ;;
+          esac
 
           meta=$(gh api \
             "repos/$GITHUB_REPOSITORY/git/ref/heads/meta" \
@@ -34,7 +48,7 @@ jobs:
             "repos/$GITHUB_REPOSITORY/contents/codex.config?ref=$meta" \
             -H 'Accept: application/vnd.github.raw+json' |
             git config --no-includes --file /dev/stdin \
-              --get codex.output-tip)
+              --get "$output_key")
 
           if test "$GITHUB_SHA" = "$recorded"
           then


### PR DESCRIPTION
Depends on #19 landing on `meta`.

The release workflow currently listens only to `codex` and validates
every push against `codex.output-tip`. The controller records and
atomically publishes `codex-unstable.output-tip` separately, so preview
output pushes need their own exact gate.

Listen to both generated branches, skip deletion events, and select the
recorded output tip from the exact pushed ref. Unknown refs and missing
state fail closed. The existing version, build, and release chain still
runs only when the selected output matches `GITHUB_SHA`.

Validation:
- topic-aware static release checks
- controller migration tests covering dual-lane release selection
- shell/YAML checks and independent audit