### PR TITLE
ci: stamp Codex release source refs

### DIFF
--- a/.github/workflows/codex-release.yml
+++ b/.github/workflows/codex-release.yml
@@ -523,10 +523,18 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           SOURCE_DESCRIPTION: ${{ needs.version.outputs.describe }}
+          SOURCE_REF: ${{ github.ref }}
           VERSION: ${{ needs.version.outputs.version }}
         run: |
           set -euo pipefail
           assets=(artifacts/git-*)
+          release_notes=$(
+            printf '%s\n' \
+              "source_ref=$SOURCE_REF" \
+              "source_sha=$GITHUB_SHA" \
+              "" \
+              "OpenAI Git release artifacts for $SOURCE_DESCRIPTION, built from $GITHUB_SHA for Codex."
+          )
 
           if gh release view "$VERSION" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1
           then
@@ -538,6 +546,6 @@ jobs:
               --repo "$GITHUB_REPOSITORY" \
               --target "$GITHUB_SHA" \
               --title "$VERSION" \
-              --notes "OpenAI Git release artifacts for $SOURCE_DESCRIPTION, built from $GITHUB_SHA for Codex." \
+              --notes "$release_notes" \
               --prerelease
           fi


### PR DESCRIPTION
Codex and codex-unstable releases currently share the same
prerelease shape. Their target SHA differs, but the GitHub release object
does not record which generated output ref triggered it, so release-API
consumers have to join against Actions runs to distinguish the lanes.

Carry `github.ref` into the publish step and put `source_ref` and
`source_sha` at the start of newly created release notes. This leaves
tags and asset names unchanged while making the lane and exact source
commit machine-readable. In particular, unstable releases record
`source_ref=refs/heads/codex-unstable`.

Validation:

- YAML parse of `.github/workflows/codex-release.yml`
- extracted publish-step shell passes `bash -n`
- concrete unstable-lane release-note expansion
- `git diff --check`
- independent controller-boundary review

This is forward-looking: the existing-release upload path does not rewrite
notes on a release that was created before this change.

<!-- codex-thread: 019fd7bf-0f33-7242-b609-d983521a8b30 -->