### PR TITLE
ci: pin reviewed Codex topics in lane plans

### DIFF
--- a/.github/CODEX.md
+++ b/.github/CODEX.md
@@ -1,49 +1,77 @@
 # Maintaining `codex` and `codex-unstable`
 
-`master` stays equivalent to upstream. `codex` is the production integration
-branch distributed with Codex. When enabled, `codex-unstable` starts at that
-exact production commit and adds reviewed preview topics. Each lane may publish
-an OpenAI Git prerelease, but only from the exact output recorded for that lane
-by the controller. The orphan `meta` branch contains the controller, reusable
-workflows, tests, documentation, and ruleset recipes. Never merge `meta` into
-`master`, `codex`, or `codex-unstable`.
+`master` stays equivalent to upstream. `codex` is the production Git
+branch distributed with Codex. `codex-unstable` starts from the exact
+generated `codex` commit and adds preview topics.
 
-Topics use branches named `??/codex/*`, where `??` is a two-character owner
-name. A topic ending in `-unstable` belongs only in `codex-unstable`; other
-active topics belong in `codex`. The existing rows in `meta:codex.config` stay
-enrolled. A new topic enters either lane only after its reviewed pull request
-merges into that lane and the controller enrolls its retained head. Merely
-pushing a matching branch, including an `-unstable` branch, never includes it
-in a build. The `-wip` and `-stale` suffixes are inactive.
+Both lane branches are outputs. Do not merge topic pull requests into them or
+push ordinary updates to them. The orphan `meta` branch is the source of
+truth and contains the controller, reusable workflows, ruleset recipes, and
+two ordered desired-state files:
 
-The generated `codex.config` records each enrolled topic's prerequisites and
-last published tip. A linear topic has one `branch.<name>.merge` value; a
-merge-shaped topic records every reviewed parent edge as a repeated `merge`
-value. When the preview lane is enabled, the file also records the exact
-production commit underlying `codex-unstable` and its published preview tip.
-Prerequisite edges form a partial order within each lane; there is no global
-topic order. Rows are sorted only to give the generated file a stable
-representation.
+- `codex.plan` for production;
+- `codex-unstable.plan` for preview.
 
-The saved tips are rebase boundaries, not another copy of the patches. They
-let a fresh runner distinguish “the prerequisite was rewritten” from “these
-are independent topics” after their current tips stop sharing ancestry. This
-is what makes amending, dropping, or replacing an already-published commit
-safe without relying on a runner's local reflogs.
+Each plan row names a topic ref, its exact reviewed source SHA, the source
+boundary used to replay it, and one prerequisite. The controller retains each
+reviewed source object at `refs/heads/codex-pins/<sha>`. A mutable topic ref
+may advance later; that does not change a published generation until another
+reviewed plan transition pins the new head.
 
-The generated `codex` history contains one explicit two-parent integration
-commit for every production topic, including prerequisites, fast-forwardable
-topics, and empty topics. `codex-unstable` starts at the exact generated
-`codex` commit and adds one explicit integration merge per enrolled preview
-topic. It remains strictly ahead even before its first topic because enabling
-it creates a tree-identical bootstrap commit. Prerequisites are integrated
-before their dependents; lexical order only breaks ties among topics that are
-ready at the same time. This makes the history deterministic without inventing
-semantic dependencies.
+`codex.config` is the realized ledger. Version 3 records the plan blob,
+source pins, generated topic tips, and lane output tips produced by the last
+successful rebuild. Plans say what should be built; `codex.config` says what
+was built.
 
-## Add a production topic
+## The review policy
 
-Create a topic from `master`, or from the topic it depends on:
+Topics are named `??/codex/*`, where `??` is a two-character owner name.
+Only names ending in `-unstable` belong in `codex-unstable`; all other
+active topics belong in `codex`.
+
+| Change | Human review | Bot action | Plan effect |
+| --- | --- | --- | --- |
+| Add | Review the topic PR against its lane | Pin the approved head and open a plan PR | Append one topic with its uniquely inferred prerequisite |
+| Alter | Review the updated topic PR against its lane | Pin the approved head and open a plan PR | Replace only that topic's source SHA and source boundary |
+| Remove | Review the generated plan PR | Open a plan PR from the explicit workflow dispatch | Delete one plan row |
+| Reorder | Review the generated plan PR | Open a plan PR from the explicit workflow dispatch | Move one existing row; keep its SHA, boundary, and prerequisite |
+
+An add or alter has one human decision: the topic PR. The pull request is
+review-only because the output-lane rulesets reject ordinary updates. When an
+approval is submitted, GitHub loads the review-event workflow from the
+trusted default branch rather than from the topic head. That trusted run:
+
+1. rechecks that the PR is open, same-repository, non-draft, aimed at the
+   matching lane, and overall `APPROVED`;
+2. requires an effective approval at the exact current head SHA;
+3. asks the dedicated plan App to create immutable pins and a
+   `codex-plan/*` branch;
+4. opens a one-row plan PR against `meta`; and
+5. runs the trusted admission check, which rechecks the topic approval and
+   gives the mechanical plan approval.
+
+The plan PR auto-merges with rebase after its required check passes. If the
+topic head changes before that happens, the exact-head check fails. A new
+approval produces a new pin and a new plan transition. Once the plan merges,
+the immutable pin remains authoritative even if the source branch moves.
+
+Remove and reorder are policy decisions rather than projections of a reviewed
+topic head. Run **Actions > Refresh codex > Run workflow** with
+`operation=remove` or `operation=reorder`; the resulting plan PR needs the
+ordinary human `meta` review. For reorder, supply `after=root` or an
+existing same-lane topic.
+
+The controller rejects an ambiguous add, an alter that changes prerequisite
+or order, a reorder that changes the source boundary, a missing prerequisite,
+more or fewer than one automation topic, and any topic that changes protected
+controller or workflow paths. A prerequisite change is deliberately not an
+alter: retire and re-add the topic under a newly reviewed ancestry, or extend
+the policy explicitly.
+
+## Day-to-day commands
+
+Start a production topic from `master`, or from its intended production
+prerequisite:
 
 ```sh
 git switch -c tb/codex/my-topic origin/master
@@ -51,49 +79,8 @@ git switch -c tb/codex/my-topic origin/master
 git push -u origin HEAD
 ```
 
-Pushing this branch does not change `codex`. To include it:
-
-1. Open a pull request from the topic to `codex` and obtain the required
-   approval.
-2. Select **Merge when ready**. The merge queue admits one reviewed topic at
-   a time and creates a normal two-parent merge commit.
-3. Run `Meta/rebuild` or `Meta/rebuild --local`. The controller verifies the
-   merged pull request, enrolls its exact retained topic head, runs staging
-   CI, and publishes the rebuilt branch.
-
-The pull request merge leaves `codex` temporarily **pending**: its tip no
-longer matches the output recorded in `meta:codex.config`. Release builds are
-skipped, and another topic cannot pass the merge queue until the controller
-atomically publishes the rebuilt `codex` and its matching `meta` state. The
-pending commit remains visible to anyone fetching `codex` directly.
-
-## Enable the preview lane
-
-After deploying the updated controller, automation trampoline, and unstable
-branch ruleset, initialize `codex-unstable` explicitly:
-
-```sh
-Meta/rebuild --local --enable-unstable
-```
-
-The controller creates a tree-identical `Initialize codex-unstable` commit
-directly on top of `codex`, records the enabled lane in `meta:codex.config`,
-and publishes both changes together. The production tip does not change, and
-no existing `*-unstable` branch is enrolled. The preview branch now exists as
-a pull-request target, is strictly ahead of production, and initially has
-exactly the same contents.
-
-Enabling and disabling are explicit, local-only operations; dispatching the
-ordinary GitHub Action cannot change whether the lane exists. Once enabled,
-both `Meta/rebuild` and `Meta/rebuild --local` maintain the preview lane.
-When the dual-lane release workflow is active, enabling the lane publishes a
-preview prerelease for the empty sentinel. Its tree matches production, but its
-commit and version are distinct. Deleting the lane publishes nothing.
-
-## Add a preview topic
-
-Create the topic from the published `codex`, or from another enrolled preview
-topic it depends on:
+Start a preview topic from the published production lane, or from its intended
+preview prerequisite:
 
 ```sh
 git switch -c tb/codex/my-topic-unstable origin/codex
@@ -101,570 +88,172 @@ git switch -c tb/codex/my-topic-unstable origin/codex
 git push -u origin HEAD
 ```
 
-Pushing this branch does not change `codex-unstable`. Open a pull request from
-the topic to `codex-unstable`, obtain the required approval, and select
-**Merge when ready**. Its separate one-at-a-time merge queue accepts only a
-same-repository `??/codex/*-unstable` topic. Run `Meta/rebuild` or
-`Meta/rebuild --local` to authenticate the reviewed merge, enroll the exact
-topic head, run staging CI, and publish the rebuilt generation.
+Open the topic PR against `codex` or `codex-unstable` and obtain approval.
+Do not click merge; the output branch cannot accept it. The approval event
+creates the pinned plan PR automatically.
 
-While a preview merge is pending, another preview topic cannot pass its merge
-queue. Production and preview admission are tracked independently; a single
-controller run can consume one pending merge from each lane. An unreviewed
-preview branch, including a whole preexisting stack of matching branches,
-remains excluded until its own pull request is merged.
-
-The pending preview merge also fails the release-publication check. Its build
-matrix starts only after the controller records and atomically publishes that
-exact `codex-unstable` output.
-
-Production topics may never depend on preview topics. Root preview topics are
-based on `codex`; their prerequisites, when present, must be other enrolled
-preview topics. Update, rebase, replace, or reorder a preview topic using the
-same ancestry rules as a production topic, substituting `codex` for `master`.
-Before retiring a preview prerequisite, restack its children onto a surviving
-preview topic or `codex`.
-
-When the lane is no longer needed, first retire every enrolled preview topic,
-then explicitly remove the generated branch and its recorded state:
+For a local diagnostic of the same projection:
 
 ```sh
-Meta/rebuild --local --disable-unstable
+Meta/codex propose-plan --remote origin \
+  --lane codex-unstable \
+  --topic tb/codex/my-topic-unstable \
+  --source-tip <full-approved-sha> \
+  --review-pr <topic-pr-number> \
+  --action auto --no-push
 ```
 
-Topic-branch deletion still requires an authorized bypass of the topic ruleset.
-Creating a separate inactive copy without removing the enrolled ref does not
-retire that topic.
-
-## Update, reorder, or remove a topic
-
-Already enrolled topics remain active across rebuilds. You may push an update
-and run the controller directly, or use another reviewed topic pull request
-before rebuilding.
-
-Keep topic history explicit. A topic may retain a reviewed merge-shaped DAG,
-including fan-in from other enrolled same-lane topics, but never merge either
-generated branch into a topic or use GitHub's **Update branch** button on
-these pull requests. The controller preserves the reviewed ordered merge
-parents and shared ancestry; it does not flatten them into a guessed linear
-stack.
-
-For a new topic, the controller infers its nearest enrolled same-lane
-topic-tip ancestors, or that lane's root when none exists. The production root
-is `master`; the preview root is the exact generated `codex`. After
-publication it keeps those recorded edges across prerequisite rewrites. If
-sibling topics share private commits, either represent that shared prefix as
-an enrolled topic or bring it in through an explicit reviewed non-first-parent
-merge. Linear hidden prerequisites and unapproved descendant tips remain
-rejected.
-
-You may append, amend, reorder, or drop commits on an existing topic. If it
-has dependents, you may leave them at the last published prerequisite tip; the
-controller uses the recorded boundary to restack them. To change a topic's
-prerequisite, rebase it so the new topic's exact current tip is in its history.
-To make it a root topic, rebase it onto the current `master` or `codex`, as
-appropriate, and remove the old private prerequisite from its history. Those
-exact ancestry changes are the reordering signal; patch similarity and
-lexical branch order are never used. If a merge-shaped rewrite conflicts,
-the controller stops without moving refs; restack the reviewed graph and run
-`Meta/rebuild` again instead of using the linear `resolve`/`continue` path.
-
-Before making a prerequisite inactive, first restack every child onto a
-surviving topic in the same lane or that lane's root. The controller refuses
-to guess whether the retired topic's commits should be discarded or
-transferred to a child.
-Deleting or renaming an enrolled active ref explicitly retires it on the next
-rebuild; because topic refs are protected against deletion, this requires an
-authorized ruleset bypass. Creating a separate `-stale` copy without removing
-the enrolled active ref does not retire it.
-
-Every admission pull request must have a same-repository `??/codex/*` head and
-target the matching lane: ordinary topics go to `codex`; `-unstable` topics go
-to `codex-unstable`. The topic ruleset retains that head after the merge. Do
-not delete, force-rewrite, or otherwise change the reviewed head before the
-controller rebuilds it. Each lane rejects squash commits, unrelated direct
-commits, multiple pending integration merges, octopus integration merges, and
-merge-only edits.
-
-## Keep dispatch and admission on the generated branches
-
-GitHub shows **Run workflow** only for a workflow present on the default
-branch. Exactly one active `??/codex/automation` topic must therefore be based
-directly on `master` and change only `.github/workflows/codex.yml` to this exact
-trampoline:
-
-```yaml
-name: Refresh codex
-
-on:
-  workflow_dispatch:
-  pull_request:
-    branches:
-      - codex
-      - codex-unstable
-    types:
-      - opened
-      - reopened
-      - synchronize
-      - ready_for_review
-  merge_group:
-    types:
-      - checks_requested
-
-permissions:
-  actions: read
-  contents: read
-  pull-requests: read
-
-jobs:
-  refresh:
-    if: github.event_name == 'workflow_dispatch'
-    uses: openai/git/.github/workflows/codex.yml@meta
-  admission:
-    name: Codex admission
-    if: >-
-      (github.event_name == 'pull_request' &&
-       github.event.pull_request.base.ref == 'codex') ||
-      (github.event_name == 'merge_group' &&
-       github.event.merge_group.base_ref == 'refs/heads/codex')
-    permissions:
-      contents: read
-      pull-requests: read
-    uses: openai/git/.github/workflows/codex-admission.yml@meta
-  unstable_admission:
-    name: Codex unstable admission
-    if: >-
-      (github.event_name == 'pull_request' &&
-       github.event.pull_request.base.ref == 'codex-unstable') ||
-      (github.event_name == 'merge_group' &&
-       github.event.merge_group.base_ref == 'refs/heads/codex-unstable')
-    permissions:
-      contents: read
-      pull-requests: read
-    uses: openai/git/.github/workflows/codex-admission.yml@meta
-```
-
-Each lane's admission job handles both ordinary pull-request checks and
-merge-group checks. It accepts a queued merge only while that lane's published
-output and `meta` agree, verifies that the group introduces exactly one
-eligible reviewed topic, and rejects changes to every GitHub Actions workflow.
-The production and preview jobs have separate required-check names. Once the
-updated automation topic is published, this exact file remains in both
-generated branch trees. The implementations stay on orphan `meta`; no
-controller files or custom patches belong on `master`.
-
-## Initialize the published topology once
-
-Normal refreshes fail closed when `meta` has no `codex.config`; they never
-infer replacement state silently. For the one-time migration, make a linked
-worktree whose path is `Meta`, then run:
+For an explicit policy PR from the command line:
 
 ```sh
-git fetch origin '+refs/heads/*:refs/remotes/origin/*'
-git worktree add -b meta Meta origin/meta
-Meta/codex initialize
-git -C Meta add -N codex.config
-git -C Meta diff --check
-git -C Meta diff -- codex.config
+Meta/codex propose-plan --remote origin \
+  --lane codex --topic tb/codex/my-topic \
+  --action reorder --after root
+
+Meta/codex propose-plan --remote origin \
+  --lane codex --topic tb/codex/my-topic \
+  --action remove
 ```
 
-`initialize` pushes nothing. It finds the common published base, reconstructs
-the aggregate from the retained topic tips, and writes `Meta/codex.config`
-only if that reconstruction has exactly the same tree as the live known-good
-`codex`. Commit that file on `meta` only after reviewing the inferred edges.
-If the trees differ, first extract every already-shipped patch into an active
-topic; do not bless the mismatch. Initialization deliberately accepts the
-currently shipped legacy automation file when its tree is known-good; every
-normal refresh still requires the automation topic to contain the exact new
-trampoline above.
-
-The same entry point supports a local dry run at any time:
-
-```sh
-Meta/codex refresh --require-automation
-```
-
-It creates a session below the repository's shared Git directory containing
-the pinned inputs, update manifest, candidate bundle, and conflict report. It
-updates the clone's `origin/*` tracking refs, but it does not update local
-branches or refs on GitHub. The low-level `rewrite`, `stage`, and `promote`
-commands are also available through `Meta/codex`. Use local refresh for
-inspection and conflict recovery. Normal publication uses `Meta/rebuild` or
-`Meta/rebuild --local`; use `Meta/publish <run-id>` only to finish a
-preparation started through GitHub.
-
-## Refresh the enabled branches
-
-From a clean, complete clone with a linked `Meta` worktree, run:
+After a plan change lands, publish the new generation:
 
 ```sh
 Meta/rebuild
-```
-
-`Meta/rebuild` updates the clean `Meta` worktree to current `origin/meta`,
-dispatches **Refresh codex**, and prints the exact run ID and URL returned by
-GitHub. It reports preparation status, validates the successful artifact, and
-stages each generated candidate separately: `codex-staging` for production
-and, when enabled, `codex-unstable-staging` for preview. It reports staging-CI
-job progress and performs one atomic promotion only after every exact
-candidate passes. Leave the command running until it reports publication.
-
-To do the rebase and assembly on your machine instead of in the preparation
-Action, run:
-
-```sh
+# or run preparation locally:
 Meta/rebuild --local
 ```
 
-This skips only the preparation Action. It fetches the current heads from
-GitHub, prepares the topics, integration commits, enabled output branches,
-and the next `codex.config` state in an isolated temporary repository, then
-imports and verifies the resulting bundle in the publisher clone. The
-temporary repository has its own rerere cache and Git configuration, so an
-old local resolution, hook, or concurrent local preparation cannot leak
-through shared repository state. The command prints the path of a persistent
-local session containing the input snapshot, update manifest, candidate OID,
-bundle, and any conflict report.
+Both forms prepare an immutable snapshot, build and verify each candidate,
+stage exact SHAs, wait for fresh staging CI, and atomically promote
+`meta`, `codex`, and the enabled `codex-unstable` output with leases.
+`Meta/codex refresh --require-automation` is a local preview only; it pushes
+nothing.
 
-`--local` does not skip CI or make a private local-only publication. After
-preparation, it uses the same user-authenticated staging pushes, waits for a
-fresh `main.yml` run for each exact candidate SHA, and performs the same
-atomic exact-lease promotion to GitHub. Use `Meta/codex refresh
---require-automation` when you want only a local preview with no server-side
-ref update.
+If a replay conflicts, the controller leaves published refs unchanged and
+prints the pinned recovery command. Resolve only in that disposable worktree,
+then run a fresh rebuild. Merge-shaped sources are preserved only when they
+already descend from the pinned lane base; a base-moving merge replay fails
+closed instead of flattening the reviewed DAG.
 
-Create the linked worktree once if it does not exist:
+## Required automation topic
 
-```sh
-git fetch origin '+refs/heads/meta:refs/remotes/origin/meta'
-git worktree add --detach Meta refs/remotes/origin/meta
-```
+Exactly one stable topic named `??/codex/automation` must be based directly
+on `master` and change only `.github/workflows/codex.yml`. Its canonical
+workflow is the default-branch trampoline that:
 
-If an older `Meta/rebuild` rejects `--local` before it can refresh itself,
-update the existing `Meta` worktree once:
+- dispatches ordinary refresh;
+- turns an approved topic PR into a trusted default-branch dispatch, which
+  then creates the automatic add/alter proposal;
+- offers explicit remove/reorder dispatch inputs; and
+- runs plan admission through `pull_request_target` while loading the
+  reusable implementation from `meta`.
 
-```sh
-git fetch origin '+refs/heads/meta:refs/remotes/origin/meta'
-git -C Meta switch --detach refs/remotes/origin/meta
-Meta/rebuild --local
-```
+The reusable plan workflows stay on `meta`; the default branch contains only
+that trampoline. During migration, the controller accepts the previous
+trampoline as published history, but it refuses the first v3 refresh until the
+plan pins the current trampoline.
 
-After that bootstrap, both rebuild forms refresh `Meta` and re-execute the
-new pinned controller automatically.
+The topic head never supplies executable workflow code. The trusted
+`pull_request_review` run only queues `codex.yml` at `refs/heads/codex`; the
+resulting default-branch dispatch calls the reusable producer from `meta`.
+That producer revalidates the PR before the `codex-plan` environment is
+opened.
 
-Both the publishing worktree and `Meta` must be clean. When `Meta/` is nested
-in the publishing worktree, the helper permits that linked-worktree directory
-but rejects every other change.
+## One-time v2 to v3 rollout
 
-To start preparation in the GitHub UI instead, open **Actions > Refresh
-codex**, select `codex`, and choose **Run workflow**. After **Rebase topics and
-assemble Codex branches** succeeds, finish that exact run from the same kind
-of clean clone:
-
-```sh
-Meta/publish <run-id>
-```
-
-The Action summary prints this command. Prepared artifacts expire after seven
-days. `Meta/publish` stays pinned to the controller used by the selected run;
-it does not update the `Meta` worktree underneath that run.
-
-Start a fresh `Meta/rebuild` or `Meta/rebuild --local`, using the same mode you
-want for the retry, after a preparation, staging, CI, lease, or promotion
-failure. The manual alternative is a fresh UI dispatch followed by
-`Meta/publish <run-id>`. Do not use **Re-run failed jobs**: a retry must
-snapshot the current refs and stage a fresh candidate.
-
-The Action:
-
-1. reads the published enrollment from `meta/codex.config`, verifies at most
-   one pending reviewed pull-request merge per enabled lane, and snapshots
-   `meta`, `master`, both outputs, their enrolled topics, and any newly
-   admitted heads;
-2. reads the published boundaries, infers only a newly admitted topic or
-   explicitly restacked edges, and rebases topics sequentially in dependency
-   order, using rerere resolutions learned from the old `codex`;
-3. integrates each enrolled production topic with an explicit merge, then
-   integrates enrolled preview topics on top of the exact generated `codex`
-   commit; freezes both results without building or executing candidate code;
-   and, when state changed, creates a direct child of the pinned `meta` tip
-   that changes only `codex.config`;
-4. uploads the bundle, pinned input snapshot, update manifest, and canonical
-   run metadata as one attempt-specific artifact; and
-5. pushes nothing.
-
-With `Meta/rebuild --local`, those preparation steps run in the isolated local
-repository instead. There is no Actions run, server artifact, or run-attempt
-attestation for that phase. The helper instead pins the exact `Meta` commit,
-materializes the controller from that commit, freezes the local session,
-checks the complete GitHub input snapshot, verifies the bundle and generated
-history, and then relies on the same exact-SHA staging CI and ref leases.
-Generated commit OIDs may differ from an Actions preparation because the
-local Git version and commit timestamps may differ; the staged candidate is
-the exact object that CI verifies.
-
-`Meta/publish` uses the current user's existing `gh` and Git credentials. It
-accepts only a successful `workflow_dispatch` run on `openai/git:codex`, the
-attempt-specific artifact from that run, and the exact reusable controller
-recorded by GitHub for `meta`. It checks the caller SHA against the snapshotted
-`codex`, requires the artifact controller to equal `Meta/HEAD`, validates the
-ZIP allowlist and bundle heads, and revalidates the complete input snapshot.
-
-Only then does it record the existing CI run IDs and push the exact production
-candidate to `codex-staging`. When preview is enabled, it also stages the
-exact preview candidate at `codex-unstable-staging`. Each user-authenticated
-push starts ordinary CI, including when its candidate changes a workflow file.
-The helper binds each candidate to a newer `main.yml` push run whose branch and
-SHA match exactly. While waiting, it prints each run URL and reports changes
-in status, completed-job count, and failure count, plus a heartbeat every five
-minutes when those values do not change.
-
-After every required run and its unique `config` job succeeds, the helper
-revalidates the snapshot and atomically updates `meta`, every enrolled topic,
-`codex`, and the enabled `codex-unstable` branch with exact leases while
-deleting both staging refs. A failed preview build cannot publish production;
-a failed production build cannot publish preview.
-
-Every push to `codex` or `codex-unstable` starts the inexpensive
-release-publication check. The job skips branch-deletion events, maps the exact
-event ref to either `codex.output-tip` or `codex-unstable.output-tip`, and reads
-that value from the current `meta` branch. The expensive build and release jobs
-proceed only when the triggering SHA matches the selected lane's recorded
-output. A reviewed pull-request merge therefore publishes no release; the
-controller's atomic output/state promotion does. The check does not require
-that SHA to remain the live lane tip, so a later pending merge cannot suppress
-a release that the controller already triggered. A canonical no-op reuses the
-existing tips, and neither staging branch releases. An atomic promotion that
-advances both outputs intentionally starts one release matrix per lane.
-Ordinary CI may reuse its own earlier successful result when the commit or tree
-is identical.
-
-Until the final push, `meta`, both generated outputs, and all topic refs remain
-unchanged. A CI, validation, lease, or promotion failure after staging leaves
-the affected staging refs available for inspection. Successful promotion
-updates all primary refs and deletes every staging ref as one atomic
+Do not commit `codex.plan` or `codex-unstable.plan` in the controller PR.
+They must be created together with their immutable pins by the bootstrap
 transaction.
 
-Git can place server-side leases only on refs included in the push. The
-controller therefore refetches `meta`, `master`, both enabled outputs, and the
-complete topic namespace immediately before promotion, then places exact
-leases on every ref it mutates or deletes in the atomic transaction. The
-generated state can therefore never describe a different published generation.
-A newly created but unadmitted topic remains excluded; a newly merged topic is
-handled by the next verified snapshot.
+Roll out in this order:
 
-Both preparation modes use `refs/remotes/origin/master` after fetching the
-current `openai/git` heads. They do not use the caller's local `master`
-branch, which may be absent or stale.
+1. Land the controller, reusable plan workflows, docs, and ruleset recipes on
+   `meta`, without plan files and without enabling the new meta, output-lane,
+   plan-branch, or pin-creation rulesets.
+2. Enable only `codex-pins-immutable.json`. It blocks update and deletion
+   while still allowing the bootstrap transaction to create new pins.
+3. Update and push the `??/codex/automation` source branch to the exact new
+   trampoline.
+4. From a clean publisher clone, run one explicit pre-v3 bootstrap alter for
+   the automation topic, then one for each other already-published topic whose
+   source SHA is intentionally being overridden. Do not refresh between these
+   commits.
+5. Run one rebuild and publish. That writes version 3 `codex.config` and
+   closes the bootstrap path.
+6. Provision the plan App and environment, seed one harmless plan-admission
+   check run, then activate the pin-creation, plan-branch, `meta`, and
+   output-lane rulesets.
+7. Smoke-test one automatic add or alter and one explicit remove or reorder.
 
-`master` is a read-only input, so Git's push protocol cannot include it as a
-compare-only command in the final ref transaction. The controller verifies it
-immediately before the push and checks it again afterward. If `master` moves
-in that narrow interval, the published candidate is still the exact tree that
-passed staging CI, but it is based on the preceding `master`; the helper prints
-a warning and the next refresh advances it. Literal atomic comparison of an
-unchanged ref would require server-side transaction support.
+The pre-v3 command is intentionally narrow. It may only alter a topic already
+present in v1/v2 published state, records the exact authorization in commit
+trailers, creates pins and `meta` in one atomic push, and may continue only
+from the immediately preceding bootstrap commit while `codex.config` is
+still v1/v2:
 
-## Resolve a rebase conflict
+```sh
+Meta/codex propose-plan --remote origin \
+  --lane codex \
+  --topic tb/codex/automation \
+  --source-tip <full-new-automation-sha> \
+  --action alter \
+  --bootstrap-authorization '<explicit authorization>'
 
-A production-topic conflict leaves every published ref unchanged and prints a
-pinned `Meta/codex resolve` command. A failed `Meta/rebuild --local` prints the
-persistent session path and leaves the same conflict report there. In either
-case, follow the exact commands in that report. For Action preparation, start
-from a clean clone that does not already have a `Meta` worktree; the printed
-commands create one at the exact controller commit for the failed run:
+Meta/codex propose-plan --remote origin \
+  --lane codex-unstable \
+  --topic tb/codex/status-preview-unstable \
+  --source-tip <full-approved-bootstrap-sha> \
+  --action alter \
+  --bootstrap-authorization '<explicit authorization>'
+```
 
-1. Run the exact fetch, detached checkout, and `resolve` commands from the
-   summary. The helper verifies the original snapshot, creates a disposable
-   worktree, and stops at the same rebase conflict.
-2. Change to the printed worktree and run:
+Bootstrap is a deployment exception performed before the pin-creation
+ruleset is active. The immutable-pin rule must already be active, so an
+earlier bootstrap commit cannot lose one of its retained objects while the
+next direct transition is prepared. After the first v3 publication, ordinary
+topic approval or explicit plan review is required.
 
-   ```sh
-   git status
-   git rebase --show-current-patch
-   # Edit every conflicted file.
-   git add <files>
-   git diff --cached --check
-   /path/to/Meta/codex continue --worktree .
-   ```
+## Repository settings
 
-3. Use the exact `Meta/codex` path printed by `resolve`. If that command reaches
-   another conflict, repeat the edit/add/check sequence and run it again. The
-   helper, not a plain
-   `git rebase --continue`, creates each resolved commit with the canonical
-   Codex committer identity while preserving its original author.
-4. Review the rewritten topic tips, then run the printed `publish-topics`
-   command. It rechecks the original snapshot and atomically pushes every
-   rewritten topic with an exact lease.
-5. Run `Meta/rebuild` or `Meta/rebuild --local` to prepare, verify, and publish
-   the repaired graph. The manual alternative is a fresh **Actions > Refresh
-   codex > Run workflow** dispatch followed by its printed `Meta/publish
-   <run-id>` command.
+Apply the checked-in ruleset recipes after the v3 publication:
 
-To abandon recovery, run `git rebase --abort` and delete the disposable
-worktree. Do not use `git rebase --quit`, push only the first conflicted topic,
-add `+` to a failed push, or use an unqualified force push. If a lease fails,
-start again from a fresh dispatch.
+- `codex-branch.json` and `codex-unstable-branch.json` make generated lanes
+  output-only; only the narrow publisher and organization-admin break-glass
+  actors bypass them.
+- `codex-pins.json` lets only the dedicated plan App create
+  `codex-pins/*`; `codex-pins-immutable.json` lets only break-glass update
+  or delete them.
+- `codex-plan-branches.json` lets only the dedicated plan App write
+  `codex-plan/*`.
+- `codex-meta.json` keeps one ordinary review, stale-review dismissal,
+  last-push approval, and the required
+  **Codex plan admission / Verify pinned manifest** check. The plan App has no
+  `meta` bypass.
 
-If topics conflict while the controller assembles `codex`, the graph declared
-them independent at that integration point when they are not independent in
-practice. Rebase the conflicting topic and its descendants onto the real
-prerequisite, push that coherent graph, and start a fresh dispatch. Do not fix
-this by merging `codex` into a topic or by maintaining a manual order.
+The dedicated App is integration `1144995` and needs Contents and Pull
+requests write for `openai/git`. Store its private key only in the
+`codex-plan` environment and restrict that environment to the trusted
+`refs/heads/codex` caller. Enable repository auto-merge and allow GitHub Actions
+to approve pull requests; otherwise the mechanical add/alter approval cannot
+complete.
 
-A preview-topic conflict also leaves every published ref unchanged, but the
-production-only `resolve`, `continue`, and `publish-topics` commands do not
-reconstruct the nested preview lane. Manually restack the affected
-`*-unstable` topic and its descendants onto their current prerequisite, push
-that coherent topic graph atomically with exact leases, and run
-`Meta/rebuild` or `Meta/rebuild --local` again.
+GitHub only offers a required check source after it has run recently. After
+publishing the new trampoline, run a harmless `meta` PR once and verify the
+exact check context before activating the new `meta` ruleset.
 
-## Configure publishing
+The local publisher remains the only actor that promotes generated outputs.
+Its staging and promotion path uses exact SHA checks and atomic leases. Do not
+replace it with a shared `GITHUB_TOKEN`; pushes made with that token do not
+trigger the staging and release workflows needed by this design.
 
-Publishing needs no repository secret, deploy key, GitHub App, or protected
-environment. It uses the publisher's ordinary credentials:
+## Releases
 
-1. Authenticate `gh` as the publishing user. `Meta/rebuild` needs permission
-   to dispatch Actions; `Meta/publish` needs permission to read the selected
-   run and its artifact. `Meta/rebuild --local` does neither, but it still
-   reads the exact staging-CI run and jobs:
+Release jobs run only for the exact lane output recorded in the current
+`meta:codex.config`. A topic PR, plan PR, staging ref, or stale output SHA
+does not publish a release. Stable and unstable promotions may happen in one
+atomic transaction, but each lane gets its own release matrix.
 
-   ```sh
-   gh auth status
-   ```
-
-2. Configure the canonical `origin` with that user's normal Git credentials.
-   `Meta/rebuild`, `Meta/rebuild --local`, and `Meta/publish` accept only the
-   standard SSH or HTTPS URL for `openai/git`. None reads a token from the
-   repository, local session, or artifact.
-3. In **Protect generated Codex branch**, **Protect generated unstable Codex
-   branch**, and **Protect Codex controller branch**, add an **always** bypass
-   for each exact human publisher. The checked-in recipes authorize only the
-   `ttaylorr-oai` user (`301000140`) plus the existing organization-admin
-   break-glass actor. Update existing rulesets; import a recipe only when its
-   matching ruleset is absent.
-
-The bypass is intentionally personal and visible. The Action cannot publish;
-it only prepares an immutable artifact. Running `Meta/rebuild`,
-`Meta/rebuild --local`, or `Meta/publish` is the approval, and Git records the
-configured user as the pusher. To add or remove a publisher, change the exact
-`User` actor in each generated-output and controller ruleset. Do not replace
-it with a broad repository role or a shared long-lived credential.
-
-The final push runs from the operator's machine. Preparation runs either in
-Actions or in the isolated local repository; staging CI still runs in Actions.
-The operator's existing Git credentials authorize the atomic ref update.
-
-The built-in `GITHUB_TOKEN` is not a substitute for the local publisher.
-[GitHub suppresses push-triggered workflows for pushes made with that
-token](https://docs.github.com/en/actions/concepts/security/github_token), so
-it would skip both the exact staging CI run and the final release workflow.
-Giving the shared GitHub Actions App a ruleset bypass would also authorize it
-outside this controller. Moving publication into Actions therefore requires a
-separate, narrowly scoped GitHub App credential; until one is provisioned, the
-local publisher remains the security and audit boundary.
-
-For an Actions preparation, the local helper downloads the artifact through
-`gh`, but pushes through `origin`. Those credentials can theoretically
-identify different users, so every publishing path prints the authenticated
-`gh` login before staging. Verify the configured Git identity when changing
-machines or credentials. A failed CI run leaves its production or preview
-staging branch for inspection; neither exposes a publishing secret.
-
-The automation topic is the only topic allowed to change the dispatch and
-admission trampoline. A directly merged topic pull request may change neither
-that trampoline nor `.github/workflows/codex-release.yml`; otherwise it could
-bypass the release guard before the controller runs. Update the enrolled
-automation and release topics through a normal controller rebuild instead.
-During migration, the reviewed release trigger may remain exactly `codex`.
-After the canonical topic upgrade, it contains exactly `codex` and
-`codex-unstable`, skips deletion events, and selects the recorded output from
-the exact event ref. Its workflow may not mention an environment or the
-`secrets` context. The controller permits the existing production-only
-publication job to make that one exact upgrade; afterward it again preserves
-the published job byte for byte. These checks are not a sandbox for untrusted
-build code: review the release topic, its reusable workflows, and the preview
-source it builds. The controller rejects other topic-controlled workflow
-changes.
-
-Once the dual-lane guard is published, the controller deliberately rejects a
-return to the production-only trigger. Disabling an empty preview lane stops
-future preview releases and its branch-deletion event publishes nothing, but
-changing the release trigger again requires a controller change first.
-
-Rebased topic commits preserve their original authors. Generated commits and
-rebase committers use
-`chatgpt-codex-connector[bot] <199175422+chatgpt-codex-connector[bot]@users.noreply.github.com>`.
-Generated merge and `meta` state commits use that identity as both author and
-committer. These commits are deliberately unsigned and do not claim verified
-GitHub App authentication. GitHub records the local credential owner as the
-pusher. Integration subjects are `Merge <topic> into codex` or
-`Merge <topic> into codex-unstable`.
-
-## Repository rulesets
-
-Create or update the repository rulesets to match the checked-in JSON files.
-Do not layer a duplicate over an existing matching ruleset: a bypass in one
-ruleset does not bypass another applicable ruleset. For a missing ruleset, use
-**Settings > Rules > Rulesets > New ruleset > Import a ruleset**.
-
-In `openai/git`, update the existing production, preview, topic, and controller
-rulesets in place. Verify that exactly one active policy ruleset covers each
-of `codex`, `codex-unstable`, `??/codex/*`, and `meta`.
-
-- `.github/rulesets/codex-topics.json` matches `??/codex/*` and blocks
-  deletion, preserving topic heads after pull-request merges.
-- `.github/rulesets/codex-branch.json` protects `codex` with pull-request,
-  review, deletion, force-push, one-at-a-time merge-queue, and trusted
-  admission-check rules. Its exact `ttaylorr-oai` user bypass permits local
-  publication; the organization-admin entry remains for break-glass access.
-- `.github/rulesets/codex-unstable-branch.json` gives `codex-unstable` the
-  same review and one-at-a-time merge-queue protections, but requires the
-  distinct **Codex unstable admission / Verify reviewed topic** check. It
-  retains the same narrowly scoped publication bypasses.
-- `.github/rulesets/codex-meta.json` protects the `meta` controller with
-  pull-request, review, deletion, and force-push rules. Its matching exact-user
-  bypass lets the same atomic push advance the generated state; the
-  organization-admin entry remains for break-glass access.
-
-Each trusted admission check verifies that the pull-request head matches the
-eligible `??/codex/*` namespace and belongs to its target lane. Do not require
-topic heads to be up to date with either generated branch: the merge queue
-checks the proposed merge against the current base without copying the
-aggregate into a topic. An actor with an explicit ruleset bypass can still
-override the queue; keep publisher bypasses narrow and reserve
-organization-admin access for emergencies.
-
-The required check is pinned to the GitHub Actions App, but a repository
-ruleset cannot pin the source workflow file. SCM review is therefore still the
-boundary for a topic that changes GitHub Actions files. If hostile writers with
-workflow-editing access are in scope, add an organization-level required
-workflow rule or use a dedicated admission App before enabling this flow.
-
-Deploy these changes in order:
-
-1. Merge the controller, lane-aware trusted admission workflow, and ruleset
-   recipe into `meta` without creating a merge commit there.
-2. Verify that the already-enrolled automation topic contains the canonical
-   two-lane trampoline, and update the release topic. The release workflow must
-   add the exact `codex-unstable` trigger, skip deleted refs, and map
-   `refs/heads/codex` and `refs/heads/codex-unstable` to their respective
-   recorded output keys.
-3. Run
-   `Meta/rebuild --local` once to publish the exact two-lane trampoline while
-   upgrading the release guard and preserving stable merge-queue settings.
-4. Update the existing **Protect generated unstable Codex branch** ruleset
-   from its recipe, including its separate required check and serial queue.
-5. If `codex.config` is still version 1 and `codex-unstable` does not exist,
-   run `Meta/rebuild --local --enable-unstable` to create the protected,
-   strictly-ahead preview target without enrolling any preexisting topic. If
-   version 2 state and the preview branch already exist, skip this step and use
-   the ordinary rebuild from step 3; `--enable-unstable` must not be repeated.
-6. Open reviewed `*-unstable` pull requests against `codex-unstable`, merge
-   them through its queue, and run the controller to publish each generation.
-
-Before handing a preview release to a consumer, verify that the production and
-preview release checks each selected their lane-specific SHA from the promoted
-`codex.config`, and that each prerelease targets that exact commit. Do not merge
-a preview pull request until the controller and topic updates, rebuild,
-ruleset update, and any required lane creation are complete.
+An unstable release records both
+`source_ref=refs/heads/codex-unstable` and its exact `source_sha` in the
+release body. New releases therefore say plainly that they came from the
+unstable lane.

--- a/.github/rulesets/codex-meta.json
+++ b/.github/rulesets/codex-meta.json
@@ -21,11 +21,26 @@
     {
       "type": "pull_request",
       "parameters": {
+        "allowed_merge_methods": [
+          "rebase"
+        ],
         "require_code_owner_review": false,
         "require_last_push_approval": true,
-        "dismiss_stale_reviews_on_push": false,
+        "dismiss_stale_reviews_on_push": true,
         "required_approving_review_count": 1,
         "required_review_thread_resolution": false
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "required_status_checks": [
+          {
+            "context": "Codex plan admission / Verify pinned manifest",
+            "integration_id": 15368
+          }
+        ],
+        "strict_required_status_checks_policy": true
       }
     }
   ],

--- a/.github/rulesets/codex-pins-immutable.json
+++ b/.github/rulesets/codex-pins-immutable.json
@@ -1,5 +1,5 @@
 {
-  "name": "Protect generated Codex branch",
+  "name": "Keep Codex pins immutable",
   "target": "branch",
   "source_type": "Repository",
   "enforcement": "active",
@@ -7,14 +7,11 @@
     "ref_name": {
       "exclude": [],
       "include": [
-        "refs/heads/codex"
+        "refs/heads/codex-pins/*"
       ]
     }
   },
   "rules": [
-    {
-      "type": "creation"
-    },
     {
       "type": "update",
       "parameters": {
@@ -26,11 +23,6 @@
     }
   ],
   "bypass_actors": [
-    {
-      "actor_id": 301000140,
-      "actor_type": "User",
-      "bypass_mode": "always"
-    },
     {
       "actor_id": 1,
       "actor_type": "OrganizationAdmin",

--- a/.github/rulesets/codex-pins.json
+++ b/.github/rulesets/codex-pins.json
@@ -1,5 +1,5 @@
 {
-  "name": "Protect generated Codex branch",
+  "name": "Allow only the Codex plan bot to create pins",
   "target": "branch",
   "source_type": "Repository",
   "enforcement": "active",
@@ -7,28 +7,19 @@
     "ref_name": {
       "exclude": [],
       "include": [
-        "refs/heads/codex"
+        "refs/heads/codex-pins/*"
       ]
     }
   },
   "rules": [
     {
       "type": "creation"
-    },
-    {
-      "type": "update",
-      "parameters": {
-        "update_allows_fetch_and_merge": false
-      }
-    },
-    {
-      "type": "deletion"
     }
   ],
   "bypass_actors": [
     {
-      "actor_id": 301000140,
-      "actor_type": "User",
+      "actor_id": 1144995,
+      "actor_type": "Integration",
       "bypass_mode": "always"
     },
     {

--- a/.github/rulesets/codex-plan-branches.json
+++ b/.github/rulesets/codex-plan-branches.json
@@ -1,5 +1,5 @@
 {
-  "name": "Protect generated Codex branch",
+  "name": "Allow only the Codex plan bot to write plan branches",
   "target": "branch",
   "source_type": "Repository",
   "enforcement": "active",
@@ -7,7 +7,7 @@
     "ref_name": {
       "exclude": [],
       "include": [
-        "refs/heads/codex"
+        "refs/heads/codex-plan/*"
       ]
     }
   },
@@ -27,8 +27,8 @@
   ],
   "bypass_actors": [
     {
-      "actor_id": 301000140,
-      "actor_type": "User",
+      "actor_id": 1144995,
+      "actor_type": "Integration",
       "bypass_mode": "always"
     },
     {

--- a/.github/rulesets/codex-unstable-branch.json
+++ b/.github/rulesets/codex-unstable-branch.json
@@ -13,47 +13,16 @@
   },
   "rules": [
     {
+      "type": "creation"
+    },
+    {
+      "type": "update",
+      "parameters": {
+        "update_allows_fetch_and_merge": false
+      }
+    },
+    {
       "type": "deletion"
-    },
-    {
-      "type": "non_fast_forward"
-    },
-    {
-      "type": "pull_request",
-      "parameters": {
-        "allowed_merge_methods": [
-          "merge"
-        ],
-        "require_code_owner_review": false,
-        "require_last_push_approval": true,
-        "dismiss_stale_reviews_on_push": false,
-        "required_approving_review_count": 1,
-        "required_review_thread_resolution": false
-      }
-    },
-    {
-      "type": "merge_queue",
-      "parameters": {
-        "check_response_timeout_minutes": 60,
-        "grouping_strategy": "ALLGREEN",
-        "max_entries_to_build": 1,
-        "max_entries_to_merge": 1,
-        "merge_method": "MERGE",
-        "min_entries_to_merge": 1,
-        "min_entries_to_merge_wait_minutes": 0
-      }
-    },
-    {
-      "type": "required_status_checks",
-      "parameters": {
-        "required_status_checks": [
-          {
-            "context": "Codex unstable admission / Verify reviewed topic",
-            "integration_id": 15368
-          }
-        ],
-        "strict_required_status_checks_policy": false
-      }
     }
   ],
   "bypass_actors": [

--- a/.github/workflows/codex-branch.sh
+++ b/.github/workflows/codex-branch.sh
@@ -9,6 +9,8 @@ preserve_worktree=
 script_dir=$(CDPATH= cd "$(dirname "$0")" && pwd)
 script_path=${CODEX_ENTRYPOINT:-$script_dir/$(basename "$0")}
 meta_config_path=codex.config
+stable_plan_path=codex.plan
+unstable_plan_path=codex-unstable.plan
 tab=$(printf '\t')
 bot_name='chatgpt-codex-connector[bot]'
 bot_email='199175422+chatgpt-codex-connector[bot]@users.noreply.github.com'
@@ -42,6 +44,19 @@ usage () {
 		[--enable-unstable | --disable-unstable]
 	   or: codex-branch verify-inputs [--remote <remote>]
 		[--base <branch>] [--codex <branch>] <snapshot>
+	   or: codex-branch validate-plan-transition [--remote <remote>]
+		--base-commit <oid> --head-commit <oid>
+	   or: codex-branch validate-topic-review
+		--pull-request <number> --lane <codex|codex-unstable>
+		--topic <branch> --source-tip <oid>
+	   or: codex-branch propose-plan [--remote <remote>]
+		--lane <codex|codex-unstable> --topic <branch>
+		[--source-tip <oid>] [--review-pr <number>]
+		[--merge <branch>] [--after <branch>]
+		[--action <auto|add|alter|remove|reorder>]
+		[--expected-meta <oid>]
+		[--plan-branch <codex-plan/name>]
+		[--bootstrap-authorization <text>] [--no-push]
 	   or: codex-branch verify-output --inputs <path>
 		--updates <path> --result <path> [--require-automation]
 		[--stable-recovery]
@@ -148,6 +163,65 @@ require_full_commit_oid () {
 		die "'$oid' is not a full commit object ID"
 }
 
+require_full_blob_oid () {
+	oid=$1
+	resolved=$(git rev-parse --verify "$oid^{blob}" 2>/dev/null) ||
+		die "'$oid' is not a blob"
+	test "$resolved" = "$oid" ||
+		die "'$oid' is not a full blob object ID"
+}
+
+plan_path_for_lane () (
+	case "$1" in
+	codex) printf '%s\n' "$stable_plan_path" ;;
+	codex-unstable) printf '%s\n' "$unstable_plan_path" ;;
+	*) die "unknown Codex lane '$1'" ;;
+	esac
+)
+
+pin_ref_for_tip () (
+	printf 'refs/heads/codex-pins/%s\n' "$1"
+)
+
+require_bootstrap_pin_guard () {
+	ruleset_ids=$(gh api --hostname github.com \
+		"repos/openai/git/rulesets?includes_parents=false&targets=branch" \
+		--paginate --jq '
+			.[] |
+			select(.name == "Keep Codex pins immutable" and
+				.target == "branch" and .enforcement == "active") |
+			.id
+		') ||
+		die "could not inspect the immutable Codex pin guard"
+	test -n "$ruleset_ids" ||
+		die "pre-v3 bootstrap requires active immutable Codex pin guard"
+	test "$(printf '%s\n' "$ruleset_ids" | sed '/^$/d' |
+		wc -l | tr -d ' ')" = 1 ||
+		die "pre-v3 bootstrap found ambiguous immutable Codex pin guards"
+	ruleset_id=$(printf '%s\n' "$ruleset_ids" | sed -n '1p')
+	case "$ruleset_id" in
+	''|*[!0-9]*) die "immutable Codex pin guard has invalid ID '$ruleset_id'" ;;
+	esac
+	guard=$(gh api --hostname github.com \
+		"repos/openai/git/rulesets/$ruleset_id" --jq '
+			.name == "Keep Codex pins immutable" and
+			.target == "branch" and
+			.enforcement == "active" and
+			.conditions.ref_name.include ==
+				["refs/heads/codex-pins/*"] and
+			.conditions.ref_name.exclude == [] and
+			([.rules[].type] | sort) == ["deletion", "update"] and
+			([.rules[] | select(.type == "update") |
+				.parameters.update_allows_fetch_and_merge]) ==
+				[false] and
+			all((.bypass_actors // [])[];
+				.actor_type == "OrganizationAdmin")
+		') ||
+		die "could not verify the immutable Codex pin guard"
+	test "$guard" = true ||
+		die "pre-v3 bootstrap requires the checked-in immutable Codex pin guard"
+}
+
 remote_ref () {
 	printf 'refs/remotes/%s/%s\n' "$1" "$2"
 }
@@ -245,15 +319,22 @@ legacy_control_paths_unchanged () (
 		.github/CODEX.md \
 		.github/rulesets/codex-branch.json \
 		.github/rulesets/codex-meta.json \
+		.github/rulesets/codex-pins.json \
+		.github/rulesets/codex-pins-immutable.json \
+		.github/rulesets/codex-plan-branches.json \
 		.github/rulesets/codex-topics.json \
 		.github/rulesets/codex-unstable-branch.json \
 		.github/workflows/codex-admission.yml \
+		.github/workflows/codex-plan-admission.yml \
+		.github/workflows/codex-plan-propose.yml \
 		.github/workflows/codex-topic.yml \
 		.github/workflows/codex.yml \
 		.github/workflows/codex-branch.sh \
 		codex \
 		publish \
 		rebuild \
+		codex.plan \
+		codex-unstable.plan \
 		codex.config \
 		t/t9905-codex-branch.sh
 )
@@ -265,15 +346,22 @@ meta_control_paths_unchanged () (
 		.github/CODEX.md \
 		.github/rulesets/codex-branch.json \
 		.github/rulesets/codex-meta.json \
+		.github/rulesets/codex-pins.json \
+		.github/rulesets/codex-pins-immutable.json \
+		.github/rulesets/codex-plan-branches.json \
 		.github/rulesets/codex-topics.json \
 		.github/rulesets/codex-unstable-branch.json \
 		.github/workflows/codex-admission.yml \
+		.github/workflows/codex-plan-admission.yml \
+		.github/workflows/codex-plan-propose.yml \
 		.github/workflows/codex-topic.yml \
 		.github/workflows/codex-branch.sh \
 		.github/workflows/main.yml \
 		codex \
 		publish \
 		rebuild \
+		codex.plan \
+		codex-unstable.plan \
 		codex.config \
 		t/t9905-codex-branch.sh &&
 	git diff --quiet "$base_oid" "$head_oid" -- \
@@ -285,54 +373,193 @@ meta_control_paths_unchanged () (
 
 write_automation_workflow () {
 	cat <<-'EOF'
-	name: Refresh codex
+name: Refresh codex
 
-	on:
-	  workflow_dispatch:
-	  pull_request:
-	    branches:
-	      - codex
-	      - codex-unstable
-	    types:
-	      - opened
-	      - reopened
-	      - synchronize
-	      - ready_for_review
-	  merge_group:
-	    types:
-	      - checks_requested
+on:
+  workflow_dispatch:
+    inputs:
+      operation:
+        description: Refresh, remove, reorder, or internal topic review
+        type: choice
+        options:
+          - refresh
+          - remove
+          - reorder
+          - topic-review
+        default: refresh
+      lane:
+        description: codex or codex-unstable for a plan operation
+        required: false
+        type: string
+      topic:
+        description: Exact topic branch for a plan operation
+        required: false
+        type: string
+      source_tip:
+        description: Exact reviewed source SHA for internal topic review
+        required: false
+        type: string
+      review_pr:
+        description: Topic PR number for internal topic review
+        required: false
+        type: string
+      after:
+        description: Existing topic or root for reorder
+        required: false
+        type: string
+      plan_branch:
+        description: Optional codex-plan/* branch name
+        required: false
+        type: string
+  pull_request_review:
+    types:
+      - submitted
+  pull_request_target:
+    branches:
+      - meta
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
 
-	permissions:
-	  actions: read
-	  contents: read
-	  pull-requests: read
+permissions:
+  actions: read
+  contents: read
+  pull-requests: read
 
-	jobs:
-	  refresh:
-	    if: github.event_name == 'workflow_dispatch'
-	    uses: openai/git/.github/workflows/codex.yml@meta
-	  admission:
-	    name: Codex admission
-	    if: >-
-	      (github.event_name == 'pull_request' &&
-	       github.event.pull_request.base.ref == 'codex') ||
-	      (github.event_name == 'merge_group' &&
-	       github.event.merge_group.base_ref == 'refs/heads/codex')
-	    permissions:
-	      contents: read
-	      pull-requests: read
-	    uses: openai/git/.github/workflows/codex-admission.yml@meta
-	  unstable_admission:
-	    name: Codex unstable admission
-	    if: >-
-	      (github.event_name == 'pull_request' &&
-	       github.event.pull_request.base.ref == 'codex-unstable') ||
-	      (github.event_name == 'merge_group' &&
-	       github.event.merge_group.base_ref == 'refs/heads/codex-unstable')
-	    permissions:
-	      contents: read
-	      pull-requests: read
-	    uses: openai/git/.github/workflows/codex-admission.yml@meta
+jobs:
+  refresh:
+    if: >-
+      github.event_name == 'workflow_dispatch' &&
+      inputs.operation == 'refresh'
+    uses: openai/git/.github/workflows/codex.yml@meta
+  topic_plan_dispatch:
+    name: Queue reviewed topic plan
+    if: >-
+      github.event_name == 'pull_request_review' &&
+      github.event.review.state == 'approved' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      (github.event.pull_request.base.ref == 'codex' ||
+       github.event.pull_request.base.ref == 'codex-unstable')
+    runs-on: ubuntu-24.04
+    permissions:
+      actions: write
+      contents: read
+    env:
+      GH_TOKEN: ${{ github.token }}
+      DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+      LANE: ${{ github.event.pull_request.base.ref }}
+      TOPIC: ${{ github.event.pull_request.head.ref }}
+      SOURCE_TIP: ${{ github.event.pull_request.head.sha }}
+      REVIEW_PR: ${{ github.event.pull_request.number }}
+    steps:
+      - name: Queue trusted plan proposal
+        run: |
+          set -euo pipefail
+          test "$GITHUB_REPOSITORY" = openai/git
+          test "$DEFAULT_BRANCH" = codex
+          gh workflow run codex.yml --repo "$GITHUB_REPOSITORY" \
+            --ref "$DEFAULT_BRANCH" \
+            -f operation=topic-review \
+            -f lane="$LANE" \
+            -f topic="$TOPIC" \
+            -f source_tip="$SOURCE_TIP" \
+            -f review_pr="$REVIEW_PR"
+  topic_plan_propose:
+    name: Propose reviewed topic plan
+    if: >-
+      github.event_name == 'workflow_dispatch' &&
+      github.ref == 'refs/heads/codex' &&
+      inputs.operation == 'topic-review'
+    permissions:
+      contents: read
+      pull-requests: read
+    uses: openai/git/.github/workflows/codex-plan-propose.yml@meta
+    with:
+      lane: ${{ inputs.lane }}
+      topic: ${{ inputs.topic }}
+      action: auto
+      source_tip: ${{ inputs.source_tip }}
+      review_pr: ${{ inputs.review_pr }}
+  policy_plan_propose:
+    name: Propose explicit plan policy
+    if: >-
+      github.event_name == 'workflow_dispatch' &&
+      github.ref == 'refs/heads/codex' &&
+      (inputs.operation == 'remove' || inputs.operation == 'reorder')
+    permissions:
+      contents: read
+      pull-requests: read
+    uses: openai/git/.github/workflows/codex-plan-propose.yml@meta
+    with:
+      lane: ${{ inputs.lane }}
+      topic: ${{ inputs.topic }}
+      action: ${{ inputs.operation }}
+      after: ${{ inputs.after }}
+      plan_branch: ${{ inputs.plan_branch }}
+  plan_admission:
+    name: Codex plan admission
+    if: >-
+      github.event_name == 'pull_request_target' &&
+      github.event.pull_request.base.ref == 'meta'
+    permissions:
+      contents: read
+      pull-requests: write
+    uses: openai/git/.github/workflows/codex-plan-admission.yml@meta
+	EOF
+}
+
+write_previous_automation_workflow () {
+	cat <<-'EOF'
+name: Refresh codex
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - codex
+      - codex-unstable
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+  merge_group:
+    types:
+      - checks_requested
+
+permissions:
+  actions: read
+  contents: read
+  pull-requests: read
+
+jobs:
+  refresh:
+    if: github.event_name == 'workflow_dispatch'
+    uses: openai/git/.github/workflows/codex.yml@meta
+  admission:
+    name: Codex admission
+    if: >-
+      (github.event_name == 'pull_request' &&
+       github.event.pull_request.base.ref == 'codex') ||
+      (github.event_name == 'merge_group' &&
+       github.event.merge_group.base_ref == 'refs/heads/codex')
+    permissions:
+      contents: read
+      pull-requests: read
+    uses: openai/git/.github/workflows/codex-admission.yml@meta
+  unstable_admission:
+    name: Codex unstable admission
+    if: >-
+      (github.event_name == 'pull_request' &&
+       github.event.pull_request.base.ref == 'codex-unstable') ||
+      (github.event_name == 'merge_group' &&
+       github.event.merge_group.base_ref == 'refs/heads/codex-unstable')
+    permissions:
+      contents: read
+      pull-requests: read
+    uses: openai/git/.github/workflows/codex-admission.yml@meta
 	EOF
 }
 
@@ -402,6 +629,12 @@ automation_workflow_is_current () {
 automation_workflow_is_reviewed () {
 	head_oid=$1
 	if automation_workflow_is_current "$head_oid"
+	then
+		return 0
+	fi
+	write_previous_automation_workflow >"$tmp_dir/expected-automation.yml"
+	if cmp -s "$tmp_dir/expected-automation.yml" \
+		"$tmp_dir/actual-automation.yml"
 	then
 		return 0
 	fi
@@ -936,9 +1169,13 @@ write_input_snapshot () (
 	unstable_oid=${1:-}
 	unstable_admission=${2:-}
 	lane_mode=${3:-}
+	plan_blob=${4:-}
+	unstable_plan_blob=${5:-}
 
 	{
 		printf 'controller\trefs/heads/meta\t%s\n' "$controller_oid"
+		test -z "$plan_blob" ||
+			printf 'plan\t%s\t%s\n' "$stable_plan_path" "$plan_blob"
 		printf 'base\trefs/heads/%s\t%s\n' "$base_name" "$base_oid"
 		printf 'codex\trefs/heads/%s\t%s\n' "$codex_name" "$codex_oid"
 		if test -n "$lane_mode"
@@ -951,6 +1188,9 @@ write_input_snapshot () (
 			printf 'unstable\trefs/heads/codex-unstable\t%s\n' \
 				"$unstable_oid"
 		fi
+		test -z "$unstable_plan_blob" ||
+			printf 'unstable-plan\t%s\t%s\n' \
+				"$unstable_plan_path" "$unstable_plan_blob"
 		if test -s "$admission"
 		then
 			IFS="$tab" read -r name oid number merge <"$admission" ||
@@ -976,6 +1216,19 @@ write_input_snapshot () (
 				printf 'unstable-topic\trefs/heads/%s\t%s\n' \
 					"$name" "$oid"
 			done <"$unstable_topics"
+		fi
+		if test -n "$plan_blob"
+		then
+			{
+				cut -f2 "$topics"
+				test -z "$unstable_topics" ||
+					cut -f2 "$unstable_topics"
+			} | LC_ALL=C sort -u |
+			while IFS= read -r oid
+			do
+				pin_ref=$(pin_ref_for_tip "$oid")
+				printf 'pin\t%s\t%s\n' "$pin_ref" "$oid"
+			done
 		fi
 	} >"$output"
 )
@@ -1006,8 +1259,62 @@ snapshot_inputs () {
 		published_state=$topics_output.published-state
 		mkdir -p "$published_state" ||
 			die "could not prepare published Codex membership"
-		read_meta_config "$controller_oid" "$base_name" "$codex_name" \
+	read_meta_config "$controller_oid" "$base_name" "$codex_name" \
 			"$published_state"
+	fi
+	if test -n "$published_state" &&
+		{ test "$(state_value "$published_state" config-version)" = 3 ||
+			git cat-file -e "$controller_oid:$stable_plan_path" \
+				2>/dev/null; }
+	then
+		test -z "$lane_mode" ||
+			die "pinned plans control whether codex-unstable is enabled"
+		published_codex=$(state_value "$published_state" published-codex-oid)
+		test "$codex_oid" = "$published_codex" ||
+			die "generated codex moved outside its published pinned-plan output"
+		plan_state=$topics_output.plan-state
+		legacy_sources=
+		if test "$(state_value "$published_state" config-version)" != 3
+		then
+			legacy_sources=$published_state/published-source-topics
+		fi
+		read_lane_plan "$controller_oid" codex "$base_name" "$base_oid" \
+			"$remote" "$topics_output" "$plan_state" "$legacy_sources"
+		plan_blob=$(state_value "$plan_state" plan-blob)
+		unstable_topics=
+		unstable_oid=
+		unstable_plan_blob=
+		if test -f "$published_state/published-unstable-oid"
+		then
+			unstable_oid=$(git rev-parse --verify \
+				"$(remote_ref "$remote" codex-unstable)^{commit}" \
+				2>/dev/null || :)
+			test -n "$unstable_oid" ||
+				die "$meta_config_path records codex-unstable, but its output disappeared"
+			test "$unstable_oid" = \
+				"$(state_value "$published_state" published-unstable-oid)" ||
+				die "generated codex-unstable moved outside its published pinned-plan output"
+			unstable_topics=$topics_output.unstable
+			unstable_plan_state=$topics_output.unstable-plan-state
+			git cat-file -e "$controller_oid:$unstable_plan_path" \
+				2>/dev/null ||
+				die "pinned-plan migration must add $unstable_plan_path"
+			legacy_unstable_sources=
+			if test "$(state_value "$published_state" config-version)" != 3
+			then
+				legacy_unstable_sources=$published_state/published-unstable-source-topics
+			fi
+			read_lane_plan "$controller_oid" codex-unstable codex \
+				"$codex_oid" "$remote" "$unstable_topics" \
+				"$unstable_plan_state" "$legacy_unstable_sources"
+			unstable_plan_blob=$(state_value "$unstable_plan_state" \
+				plan-blob)
+		fi
+		write_input_snapshot "$controller_oid" "$base_name" "$base_oid" \
+			"$codex_name" "$codex_oid" "$topics_output" "$output" \
+			"$topics_output.admission" "$unstable_topics" "$unstable_oid" \
+			"" "" "$plan_blob" "$unstable_plan_blob"
+		return
 	fi
 	collect_topics "$remote" "$topics_output" "$published_state" \
 		"$codex_oid" "$base_oid"
@@ -1217,14 +1524,654 @@ write_meta_config () (
 	test -z "$unstable_rows" || rm -f "$output.rows"
 )
 
+write_meta_config_v3 () (
+	base_name=$1
+	base_oid=$2
+	codex_name=$3
+	codex_oid=$4
+	rows=$5
+	output=$6
+	applied_plan=$7
+	unstable_rows=${8:-}
+	unstable_base=${9:-}
+	unstable_output=${10:-}
+	unstable_applied_plan=${11:-}
+
+	{
+		printf '[codex]\n'
+		printf '\tversion = 3\n'
+		printf '\tbase-ref = refs/heads/%s\n' "$base_name"
+		printf '\tbase-tip = %s\n' "$base_oid"
+		printf '\toutput-ref = refs/heads/%s\n' "$codex_name"
+		printf '\toutput-tip = %s\n' "$codex_oid"
+		printf '\tapplied-plan = %s\n' "$applied_plan"
+		if test -n "$unstable_applied_plan"
+		then
+			printf '\n[codex-unstable]\n'
+			printf '\tbase-ref = refs/heads/%s\n' "$codex_name"
+			printf '\tbase-tip = %s\n' "$unstable_base"
+			printf '\toutput-ref = refs/heads/codex-unstable\n'
+			printf '\toutput-tip = %s\n' "$unstable_output"
+			printf '\tapplied-plan = %s\n' "$unstable_applied_plan"
+			cat "$rows" "$unstable_rows" | LC_ALL=C sort \
+				>"$output.rows" ||
+				die "could not sort stable and unstable topic state"
+			rows=$output.rows
+		fi
+		while IFS="$tab" read -r name source_tip codex_tip prerequisites
+		do
+			quoted=$(config_subsection_quote "$name")
+			printf '\n[branch "%s"]\n' "$quoted"
+			printf '\tremote = .\n'
+			printf '\tsource-ref = refs/heads/%s\n' "$name"
+			printf '\tsource-tip = %s\n' "$source_tip"
+			for prerequisite in $prerequisites
+			do
+				printf '\tmerge = refs/heads/%s\n' "$prerequisite"
+			done
+			printf '\tcodex-tip = %s\n' "$codex_tip"
+		done <"$rows"
+	} >"$output" || die "could not write $meta_config_path"
+	test -z "$unstable_applied_plan" || rm -f "$output.rows"
+)
+
+read_meta_config_v3 () (
+	controller_oid=$1
+	base_name=$2
+	codex_name=$3
+	state=$4
+	config=$state/published-config
+	rows=$state/published-topics
+	source_rows=$state/published-source-topics
+	unstable_rows=$state/published-unstable-topics
+	unstable_source_rows=$state/published-unstable-source-topics
+
+	base_ref=$(config_get_one "$config" codex.base-ref)
+	base_tip=$(config_get_one "$config" codex.base-tip)
+	output_ref=$(config_get_one "$config" codex.output-ref)
+	output_tip=$(config_get_one "$config" codex.output-tip)
+	applied_plan=$(config_get_one "$config" codex.applied-plan)
+	test "$base_ref" = "refs/heads/$base_name" ||
+		die "$meta_config_path records base '$base_ref', not refs/heads/$base_name"
+	test "$output_ref" = "refs/heads/$codex_name" ||
+		die "$meta_config_path records output '$output_ref', not refs/heads/$codex_name"
+	require_full_commit_oid "$base_tip"
+	require_full_commit_oid "$output_tip"
+	require_full_blob_oid "$applied_plan"
+	unstable_enabled=
+	if git config --no-includes --file "$config" \
+		--get codex-unstable.output-tip >/dev/null 2>&1
+	then
+		unstable_enabled=t
+		unstable_base_ref=$(config_get_one "$config" \
+			codex-unstable.base-ref)
+		unstable_base_tip=$(config_get_one "$config" \
+			codex-unstable.base-tip)
+		unstable_output_ref=$(config_get_one "$config" \
+			codex-unstable.output-ref)
+		unstable_output_tip=$(config_get_one "$config" \
+			codex-unstable.output-tip)
+		unstable_applied_plan=$(config_get_one "$config" \
+			codex-unstable.applied-plan)
+		test "$unstable_base_ref" = "refs/heads/$codex_name" ||
+			die "$meta_config_path records unstable base '$unstable_base_ref', not refs/heads/$codex_name"
+		test "$unstable_output_ref" = refs/heads/codex-unstable ||
+			die "$meta_config_path records invalid unstable output '$unstable_output_ref'"
+		require_full_commit_oid "$unstable_base_tip"
+		require_full_commit_oid "$unstable_output_tip"
+		require_full_blob_oid "$unstable_applied_plan"
+		test "$unstable_base_tip" = "$output_tip" ||
+			die "$meta_config_path unstable base does not match its published codex output"
+		git merge-base --is-ancestor "$unstable_base_tip" \
+			"$unstable_output_tip" ||
+			die "$meta_config_path unstable output is not based on codex"
+		test "$unstable_base_tip" != "$unstable_output_tip" ||
+			die "$meta_config_path unstable output is not strictly ahead of codex"
+	fi
+
+	: >"$rows"
+	: >"$source_rows"
+	: >"$unstable_rows"
+	: >"$unstable_source_rows"
+	git config --no-includes --file "$config" --get-regexp \
+		'^branch\..*\.codex-tip$' >"$state/published-tip-keys" || :
+	while IFS=' ' read -r key codex_tip
+	do
+		name=${key#branch.}
+		name=${name%.codex-tip}
+		is_active_topic_name "$name" ||
+			die "$meta_config_path records invalid topic '$name'"
+		remote=$(config_get_one "$config" "branch.$name.remote")
+		test "$remote" = . ||
+			die "$meta_config_path gives '$name' non-local remote '$remote'"
+		source_ref=$(config_get_one "$config" "branch.$name.source-ref")
+		test "$source_ref" = "refs/heads/$name" ||
+			die "$meta_config_path gives '$name' invalid source '$source_ref'"
+		source_tip=$(config_get_one "$config" "branch.$name.source-tip")
+		require_full_commit_oid "$source_tip"
+		require_full_commit_oid "$codex_tip"
+		merges=$(git config --no-includes --file "$config" \
+			--get-all "branch.$name.merge" || :)
+		test -n "$merges" ||
+			die "$meta_config_path is missing 'branch.$name.merge'"
+		prerequisites=
+		for merge in $merges
+		do
+			case "$merge" in
+			"refs/heads/$base_name") prerequisite=$base_name ;;
+			"refs/heads/$codex_name") prerequisite=$codex_name ;;
+			refs/heads/*) prerequisite=${merge#refs/heads/} ;;
+			*) die "$meta_config_path gives '$name' invalid prerequisite '$merge'" ;;
+			esac
+			case " $prerequisites " in
+			*" $prerequisite "*)
+				die "$meta_config_path repeats prerequisite '$prerequisite' for '$name'"
+				;;
+			esac
+			prerequisites=${prerequisites:+$prerequisites }$prerequisite
+		done
+		if is_unstable_topic_name "$name"
+		then
+			test -n "$unstable_enabled" ||
+				die "$meta_config_path records unstable topic '$name' without an unstable lane"
+			for prerequisite in $prerequisites
+			do
+				if test "$prerequisite" != "$codex_name"
+				then
+					is_unstable_topic_name "$prerequisite" ||
+						die "$meta_config_path gives unstable topic '$name' invalid prerequisite '$prerequisite'"
+				fi
+			done
+			target_rows=$unstable_rows
+			target_source_rows=$unstable_source_rows
+		else
+			for prerequisite in $prerequisites
+			do
+				if test "$prerequisite" != "$base_name"
+				then
+					is_stable_topic_name "$prerequisite" ||
+						die "$meta_config_path gives '$name' invalid prerequisite '$prerequisite'"
+				fi
+			done
+			target_rows=$rows
+			target_source_rows=$source_rows
+		fi
+		printf '%s\t%s\t%s\n' "$name" "$codex_tip" "$prerequisites" \
+			>>"$target_rows" ||
+			die "could not read '$name' from $meta_config_path"
+		printf '%s\t%s\t%s\n' "$name" "$source_tip" "$prerequisites" \
+			>>"$target_source_rows" ||
+			die "could not read '$name' source from $meta_config_path"
+	done <"$state/published-tip-keys"
+	LC_ALL=C sort -o "$rows" "$rows"
+	LC_ALL=C sort -o "$source_rows" "$source_rows"
+	LC_ALL=C sort -o "$unstable_rows" "$unstable_rows"
+	LC_ALL=C sort -o "$unstable_source_rows" "$unstable_source_rows"
+
+	while IFS="$tab" read -r name codex_tip prerequisites
+	do
+		for prerequisite in $prerequisites
+		do
+			if test "$prerequisite" = "$base_name"
+			then
+				prerequisite_tip=$base_tip
+			else
+				prerequisite_tip=$(published_tip "$rows" "$prerequisite")
+				test -n "$prerequisite_tip" ||
+					die "$meta_config_path records missing prerequisite '$prerequisite' for '$name'"
+			fi
+			git merge-base --is-ancestor "$prerequisite_tip" "$codex_tip" ||
+				die "$meta_config_path boundary for '$name' is not in its published history"
+		done
+		git merge-base --is-ancestor "$codex_tip" "$output_tip" ||
+			die "$meta_config_path output does not contain published topic '$name'"
+	done <"$rows"
+	if test -n "$unstable_enabled"
+	then
+		if ! test -s "$unstable_rows"
+		then
+			unstable_sentinel_is_canonical "$unstable_base_tip" \
+				"$unstable_output_tip" ||
+				die "$meta_config_path empty unstable output is not its canonical sentinel"
+		fi
+		while IFS="$tab" read -r name codex_tip prerequisites
+		do
+			for prerequisite in $prerequisites
+			do
+				if test "$prerequisite" = "$codex_name"
+				then
+					prerequisite_tip=$unstable_base_tip
+				else
+					prerequisite_tip=$(published_tip "$unstable_rows" \
+						"$prerequisite")
+					test -n "$prerequisite_tip" ||
+						die "$meta_config_path records missing unstable prerequisite '$prerequisite' for '$name'"
+				fi
+				git merge-base --is-ancestor "$prerequisite_tip" "$codex_tip" ||
+					die "$meta_config_path boundary for unstable topic '$name' is not in its published history"
+			done
+			git merge-base --is-ancestor "$codex_tip" "$unstable_output_tip" ||
+				die "$meta_config_path output does not contain published unstable topic '$name'"
+		done <"$unstable_rows"
+	fi
+	git merge-base --is-ancestor "$base_tip" "$output_tip" ||
+		die "$meta_config_path output is not based on its recorded base"
+
+	: >"$state/canonical-v3-rows"
+	while IFS="$tab" read -r name codex_tip prerequisites
+	do
+		source_tip=$(published_tip "$source_rows" "$name")
+		printf '%s\t%s\t%s\t%s\n' "$name" "$source_tip" \
+			"$codex_tip" "$prerequisites" >>"$state/canonical-v3-rows"
+	done <"$rows"
+	: >"$state/canonical-v3-unstable-rows"
+	while IFS="$tab" read -r name codex_tip prerequisites
+	do
+		source_tip=$(published_tip "$unstable_source_rows" "$name")
+		printf '%s\t%s\t%s\t%s\n' "$name" "$source_tip" \
+			"$codex_tip" "$prerequisites" \
+			>>"$state/canonical-v3-unstable-rows"
+	done <"$unstable_rows"
+	if test -n "$unstable_enabled"
+	then
+		write_meta_config_v3 "$base_name" "$base_tip" "$codex_name" \
+			"$output_tip" "$state/canonical-v3-rows" \
+			"$state/canonical-published-config" "$applied_plan" \
+			"$state/canonical-v3-unstable-rows" \
+			"$unstable_base_tip" "$unstable_output_tip" \
+			"$unstable_applied_plan"
+	else
+		write_meta_config_v3 "$base_name" "$base_tip" "$codex_name" \
+			"$output_tip" "$state/canonical-v3-rows" \
+			"$state/canonical-published-config" "$applied_plan"
+	fi
+	if ! cmp -s "$config" "$state/canonical-published-config"
+	then
+		diff -u "$config" "$state/canonical-published-config" >&2 || :
+		die "$meta_config_path is not in canonical form"
+	fi
+	printf '%s\n' 3 >"$state/config-version"
+	printf '%s\n' "$base_tip" >"$state/published-base-oid"
+	printf '%s\n' "$output_tip" >"$state/published-codex-oid"
+	printf '%s\n' "$applied_plan" >"$state/published-plan-blob"
+	if test -n "$unstable_enabled"
+	then
+		printf '%s\n' "$unstable_base_tip" \
+			>"$state/published-unstable-base-oid"
+		printf '%s\n' "$unstable_output_tip" \
+			>"$state/published-unstable-oid"
+		printf '%s\n' "$unstable_applied_plan" \
+			>"$state/published-unstable-plan-blob"
+	fi
+)
+
 config_get_one () (
 	config=$1
 	key=$2
+	label=${3:-$meta_config_path}
 	values=$(git config --no-includes --file "$config" --get-all "$key" || :)
-	test -n "$values" || die "$meta_config_path is missing '$key'"
+	test -n "$values" || die "$label is missing '$key'"
 	test "$(printf '%s\n' "$values" | wc -l | tr -d ' ')" = 1 ||
-		die "$meta_config_path has more than one '$key'"
+		die "$label has more than one '$key'"
 	printf '%s\n' "$values"
+)
+
+write_lane_plan () (
+	lane=$1
+	base_name=$2
+	rows=$3
+	source_bases=$4
+	output=$5
+	path=$(plan_path_for_lane "$lane")
+
+	{
+		printf '[plan]\n'
+		printf '\tversion = 1\n'
+		printf '\tlane = %s\n' "$lane"
+		printf '\tbase-ref = refs/heads/%s\n' "$base_name"
+		while IFS="$tab" read -r name tip prerequisites
+		do
+			printf '\ttopic = refs/heads/%s\n' "$name"
+		done <"$rows"
+		while IFS="$tab" read -r name tip prerequisites
+		do
+			quoted=$(config_subsection_quote "$name")
+			printf '\n[branch "%s"]\n' "$quoted"
+			printf '\tremote = .\n'
+			printf '\tsource-ref = refs/heads/%s\n' "$name"
+			printf '\tsource-tip = %s\n' "$tip"
+			source_base=$(plan_source_base "$source_bases" "$name")
+			test -n "$source_base" ||
+				die "$path has no source boundary for '$name'"
+			require_full_commit_oid "$source_base"
+			printf '\tsource-base = %s\n' "$source_base"
+			for prerequisite in $prerequisites
+			do
+				printf '\tmerge = refs/heads/%s\n' "$prerequisite"
+			done
+		done <"$rows"
+	} >"$output" || die "could not write $path"
+)
+
+plan_tip () (
+	rows=$1
+	name=$2
+	awk -F '\t' -v name="$name" '$1 == name { value=$2 }
+		END { if (value != "") print value }' "$rows"
+)
+
+plan_prerequisites () (
+	rows=$1
+	name=$2
+	awk -F '\t' -v name="$name" '$1 == name { value=$3 }
+		END { if (value != "") print value }' "$rows"
+)
+
+plan_source_base () (
+	rows=$1
+	name=$2
+	awk -F '\t' -v name="$name" '$1 == name { value=$2 }
+		END { if (value != "") print value }' "$rows"
+)
+
+pinned_root_boundary () (
+	current_base=$1
+	published_base=$2
+	tip=$3
+	bases=$(git merge-base --all "$current_base" "$tip") ||
+		return 1
+	test -n "$bases" || return 1
+	test "$(printf '%s\n' "$bases" | wc -l | tr -d ' ')" = 1 ||
+		return 1
+	boundary=$(printf '%s\n' "$bases" | sed -n '1p')
+	git merge-base --is-ancestor "$published_base" "$boundary" ||
+		return 1
+	printf '%s\n' "$boundary"
+)
+
+select_nearest_plan_boundary () (
+	candidates=$1
+	tip=$2
+	selected_name=
+	selected_boundary=
+	while IFS="$tab" read -r name boundary
+	do
+		test -n "$name" && test -n "$boundary" || continue
+		git merge-base --is-ancestor "$boundary" "$tip" ||
+			continue
+		if test -z "$selected_boundary"
+		then
+			selected_name=$name
+			selected_boundary=$boundary
+			continue
+		fi
+		if test "$boundary" = "$selected_boundary"
+		then
+			test "$name" = "$selected_name" ||
+				die "pinned topic has two equally near prerequisites '$selected_name' and '$name'"
+			continue
+		fi
+		if git merge-base --is-ancestor "$selected_boundary" \
+			"$boundary"
+		then
+			selected_name=$name
+			selected_boundary=$boundary
+		elif git merge-base --is-ancestor "$boundary" \
+			"$selected_boundary"
+		then
+			:
+		else
+			die "pinned topic has incomparable prerequisites '$selected_name' and '$name'"
+		fi
+	done <"$candidates"
+	test -n "$selected_boundary" || return 1
+	printf '%s\t%s\n' "$selected_name" "$selected_boundary"
+)
+
+infer_added_plan_boundary () (
+	rows=$1
+	published_rows=$2
+	lane_base=$3
+	current_base=$4
+	published_base=$5
+	tip=$6
+	candidates=$tmp_dir/add-boundary-candidates
+	: >"$candidates"
+	if boundary=$(pinned_root_boundary "$current_base" \
+		"$published_base" "$tip")
+	then
+		printf '%s\t%s\n' "$lane_base" "$boundary" >>"$candidates"
+	fi
+	while IFS="$tab" read -r name source_tip prerequisites
+	do
+		printf '%s\t%s\n' "$name" "$source_tip" >>"$candidates"
+		generated_tip=$(published_tip "$published_rows" "$name")
+		test -z "$generated_tip" ||
+			printf '%s\t%s\n' "$name" "$generated_tip" \
+				>>"$candidates"
+	done <"$rows"
+	select_nearest_plan_boundary "$candidates" "$tip" ||
+		die "new pinned topic is not based on a unique lane boundary"
+)
+
+infer_altered_plan_boundary () (
+	rows=$1
+	source_bases=$2
+	published_rows=$3
+	lane_base=$4
+	current_base=$5
+	published_base=$6
+	topic=$7
+	prerequisite=$8
+	tip=$9
+	candidates=$tmp_dir/alter-boundary-candidates
+	: >"$candidates"
+	old_source_base=$(plan_source_base "$source_bases" "$topic")
+	test -z "$old_source_base" ||
+		printf '%s\t%s\n' "$prerequisite" "$old_source_base" \
+			>>"$candidates"
+	if test "$prerequisite" = "$lane_base"
+	then
+		if boundary=$(pinned_root_boundary "$current_base" \
+			"$published_base" "$tip")
+		then
+			printf '%s\t%s\n' "$prerequisite" "$boundary" \
+				>>"$candidates"
+		fi
+	else
+		parent_source=$(plan_tip "$rows" "$prerequisite")
+		test -z "$parent_source" ||
+			printf '%s\t%s\n' "$prerequisite" "$parent_source" \
+				>>"$candidates"
+		parent_generated=$(published_tip "$published_rows" \
+			"$prerequisite")
+		test -z "$parent_generated" ||
+			printf '%s\t%s\n' "$prerequisite" \
+				"$parent_generated" >>"$candidates"
+	fi
+	selected=$(select_nearest_plan_boundary "$candidates" "$tip") ||
+		die "altered pinned topic '$topic' is outside its reviewed prerequisite"
+	IFS="$tab" read -r selected_name boundary <<-EOF
+	$selected
+	EOF
+	test "$selected_name" = "$prerequisite" ||
+		die "altered pinned topic '$topic' changes prerequisite without a manifest review"
+	printf '%s\n' "$boundary"
+)
+
+read_lane_plan () (
+	controller_oid=$1
+	lane=$2
+	base_name=$3
+	source_base_oid=$4
+	remote=$5
+	output=$6
+	state=$7
+	legacy_sources=${8:-}
+	path=$(plan_path_for_lane "$lane")
+	config=$state/plan-config
+	rows=$state/desired-prerequisites
+	source_bases=$state/desired-source-bases
+	order=$state/desired-order
+	label=$path
+
+	mkdir -p "$state" || die "could not prepare $path state"
+	git show "$controller_oid:$path" >"$config" 2>/dev/null ||
+		die "meta has no $path"
+	version=$(config_get_one "$config" plan.version "$label")
+	test "$version" = 1 ||
+		die "$path has unsupported version '$version'"
+	actual_lane=$(config_get_one "$config" plan.lane "$label")
+	test "$actual_lane" = "$lane" ||
+		die "$path records lane '$actual_lane', not '$lane'"
+	base_ref=$(config_get_one "$config" plan.base-ref "$label")
+	test "$base_ref" = "refs/heads/$base_name" ||
+		die "$path records base '$base_ref', not refs/heads/$base_name"
+	plan_blob=$(git rev-parse "$controller_oid:$path" 2>/dev/null) ||
+		die "could not resolve $path"
+	require_full_blob_oid "$plan_blob"
+	printf '%s\n' "$plan_blob" >"$state/plan-blob"
+
+	: >"$output"
+	: >"$rows"
+	: >"$source_bases"
+	: >"$order"
+	git config --no-includes --file "$config" --get-all plan.topic \
+		>"$state/plan-topic-refs" || :
+	while IFS= read -r ref
+	do
+		case "$ref" in
+		refs/heads/*) name=${ref#refs/heads/} ;;
+		*) die "$path records invalid topic '$ref'" ;;
+		esac
+		case "$lane" in
+		codex)
+			is_stable_topic_name "$name" ||
+				die "$path records invalid production topic '$name'"
+			;;
+		codex-unstable)
+			is_unstable_topic_name "$name" ||
+				die "$path records invalid unstable topic '$name'"
+			;;
+		esac
+		if awk -F '\t' -v name="$name" '$1 == name { found=1 }
+			END { exit !found }' "$rows"
+		then
+			die "$path records topic '$name' more than once"
+		fi
+		topic_remote=$(config_get_one "$config" \
+			"branch.$name.remote" "$label")
+		test "$topic_remote" = . ||
+			die "$path gives '$name' non-local remote '$topic_remote'"
+		source_ref=$(config_get_one "$config" \
+			"branch.$name.source-ref" "$label")
+		test "$source_ref" = "refs/heads/$name" ||
+			die "$path gives '$name' source '$source_ref', not refs/heads/$name"
+		tip=$(config_get_one "$config" \
+			"branch.$name.source-tip" "$label")
+		require_full_commit_oid "$tip"
+		source_base=$(config_get_one "$config" \
+			"branch.$name.source-base" "$label")
+		require_full_commit_oid "$source_base"
+		merges=$(git config --no-includes --file "$config" \
+			--get-all "branch.$name.merge" || :)
+		test -n "$merges" ||
+			die "$path is missing 'branch.$name.merge'"
+		prerequisites=
+		for merge in $merges
+		do
+			case "$merge" in
+			"refs/heads/$base_name") prerequisite=$base_name ;;
+			refs/heads/*)
+				prerequisite=${merge#refs/heads/}
+				case "$lane" in
+				codex) is_stable_topic_name "$prerequisite" ;;
+				codex-unstable) is_unstable_topic_name "$prerequisite" ;;
+				esac ||
+					die "$path gives '$name' invalid prerequisite '$merge'"
+				;;
+			*) die "$path gives '$name' invalid prerequisite '$merge'" ;;
+			esac
+			case " $prerequisites " in
+			*" $prerequisite "*)
+				die "$path repeats prerequisite '$prerequisite' for '$name'"
+				;;
+			esac
+			prerequisites=${prerequisites:+$prerequisites }$prerequisite
+		done
+		case " $prerequisites " in
+		*" $base_name "*)
+			test "$prerequisites" = "$base_name" ||
+				die "$path mixes $base_name with topic prerequisites for '$name'"
+			;;
+		esac
+		printf '%s\t%s\t%s\n' "$name" "$tip" "$prerequisites" \
+			>>"$rows" || die "could not read '$name' from $path"
+		printf '%s\t%s\n' "$name" "$source_base" \
+			>>"$source_bases" ||
+			die "could not read '$name' source boundary from $path"
+		printf '%s\t%s\n' "$name" "$tip" >>"$output" ||
+			die "could not pin '$name' from $path"
+		printf '%s\n' "$name" >>"$order" ||
+			die "could not retain $path order"
+	done <"$state/plan-topic-refs"
+
+	if test "$lane" = codex
+	then
+		test -s "$rows" || die "$path contains no production topics"
+	fi
+	git config --no-includes --file "$config" --get-regexp \
+		'^branch\..*\.source-tip$' >"$state/plan-tip-keys" || :
+	test "$(wc -l <"$state/plan-tip-keys" | tr -d ' ')" = \
+		"$(wc -l <"$rows" | tr -d ' ')" ||
+		die "$path has branch rows outside its ordered topic list"
+	while IFS=' ' read -r key unused_tip
+	do
+		name=${key#branch.}
+		name=${name%.source-tip}
+		awk -F '\t' -v name="$name" '$1 == name { found=1 }
+			END { exit !found }' "$rows" ||
+			die "$path has unlisted branch '$name'"
+	done <"$state/plan-tip-keys"
+
+	position=0
+	while IFS="$tab" read -r name tip prerequisites
+	do
+		position=$((position + 1))
+		for prerequisite in $prerequisites
+		do
+			if test "$prerequisite" = "$base_name"
+			then
+				# The plan pins reviewed topic inputs, not a moving
+				# lane base.  Root topics are replayed onto the
+				# current base during preparation.
+				continue
+			else
+				test -n "$(plan_tip "$rows" "$prerequisite")" ||
+					die "$path records missing prerequisite '$prerequisite' for '$name'"
+				prerequisite_position=$(awk -F '\t' \
+					-v name="$prerequisite" '$1 == name { print NR; exit }' \
+					"$rows")
+				test "$prerequisite_position" -lt "$position" ||
+					die "$path orders prerequisite '$prerequisite' after '$name'"
+			fi
+		done
+		if test "$remote" != -
+		then
+			pin_ref=$(pin_ref_for_tip "$tip")
+			pin_name=${pin_ref#refs/heads/}
+			pin_oid=$(git rev-parse --verify \
+				"$(remote_ref "$remote" "$pin_name")^{commit}" \
+				2>/dev/null) ||
+				die "$path has no immutable pin for '$name' at $tip"
+			test "$pin_oid" = "$tip" ||
+				die "$path immutable pin for '$name' does not name $tip"
+		fi
+	done <"$rows"
+	write_lane_plan "$lane" "$base_name" "$rows" "$source_bases" \
+		"$state/canonical-plan"
+	cmp -s "$config" "$state/canonical-plan" ||
+		die "$path is not in canonical form"
 )
 
 published_tip () (
@@ -1274,8 +2221,14 @@ read_meta_config () (
 	git show "$controller_oid:$meta_config_path" >"$config" 2>/dev/null ||
 		die "meta has no $meta_config_path; run Meta/codex initialize before refreshing"
 	version=$(config_get_one "$config" codex.version)
-	test "$version" = 1 || test "$version" = 2 ||
+	test "$version" = 1 || test "$version" = 2 || test "$version" = 3 ||
 		die "$meta_config_path has unsupported version '$version'"
+	if test "$version" = 3
+	then
+		read_meta_config_v3 "$controller_oid" "$base_name" \
+			"$codex_name" "$state"
+		return
+	fi
 	base_ref=$(config_get_one "$config" codex.base-ref)
 	base_tip=$(config_get_one "$config" codex.base-tip)
 	output_ref=$(config_get_one "$config" codex.output-ref)
@@ -1397,6 +2350,13 @@ read_meta_config () (
 	done <"$state/published-tip-keys"
 	LC_ALL=C sort -o "$rows" "$rows"
 	LC_ALL=C sort -o "$unstable_rows" "$unstable_rows"
+	# Version 1/2 rewrote topic refs in place, so the published
+	# generated boundary is also the only safe source boundary for a
+	# one-shot pinned-plan migration.
+	cp "$rows" "$state/published-source-topics" ||
+		die "could not retain legacy source boundaries"
+	cp "$unstable_rows" "$state/published-unstable-source-topics" ||
+		die "could not retain legacy unstable source boundaries"
 	test "$(cut -f1 "$rows" | sort -u | wc -l | tr -d ' ')" = \
 		"$(wc -l <"$rows" | tr -d ' ')" ||
 		die "$meta_config_path records a topic more than once"
@@ -2353,6 +3313,155 @@ prepare_stateful_plan () (
 	: >"$state/results"
 )
 
+prepare_pinned_plan () (
+	base_name=$1
+	base_oid=$2
+	topics=$3
+	state=$4
+	desired=$state/desired-prerequisites
+	desired_source_bases=$state/desired-source-bases
+	published=$state/published-topics
+	published_sources=$state/published-source-topics
+	published_base=$(state_value "$state" published-base-oid)
+	source_base=$(state_value "$state" source-base-oid)
+	plan=$state/plan
+
+	: >"$plan"
+	while IFS="$tab" read -r name current_tip
+	do
+		prerequisites=$(plan_prerequisites "$desired" "$name")
+		test -n "$prerequisites" ||
+			die "pinned plan has no prerequisite for '$name'"
+		reviewed_source_base=$(plan_source_base "$desired_source_bases" \
+			"$name")
+		test -n "$reviewed_source_base" ||
+			die "pinned plan has no source boundary for '$name'"
+		set -- $prerequisites
+		test $# = 1 ||
+			die "pinned plan topic '$name' has more than one prerequisite; split merge-shaped topics before enrolling them"
+		prerequisite=$1
+		if test "$prerequisite" = "$base_name"
+		then
+			desired_source_base=$source_base
+		else
+			desired_source_base=$(current_topic_tip "$topics" \
+				"$prerequisite")
+			test -n "$desired_source_base" ||
+				die "pinned plan topic '$name' has missing prerequisite '$prerequisite'"
+		fi
+		merge_commit=$(git rev-list --min-parents=2 \
+			"$reviewed_source_base..$current_tip" | sed -n '1p')
+		if test -n "$merge_commit"
+		then
+			# Keep a reviewed merge-shaped source byte-for-byte only when
+			# it already sits on the exact generated lane base.  Rebasing
+			# such a DAG needs the dedicated merge replay path; guessing a
+			# linear range would flatten reviewed topology.
+			if test "$reviewed_source_base" = "$base_oid" &&
+				git merge-base --is-ancestor "$base_oid" "$current_tip"
+			then
+				printf '%s\t%s\t%s\t%s\t%s\n' "$name" \
+					"$current_tip" "$prerequisite" "$base_oid" \
+					"$desired_source_base" >>"$plan" ||
+					die "could not record merge-shaped pinned topic '$name'"
+				continue
+			fi
+			die "pinned merge-shaped topic '$name' needs a base move; restack it explicitly before publication"
+		fi
+
+		published_generated=$(published_tip "$published" "$name")
+		published_source=$(published_tip "$published_sources" "$name")
+		if test -n "$published_generated"
+		then
+			test -n "$published_source" ||
+				die "$meta_config_path has no source boundary for '$name'"
+			old_prerequisites=$(published_prerequisites "$published" "$name")
+			set -- $old_prerequisites
+			test $# = 1 ||
+				die "$meta_config_path records merge-shaped topic '$name'; migrate it before using pinned plans"
+			old_prerequisite=$1
+			if test "$old_prerequisite" = "$base_name"
+			then
+				old_source_base=$published_base
+				old_generated_base=$published_base
+			else
+				old_source_base=$(published_tip "$published_sources" \
+					"$old_prerequisite")
+				old_generated_base=$(published_tip "$published" \
+					"$old_prerequisite")
+				test -n "$old_source_base" &&
+					test -n "$old_generated_base" ||
+					die "$meta_config_path has missing published prerequisite '$old_prerequisite' for '$name'"
+			fi
+
+			if test "$current_tip" = "$published_source" &&
+				test "$prerequisites" = "$old_prerequisites"
+			then
+				# The reviewed source did not change. Rebase the already
+				# generated topic only when its generated parent moves.
+				old=$published_generated
+				old_base=$old_generated_base
+				elif test "$prerequisites" = "$old_prerequisites"
+				then
+					old=$current_tip
+					if test "$desired_source_base" != "$old_source_base" &&
+					git merge-base --is-ancestor \
+						"$desired_source_base" "$current_tip"
+				then
+						# The author explicitly restacked onto the new
+						# prerequisite source tip.
+						old_base=$desired_source_base
+					elif test "$reviewed_source_base" != \
+						"$old_source_base" &&
+						git merge-base --is-ancestor \
+							"$reviewed_source_base" "$current_tip"
+					then
+						# The plan records the exact source boundary
+						# reviewed with this new tip.  It may be an
+						# older lane base if that base moved after
+						# the plan was admitted.
+						old_base=$reviewed_source_base
+					elif git merge-base --is-ancestor \
+					"$old_source_base" "$current_tip"
+				then
+					# Keep the old source boundary when a parent was
+					# rewritten but this child was not restacked.
+					old_base=$old_source_base
+				else
+					die "pinned topic '$name' is outside both its applied and desired source boundaries"
+				fi
+			else
+				old=$current_tip
+				git merge-base --is-ancestor "$reviewed_source_base" \
+					"$current_tip" ||
+					die "reordered topic '$name' is not based on its desired prerequisite '$prerequisite'"
+				old_base=$reviewed_source_base
+			fi
+		else
+			old=$current_tip
+			git merge-base --is-ancestor "$reviewed_source_base" \
+				"$current_tip" ||
+				die "new pinned topic '$name' is not based on its desired prerequisite '$prerequisite'"
+			old_base=$reviewed_source_base
+		fi
+		printf '%s\t%s\t%s\t%s\t%s\n' "$name" "$old" \
+			"$prerequisite" "$old_base" "$desired_source_base" \
+			>>"$plan" || die "could not record pinned rewrite for '$name'"
+	done <"$topics"
+
+	while IFS="$tab" read -r old_name old_tip old_prerequisite
+	do
+		current_topic_tip "$topics" "$old_name" >/dev/null && continue
+		if awk -F '\t' -v prerequisite="$old_name" \
+			'$3 == prerequisite { found=1 } END { exit !found }' "$plan"
+		then
+			die "pinned plan removes '$old_name' while an active topic still depends on it"
+		fi
+	done <"$published"
+	: >"$state/map"
+	: >"$state/results"
+)
+
 rebase_in_progress () {
 	worktree=$1
 	test -d "$(git -C "$worktree" rev-parse --path-format=absolute \
@@ -2547,6 +3656,13 @@ finish_updates () {
 	results=$state/results
 	updates=$state/topic-updates
 	: >"$updates" || die "could not prepare topic updates"
+	if test -f "$state/pinned-plan-mode"
+	then
+		# Topic refs are reviewed inputs, not generated outputs.  The
+		# App-owned codex-pins/<sha> ref retains the reviewed object; no
+		# mutable source ref participates in publication.
+		return
+	fi
 	while IFS="$tab" read -r name old
 	do
 		new=$(result_lookup "$results" "$name")
@@ -2594,6 +3710,76 @@ write_complete_updates () {
 write_next_meta_config () (
 	state=$1
 	candidate=$2
+	if test -f "$state/pinned-plan-mode"
+	then
+		rows=$state/next-published-topics
+		: >"$rows"
+		while IFS="$tab" read -r name source_tip
+		do
+			generated_tip=$(result_lookup "$state/results" "$name")
+			test -n "$generated_tip" ||
+				die "pinned topic '$name' has no generated tip"
+			prerequisites=$(plan_prerequisites \
+				"$state/desired-prerequisites" "$name")
+			test -n "$prerequisites" ||
+				die "pinned topic '$name' has no recorded prerequisite"
+			printf '%s\t%s\t%s\t%s\n' "$name" "$source_tip" \
+				"$generated_tip" "$prerequisites" >>"$rows" ||
+				die "could not record next pinned state for '$name'"
+		done <"$state/topics"
+		LC_ALL=C sort -o "$rows" "$rows"
+		unstable_rows=
+		unstable_plan_blob=
+		if test -f "$state/unstable-output-oid" &&
+			! is_null_oid "$(state_value "$state" unstable-output-oid)"
+		then
+			unstable_state=$state/unstable
+			unstable_rows=$state/next-published-unstable-topics
+			: >"$unstable_rows"
+			if test -d "$unstable_state" &&
+				test -f "$unstable_state/pinned-plan-mode"
+			then
+				while IFS="$tab" read -r name source_tip
+				do
+					generated_tip=$(result_lookup \
+						"$unstable_state/results" "$name")
+					test -n "$generated_tip" ||
+						die "pinned unstable topic '$name' has no generated tip"
+					prerequisites=$(plan_prerequisites \
+						"$unstable_state/desired-prerequisites" "$name")
+					test -n "$prerequisites" ||
+						die "pinned unstable topic '$name' has no recorded prerequisite"
+					printf '%s\t%s\t%s\t%s\n' "$name" \
+						"$source_tip" "$generated_tip" "$prerequisites" \
+						>>"$unstable_rows" ||
+						die "could not record next pinned unstable state for '$name'"
+				done <"$unstable_state/topics"
+				unstable_plan_blob=$(state_value "$unstable_state" \
+					plan-blob)
+			else
+				unstable_plan_blob=$(state_value \
+					"$state/desired-unstable-plan" plan-blob)
+			fi
+			LC_ALL=C sort -o "$unstable_rows" "$unstable_rows"
+		fi
+		if test -n "$unstable_plan_blob"
+		then
+			write_meta_config_v3 "$(state_value "$state" base-name)" \
+				"$(state_value "$state" base-oid)" \
+				"$(state_value "$state" codex-name)" "$candidate" \
+				"$rows" "$state/next-meta-config" \
+				"$(state_value "$state" plan-blob)" "$unstable_rows" \
+				"$candidate" "$(state_value "$state" unstable-output-oid)" \
+				"$unstable_plan_blob"
+		else
+			write_meta_config_v3 "$(state_value "$state" base-name)" \
+				"$(state_value "$state" base-oid)" \
+				"$(state_value "$state" codex-name)" "$candidate" \
+				"$rows" "$state/next-meta-config" \
+				"$(state_value "$state" plan-blob)"
+		fi
+		return
+	fi
 	rows=$state/next-published-topics
 	: >"$rows"
 	while IFS="$tab" read -r name old
@@ -3278,6 +4464,29 @@ write_integration_topics () {
 	plan=$state/integration-plan
 	ready=$state/integration-ready
 	merged=$state/integration-topics
+	if test -f "$state/pinned-plan-mode"
+	then
+		: >"$merged" || die "could not prepare the topic integration order"
+		while IFS= read -r name
+		do
+			plan_row=$(awk -F '\t' -v name="$name" \
+				'$1 == name { print; exit }' "$state/plan")
+			test -n "$plan_row" ||
+				die "pinned plan order names missing topic '$name'"
+			prerequisites=$(planned_prerequisites "$state" "$name")
+			for dependency in $prerequisites
+			do
+				test "$dependency" = "$base_name" && continue
+				integration_name_recorded "$merged" "$dependency" ||
+					die "pinned plan orders '$name' before prerequisite '$dependency'"
+			done
+			oid=$(result_lookup "$state/results" "$name")
+			test -n "$oid" || die "topic '$name' has no generated tip"
+			printf '%s\t%s\n' "$name" "$oid" >>"$merged" ||
+				die "could not retain pinned integration order"
+		done <"$state/desired-order"
+		return
+	fi
 	LC_ALL=C sort -t "$tab" -k1,1 "$state/plan" >"$plan" ||
 		die "could not sort topics for integration"
 	: >"$merged" || die "could not prepare the topic integration order"
@@ -3384,11 +4593,23 @@ assemble_candidate () {
 			die "could not record integration progress"
 	done <"$state/integration-topics"
 
-	while IFS="$tab" read -r ref old oid
-	do
-		git -C "$worktree" merge-base --is-ancestor "$oid" HEAD ||
-			die "candidate does not contain '$ref'"
-	done <"$state/topic-updates"
+	if test -f "$state/pinned-plan-mode"
+	then
+		while IFS="$tab" read -r name source_tip
+		do
+			oid=$(result_lookup "$state/results" "$name")
+			test -n "$oid" ||
+				die "pinned topic '$name' has no generated tip"
+			git -C "$worktree" merge-base --is-ancestor "$oid" HEAD ||
+				die "candidate does not contain generated topic '$name'"
+		done <"$state/topics"
+	else
+		while IFS="$tab" read -r ref old oid
+		do
+			git -C "$worktree" merge-base --is-ancestor "$oid" HEAD ||
+				die "candidate does not contain '$ref'"
+		done <"$state/topic-updates"
+	fi
 	candidate=$(git -C "$worktree" rev-parse HEAD) ||
 		die "could not resolve the codex candidate"
 	codex_has_expected_integrations "$state" "$candidate" ||
@@ -3535,6 +4756,50 @@ initialize_rewrite () {
 	printf '%s\n' "$script_path" >"$state/helper"
 
 	read_meta_config "$controller_oid" "$base_name" "$codex_name" "$state"
+	if awk -F '\t' '$1 == "plan" { found=1 } END { exit !found }' \
+		"$inputs"
+	then
+		plan_state=$state/desired-plan
+		read_lane_plan "$controller_oid" codex "$base_name" "$base_oid" \
+			- "$plan_state/topics" "$plan_state"
+		cmp -s "$state/topics" "$plan_state/topics" ||
+			die "input snapshot does not match the pinned production plan"
+			cp "$plan_state/desired-prerequisites" \
+				"$state/desired-prerequisites" ||
+				die "could not retain pinned production prerequisites"
+			cp "$plan_state/desired-source-bases" \
+				"$state/desired-source-bases" ||
+				die "could not retain pinned production source boundaries"
+		cp "$plan_state/desired-order" "$state/desired-order" ||
+			die "could not retain pinned production order"
+		cp "$plan_state/plan-blob" "$state/plan-blob" ||
+			die "could not retain pinned production plan"
+		: >"$state/pinned-plan-mode"
+		printf '%s\n' "$base_oid" >"$state/source-base-oid"
+		published_codex_oid=$(state_value "$state" published-codex-oid)
+		test "$codex_oid" = "$published_codex_oid" ||
+			die "generated codex moved outside its published pinned-plan output"
+		if test -f "$state/published-unstable-oid"
+		then
+			unstable_plan_state=$state/desired-unstable-plan
+			read_lane_plan "$controller_oid" codex-unstable codex \
+				"$codex_oid" - "$unstable_plan_state/topics" \
+				"$unstable_plan_state"
+			cmp -s "$state/unstable-topics" \
+				"$unstable_plan_state/topics" ||
+				die "input snapshot does not match the pinned unstable plan"
+		fi
+		validate_lane_isolation "$state" "$state/topics" \
+			"$state/unstable-topics" "$codex_oid"
+		prepare_pinned_plan "$base_name" "$base_oid" "$state/topics" \
+			"$state"
+		if test -n "$rerere_name" && test "$codex_oid" != "$base_oid" &&
+			git merge-base --is-ancestor "$base_oid" "$codex_oid"
+		then
+			train_rerere "$worktree" "$base_oid" "$codex_oid"
+		fi
+		return
+	fi
 	if test -s "$state/published-topics" && ! test -s "$state/topics"
 	then
 		die "all previously published production topics disappeared"
@@ -3588,11 +4853,16 @@ prepare_unstable_candidate () (
 				die "could not disable the empty codex-unstable output"
 			return 0
 		fi
-		if test "$version" = 1 && test "$mode" != enable
-		then
-			return 0
-		fi
-		test -n "$unstable_old" ||
+			if test "$version" = 1 && test "$mode" != enable
+			then
+				return 0
+			fi
+			if test "$version" = 3 &&
+				! test -f "$state/published-unstable-oid"
+			then
+				return 0
+			fi
+			test -n "$unstable_old" ||
 			die "the enabled codex-unstable output was not snapshotted"
 		mkdir -p "$state/unstable" ||
 			die "could not prepare empty codex-unstable state"
@@ -3649,7 +4919,34 @@ prepare_unstable_candidate () (
 	printf '%s\n' "$(state_value "$state" require-automation)" \
 		>"$unstable_state/require-automation"
 	printf '%s\n' "$script_path" >"$unstable_state/helper"
-	if test "$version" = 2
+	if test -f "$state/pinned-plan-mode"
+	then
+		plan_state=$state/desired-unstable-plan
+			cp "$plan_state/desired-prerequisites" \
+				"$unstable_state/desired-prerequisites" ||
+				die "could not retain pinned unstable prerequisites"
+			cp "$plan_state/desired-source-bases" \
+				"$unstable_state/desired-source-bases" ||
+				die "could not retain pinned unstable source boundaries"
+		cp "$plan_state/desired-order" "$unstable_state/desired-order" ||
+			die "could not retain pinned unstable order"
+		cp "$plan_state/plan-blob" "$unstable_state/plan-blob" ||
+			die "could not retain pinned unstable plan"
+		cp "$state/published-unstable-source-topics" \
+			"$unstable_state/published-source-topics" ||
+			die "could not retain published unstable source boundaries"
+		: >"$unstable_state/pinned-plan-mode"
+		# Raw unstable sources are reviewed against the published codex
+		# input.  The generated lane is reconstructed on the new stable
+		# candidate below.
+		printf '%s\n' "$(state_value "$state" codex-oid)" \
+			>"$unstable_state/source-base-oid"
+	fi
+	if test -f "$state/pinned-plan-mode"
+	then
+		published_base=$(state_value "$state" published-unstable-base-oid)
+		published_output=$(state_value "$state" published-unstable-oid)
+	elif test "$version" = 2
 	then
 		published_base=$(state_value "$state" published-unstable-base-oid)
 		published_output=$(state_value "$state" published-unstable-oid)
@@ -3663,8 +4960,14 @@ prepare_unstable_candidate () (
 		>"$unstable_state/published-base-oid"
 	printf '%s\n' "$published_output" \
 		>"$unstable_state/published-codex-oid"
-	prepare_stateful_plan codex "$stable_candidate" \
-		"$unstable_state/topics" "$unstable_state" unstable
+	if test -f "$unstable_state/pinned-plan-mode"
+	then
+		prepare_pinned_plan codex "$stable_candidate" \
+			"$unstable_state/topics" "$unstable_state"
+	else
+		prepare_stateful_plan codex "$stable_candidate" \
+			"$unstable_state/topics" "$unstable_state" unstable
+	fi
 	if ! process_planned_graph "$worktree" "$unstable_state"
 	then
 		if test -f "$unstable_state/merge-graph"
@@ -4068,10 +5371,20 @@ rewrite () {
 	codex_oid=$(state_value "$state" codex-oid)
 	contained=t
 	git merge-base --is-ancestor "$base_oid" "$codex_oid" || contained=
-	while IFS="$tab" read -r ref old new
-	do
-		git merge-base --is-ancestor "$new" "$codex_oid" || contained=
-	done <"$state/topic-updates"
+	if test -f "$state/pinned-plan-mode"
+	then
+		while IFS="$tab" read -r name source_tip
+		do
+			generated_tip=$(result_lookup "$state/results" "$name")
+			git merge-base --is-ancestor "$generated_tip" "$codex_oid" ||
+				contained=
+		done <"$state/topics"
+	else
+		while IFS="$tab" read -r ref old new
+		do
+			git merge-base --is-ancestor "$new" "$codex_oid" || contained=
+		done <"$state/topic-updates"
+	fi
 	if test -n "$contained" &&
 		test "$(git rev-parse "$candidate^{tree}")" = \
 		"$(git rev-parse "$codex_oid^{tree}")" &&
@@ -4140,14 +5453,1154 @@ verify_inputs () {
 	fi
 }
 
+plan_trailer_one () (
+	commit=$1
+	key=$2
+	label=$3
+	values=$(git show -s --format="%(trailers:key=$key,valueonly)" \
+		"$commit") ||
+		die "could not read $label from plan transition"
+	test -n "$values" ||
+		die "plan transition is missing $label"
+	test "$(printf '%s\n' "$values" | wc -l | tr -d ' ')" = 1 ||
+		die "plan transition repeats $label"
+	printf '%s\n' "$values"
+)
+
+plan_trailer_optional () (
+	commit=$1
+	key=$2
+	label=$3
+	values=$(git show -s --format="%(trailers:key=$key,valueonly)" \
+		"$commit") ||
+		die "could not read $label from plan transition"
+	test "$(printf '%s\n' "$values" | sed '/^$/d' | wc -l |
+		tr -d ' ')" -le 1 ||
+		die "plan transition repeats $label"
+	printf '%s\n' "$values" | sed -n '1p'
+)
+
+validate_topic_review () {
+	repository=openai/git
+	pull_number=
+	lane=
+	topic=
+	source_tip=
+	while test $# -gt 0
+	do
+		case "$1" in
+		--repository) require_arg "$@"; repository=$2; shift 2 ;;
+		--pull-request) require_arg "$@"; pull_number=$2; shift 2 ;;
+		--lane) require_arg "$@"; lane=$2; shift 2 ;;
+		--topic) require_arg "$@"; topic=$2; shift 2 ;;
+		--source-tip) require_arg "$@"; source_tip=$2; shift 2 ;;
+		*) die "unknown validate-topic-review option '$1'" ;;
+		esac
+	done
+	test "$repository" = openai/git ||
+		die "reviewed Codex topics must belong to openai/git"
+	case "$pull_number" in
+	''|*[!0-9]*) die "validate-topic-review needs a pull request number" ;;
+	esac
+	topic=${topic#refs/heads/}
+	case "$lane" in
+	codex)
+		is_stable_topic_name "$topic" ||
+			die "'$topic' is not a production Codex topic"
+		;;
+	codex-unstable)
+		is_unstable_topic_name "$topic" ||
+			die "'$topic' is not an unstable Codex topic"
+		;;
+	*) die "unknown Codex lane '$lane'" ;;
+	esac
+	require_full_commit_oid "$source_tip"
+	make_tmp_dir
+	gh api --hostname github.com \
+		"repos/$repository/pulls/$pull_number" \
+		--jq '[.state, (.draft | tostring), .base.ref,
+			(.head.repo.full_name // "-"), .head.ref, .head.sha,
+			(.user.login // "-")] | @tsv' >"$tmp_dir/topic-pr" ||
+		die "could not inspect reviewed topic pull request #$pull_number"
+	IFS="$tab" read -r state draft base head_repository head_ref \
+		head_sha author <"$tmp_dir/topic-pr" ||
+		die "could not parse reviewed topic pull request #$pull_number"
+	test "$state" = open ||
+		die "reviewed topic pull request #$pull_number is not open"
+	test "$draft" = false ||
+		die "reviewed topic pull request #$pull_number is draft"
+	test "$base" = "$lane" ||
+		die "reviewed topic pull request #$pull_number targets '$base', not '$lane'"
+	test "$head_repository" = "$repository" ||
+		die "reviewed topic pull request #$pull_number is not same-repository"
+	test "$head_ref" = "$topic" ||
+		die "reviewed topic pull request #$pull_number names '$head_ref', not '$topic'"
+	test "$head_sha" = "$source_tip" ||
+		die "reviewed topic pull request #$pull_number moved from $source_tip to $head_sha"
+	review_decision=$(gh pr view "$pull_number" --repo "$repository" \
+		--json reviewDecision --jq '.reviewDecision') ||
+		die "could not read review decision for topic pull request #$pull_number"
+	test "$review_decision" = APPROVED ||
+		die "topic pull request #$pull_number is not approved"
+	gh api --hostname github.com --paginate \
+		"repos/$repository/pulls/$pull_number/reviews?per_page=100" \
+		--jq '.[] | [.user.login, .state, (.commit_id // "-"),
+			.author_association] | @tsv' >"$tmp_dir/topic-reviews" ||
+		die "could not inspect reviews for topic pull request #$pull_number"
+	awk -F '\t' -v author="$author" -v head="$source_tip" '
+		NF == 4 && $2 ~ /^(APPROVED|CHANGES_REQUESTED|DISMISSED)$/ {
+			state[$1] = $2
+			commit[$1] = $3
+			association[$1] = $4
+		}
+		END {
+			for (reviewer in state)
+				if (reviewer != author &&
+					state[reviewer] == "APPROVED" &&
+					commit[reviewer] == head &&
+					association[reviewer] ~ /^(OWNER|MEMBER|COLLABORATOR)$/)
+					approved++
+			exit !approved
+		}
+	' "$tmp_dir/topic-reviews" ||
+		die "topic pull request #$pull_number has no current approval for $source_tip"
+	say "validated reviewed topic pull request #$pull_number at $source_tip"
+}
+
+validate_plan_transition () {
+	remote=origin
+	base_commit=
+	head_commit=
+	while test $# -gt 0
+	do
+		case "$1" in
+		--remote) require_arg "$@"; remote=$2; shift 2 ;;
+		--base-commit) require_arg "$@"; base_commit=$2; shift 2 ;;
+		--head-commit) require_arg "$@"; head_commit=$2; shift 2 ;;
+		*) die "unknown validate-plan-transition option '$1'" ;;
+		esac
+	done
+	test -n "$base_commit" && test -n "$head_commit" ||
+		die "validate-plan-transition requires --base-commit and --head-commit"
+	make_tmp_dir
+	require_full_repository
+	base_commit=$(resolve_commit "$base_commit")
+	head_commit=$(resolve_commit "$head_commit")
+	parents=$(git show -s --format=%P "$head_commit") ||
+		die "could not inspect plan transition head"
+	test "$parents" = "$base_commit" ||
+		die "plan transition head is not one direct child of its meta base"
+	git diff-tree --no-commit-id --name-only -r "$base_commit" \
+		"$head_commit" | LC_ALL=C sort >"$tmp_dir/changed-paths" ||
+		die "could not inspect plan transition paths"
+
+	git show "$base_commit:$meta_config_path" >"$tmp_dir/base-config" \
+		2>/dev/null ||
+		die "plan transition base has no $meta_config_path"
+	base_ref=$(config_get_one "$tmp_dir/base-config" codex.base-ref)
+	base_name=${base_ref#refs/heads/}
+	codex_ref=$(config_get_one "$tmp_dir/base-config" codex.output-ref)
+	codex_name=${codex_ref#refs/heads/}
+	mkdir -p "$tmp_dir/base-state" ||
+		die "could not prepare plan transition state"
+	read_meta_config "$base_commit" "$base_name" "$codex_name" \
+		"$tmp_dir/base-state"
+	version=$(state_value "$tmp_dir/base-state" config-version)
+	base_has_plan=
+	git cat-file -e "$base_commit:$stable_plan_path" 2>/dev/null &&
+		base_has_plan=t
+	if test -z "$base_has_plan"
+	then
+		test "$version" = 1 || test "$version" = 2 ||
+			die "only a v1/v2 controller may bootstrap pinned plans"
+		{
+			printf '%s\n' "$stable_plan_path"
+			if test -f "$tmp_dir/base-state/published-unstable-oid"
+			then
+				printf '%s\n' "$unstable_plan_path"
+			fi
+		} >"$tmp_dir/expected-paths"
+		LC_ALL=C sort -o "$tmp_dir/expected-paths" \
+			"$tmp_dir/expected-paths"
+	else
+		git cat-file -e "$base_commit:$unstable_plan_path" 2>/dev/null &&
+			base_has_unstable_plan=t || base_has_unstable_plan=
+		count=$(wc -l <"$tmp_dir/changed-paths" | tr -d ' ')
+		test "$count" = 1 ||
+			die "a normal plan transition must change exactly one lane plan"
+		case "$(sed -n '1p' "$tmp_dir/changed-paths")" in
+		"$stable_plan_path"|"$unstable_plan_path") ;;
+		*) die "a normal plan transition may change only one lane plan" ;;
+		esac
+		cp "$tmp_dir/changed-paths" "$tmp_dir/expected-paths"
+	fi
+	cmp -s "$tmp_dir/changed-paths" "$tmp_dir/expected-paths" ||
+		die "plan transition changes paths outside its pinned manifest"
+
+	base_oid=$(resolve_commit "$(remote_ref "$remote" "$base_name")")
+	codex_oid=$(resolve_commit "$(remote_ref "$remote" "$codex_name")")
+	legacy_sources=
+	legacy_unstable_sources=
+	if test -z "$base_has_plan"
+	then
+		legacy_sources=$tmp_dir/base-state/published-source-topics
+		legacy_unstable_sources=$tmp_dir/base-state/published-unstable-source-topics
+	fi
+	read_lane_plan "$head_commit" codex "$base_name" "$base_oid" \
+		"$remote" "$tmp_dir/head-topics" "$tmp_dir/head-plan" \
+		"$legacy_sources"
+	head_unstable_state=-
+	if test -f "$tmp_dir/base-state/published-unstable-oid"
+	then
+		read_lane_plan "$head_commit" codex-unstable "$codex_name" \
+			"$codex_oid" "$remote" "$tmp_dir/head-unstable-topics" \
+			"$tmp_dir/head-unstable-plan" "$legacy_unstable_sources"
+		head_unstable_state=$tmp_dir/head-unstable-plan
+	fi
+	validate_pinned_plan_policy "$tmp_dir/head-plan" \
+		"$head_unstable_state" "$base_name" "$version"
+
+	base_stable_rows=$tmp_dir/base-stable-rows
+	base_unstable_rows=$tmp_dir/base-unstable-rows
+	base_stable_source_bases=$tmp_dir/base-stable-source-bases
+	base_unstable_source_bases=$tmp_dir/base-unstable-source-bases
+	has_unstable=
+	if test -n "$base_has_plan"
+	then
+		read_lane_plan "$base_commit" codex "$base_name" "$base_oid" - \
+			"$tmp_dir/base-topics" "$tmp_dir/base-plan"
+		cp "$tmp_dir/base-plan/desired-prerequisites" \
+			"$base_stable_rows"
+		cp "$tmp_dir/base-plan/desired-source-bases" \
+			"$base_stable_source_bases"
+		if test -n "$base_has_unstable_plan"
+		then
+			has_unstable=t
+			read_lane_plan "$base_commit" codex-unstable "$codex_name" \
+				"$codex_oid" - "$tmp_dir/base-unstable-topics" \
+				"$tmp_dir/base-unstable-plan"
+			cp "$tmp_dir/base-unstable-plan/desired-prerequisites" \
+				"$base_unstable_rows"
+			cp "$tmp_dir/base-unstable-plan/desired-source-bases" \
+				"$base_unstable_source_bases"
+		fi
+	else
+		published_plan_rows "$tmp_dir/base-state" codex \
+			"$base_stable_rows"
+		published_source_base_rows "$tmp_dir/base-state" codex \
+			"$base_name" "$base_stable_source_bases"
+		if test -f "$tmp_dir/base-state/published-unstable-oid"
+		then
+			has_unstable=t
+			published_plan_rows "$tmp_dir/base-state" \
+				codex-unstable "$base_unstable_rows"
+			published_source_base_rows "$tmp_dir/base-state" \
+				codex-unstable "$codex_name" \
+				"$base_unstable_source_bases"
+		fi
+	fi
+
+	lane=$(plan_trailer_one "$head_commit" Codex-Plan-Lane \
+		"Codex-Plan-Lane")
+	action=$(plan_trailer_one "$head_commit" Codex-Plan-Action \
+		"Codex-Plan-Action")
+	topic=$(plan_trailer_one "$head_commit" Codex-Plan-Topic \
+		"Codex-Plan-Topic")
+	topic=${topic#refs/heads/}
+	source_tip=$(plan_trailer_optional "$head_commit" \
+		Codex-Plan-Source-Tip "Codex-Plan-Source-Tip")
+	source_base=$(plan_trailer_optional "$head_commit" \
+		Codex-Plan-Source-Base "Codex-Plan-Source-Base")
+	merge=$(plan_trailer_optional "$head_commit" Codex-Plan-Merge \
+		"Codex-Plan-Merge")
+	after=$(plan_trailer_optional "$head_commit" Codex-Plan-After \
+		"Codex-Plan-After")
+	review_pr=$(plan_trailer_optional "$head_commit" Codex-Plan-Review \
+		"Codex-Plan-Review")
+	bootstrap=$(plan_trailer_optional "$head_commit" Codex-Plan-Bootstrap \
+		"Codex-Plan-Bootstrap")
+	authorization=$(plan_trailer_optional "$head_commit" \
+		Codex-Plan-Authorization "Codex-Plan-Authorization")
+	merge=${merge#refs/heads/}
+	if test -n "$after" && test "$after" != root
+	then
+		after=${after#refs/heads/}
+	fi
+	case "$lane" in
+	codex)
+		is_stable_topic_name "$topic" ||
+			die "plan transition names invalid production topic '$topic'"
+		rows=$base_stable_rows
+		source_bases=$base_stable_source_bases
+		published_rows=$tmp_dir/base-state/published-topics
+		lane_root=$base_name
+		lane_root_oid=$base_oid
+		lane_published_base_oid=$(state_value "$tmp_dir/base-state" \
+			published-base-oid)
+		;;
+	codex-unstable)
+		test -n "$has_unstable" ||
+			die "plan transition names disabled codex-unstable lane"
+		is_unstable_topic_name "$topic" ||
+			die "plan transition names invalid unstable topic '$topic'"
+		rows=$base_unstable_rows
+		source_bases=$base_unstable_source_bases
+		published_rows=$tmp_dir/base-state/published-unstable-topics
+		lane_root=$codex_name
+		lane_root_oid=$codex_oid
+		lane_published_base_oid=$(state_value "$tmp_dir/base-state" \
+			published-unstable-base-oid)
+		;;
+	*) die "plan transition names unknown lane '$lane'" ;;
+	esac
+	current_prerequisites=$(plan_prerequisites "$rows" "$topic")
+	old_source_base=$(plan_source_base "$source_bases" "$topic")
+	if test -n "$bootstrap"
+	then
+		test "$bootstrap" = true && test -n "$authorization" &&
+			{ test "$version" = 1 || test "$version" = 2; } ||
+			die "plan bootstrap needs a v1/v2 base and explicit authorization"
+		test "$action" = alter ||
+			die "plan bootstrap may alter only an already-published topic"
+		if test -n "$base_has_plan"
+		then
+			test "$(plan_trailer_optional "$base_commit" \
+				Codex-Plan-Bootstrap "Codex-Plan-Bootstrap")" = true ||
+				die "plan bootstrap may continue only from an earlier bootstrap commit"
+		fi
+		test -z "$review_pr" ||
+			die "plan bootstrap cannot claim a topic review"
+	else
+		test -z "$authorization" ||
+			die "plan authorization appears without a bootstrap marker"
+	fi
+	case "$action" in
+	add|alter)
+		test -n "$source_tip" && test -n "$source_base" &&
+			test -n "$merge" &&
+			{ test -n "$review_pr" || test "$bootstrap" = true; } ||
+			die "plan transition '$action' needs source-tip, source-base, merge, and review or bootstrap trailers"
+		if test -n "$review_pr"
+		then
+			case "$review_pr" in
+			*[!0-9]*|'') die "plan transition has invalid review '$review_pr'" ;;
+			esac
+		fi
+		require_full_commit_oid "$source_tip"
+		require_full_commit_oid "$source_base"
+		if test "$action" = alter
+		then
+			test -z "$after" ||
+				die "plan transition alter cannot also reorder"
+		fi
+		;;
+	remove)
+		test -z "$source_tip" && test -z "$source_base" &&
+			test -z "$merge" &&
+			test -z "$after" && test -z "$review_pr" &&
+			test -z "$bootstrap" ||
+			die "plan transition remove has unexpected row trailers"
+		;;
+	reorder)
+		test -z "$source_tip" && test -z "$source_base" &&
+			test -z "$merge" &&
+			test -n "$after" && test -z "$review_pr" &&
+			test -z "$bootstrap" ||
+			die "plan transition reorder needs only an after trailer"
+		source_tip=$(plan_tip "$rows" "$topic")
+		merge=$(plan_prerequisites "$rows" "$topic")
+		source_base=$(plan_source_base "$source_bases" "$topic")
+		;;
+	*) die "plan transition names unknown action '$action'" ;;
+	esac
+	case "$action" in
+	add)
+		test -z "$current_prerequisites" ||
+			die "plan transition adds already-enrolled topic '$topic'"
+		test -z "$after" ||
+			die "bot-projected add may only append its inferred topic"
+		inferred=$(infer_added_plan_boundary "$rows" "$published_rows" \
+			"$lane_root" "$lane_root_oid" \
+			"$lane_published_base_oid" "$source_tip")
+		IFS="$tab" read -r inferred_merge inferred_source_base <<-EOF
+		$inferred
+		EOF
+		test "$merge" = "$inferred_merge" &&
+			test "$source_base" = "$inferred_source_base" ||
+			die "plan transition add is not the reviewed topic's inferred projection"
+		;;
+	alter)
+		test -n "$current_prerequisites" ||
+			die "plan transition alters missing topic '$topic'"
+		test "$merge" = "$current_prerequisites" ||
+			die "bot-projected alter may not change a topic prerequisite"
+		set -- $merge
+		test $# = 1 ||
+			die "bot-projected alter cannot change a merge-shaped topic"
+		inferred_source_base=$(infer_altered_plan_boundary "$rows" \
+			"$source_bases" "$published_rows" "$lane_root" \
+			"$lane_root_oid" "$lane_published_base_oid" "$topic" \
+			"$merge" "$source_tip")
+		test "$source_base" = "$inferred_source_base" ||
+			die "plan transition alter is not the reviewed topic's inferred projection"
+		;;
+	reorder)
+		test "$source_base" = "$old_source_base" ||
+			die "plan transition reorder changes the topic source boundary"
+		;;
+	remove) ;;
+	esac
+	if test "$action" != remove
+	then
+		git merge-base --is-ancestor "$source_base" "$source_tip" ||
+			die "plan transition source tip is outside its source boundary"
+	fi
+	test "$after" != "$topic" ||
+		die "plan transition orders '$topic' after itself"
+	cp "$base_stable_rows" "$tmp_dir/expected-stable-rows"
+	cp "$base_stable_source_bases" \
+		"$tmp_dir/expected-stable-source-bases"
+	if test -n "$has_unstable"
+	then
+		cp "$base_unstable_rows" "$tmp_dir/expected-unstable-rows"
+		cp "$base_unstable_source_bases" \
+			"$tmp_dir/expected-unstable-source-bases"
+	fi
+	if test "$lane" = codex
+	then
+		expected_rows=$tmp_dir/expected-stable-rows
+		expected_source_bases=$tmp_dir/expected-stable-source-bases
+	else
+		expected_rows=$tmp_dir/expected-unstable-rows
+		expected_source_bases=$tmp_dir/expected-unstable-source-bases
+	fi
+	replace_plan_row "$expected_rows" "$expected_rows.next" "$topic" \
+		"$source_tip" "$merge" "$action" "$after"
+	mv "$expected_rows.next" "$expected_rows"
+	replace_plan_source_base "$expected_source_bases" \
+		"$expected_source_bases.next" "$topic" "$source_base" \
+		"$action"
+	mv "$expected_source_bases.next" "$expected_source_bases"
+	write_lane_plan codex "$base_name" "$tmp_dir/expected-stable-rows" \
+		"$tmp_dir/expected-stable-source-bases" \
+		"$tmp_dir/expected-$stable_plan_path"
+	git show "$head_commit:$stable_plan_path" \
+		>"$tmp_dir/actual-$stable_plan_path" 2>/dev/null ||
+		die "plan transition head has no $stable_plan_path"
+	cmp -s "$tmp_dir/expected-$stable_plan_path" \
+		"$tmp_dir/actual-$stable_plan_path" ||
+		die "plan transition is not exactly one declared $action"
+	if test -n "$has_unstable"
+	then
+		write_lane_plan codex-unstable "$codex_name" \
+			"$tmp_dir/expected-unstable-rows" \
+			"$tmp_dir/expected-unstable-source-bases" \
+			"$tmp_dir/expected-$unstable_plan_path"
+		git show "$head_commit:$unstable_plan_path" \
+			>"$tmp_dir/actual-$unstable_plan_path" 2>/dev/null ||
+			die "plan transition head has no $unstable_plan_path"
+		cmp -s "$tmp_dir/expected-$unstable_plan_path" \
+			"$tmp_dir/actual-$unstable_plan_path" ||
+			die "plan transition is not exactly one declared $action"
+	fi
+	say "validated pinned plan transition $base_commit..$head_commit"
+}
+
+published_plan_rows () (
+	state=$1
+	lane=$2
+	output=$3
+	case "$lane" in
+	codex)
+		rows=$state/published-topics
+		base_oid=$(state_value "$state" published-base-oid)
+		output_oid=$(state_value "$state" published-codex-oid)
+		;;
+	codex-unstable)
+		rows=$state/published-unstable-topics
+		base_oid=$(state_value "$state" published-unstable-base-oid)
+		output_oid=$(state_value "$state" published-unstable-oid)
+		;;
+	*) die "unknown Codex lane '$lane'" ;;
+	esac
+	: >"$output"
+	git rev-list --first-parent --reverse "$base_oid..$output_oid" |
+	while IFS= read -r commit
+	do
+		marker=$(git show -s \
+			--format='%(trailers:key=Codex-Integration,valueonly)' \
+			"$commit") || exit 1
+		test -n "$marker" || continue
+		name=${marker%@*}
+		row=$(awk -F '\t' -v name="$name" '$1 == name {
+			print; exit
+		}' "$rows")
+		test -n "$row" || continue
+		IFS="$tab" read -r row_name tip prerequisites <<-EOF
+		$row
+		EOF
+		printf '%s\t%s\t%s\n' "$row_name" "$tip" "$prerequisites"
+	done >"$output"
+	test "$(wc -l <"$output" | tr -d ' ')" = \
+		"$(wc -l <"$rows" | tr -d ' ')" ||
+	die "could not recover the published $lane integration order"
+)
+
+published_source_base_rows () (
+	state=$1
+	lane=$2
+	root=$3
+	output=$4
+	case "$lane" in
+	codex)
+		rows=$state/published-topics
+		source_rows=$state/published-source-topics
+		root_tip=$(state_value "$state" published-base-oid)
+		;;
+	codex-unstable)
+		rows=$state/published-unstable-topics
+		source_rows=$state/published-unstable-source-topics
+		root_tip=$(state_value "$state" published-unstable-base-oid)
+		;;
+	*) die "unknown Codex lane '$lane'" ;;
+	esac
+	: >"$output"
+	while IFS="$tab" read -r name tip prerequisites
+	do
+		set -- $prerequisites
+		test $# = 1 ||
+			die "cannot recover source boundary for merge-shaped '$name'"
+		if test "$1" = "$root"
+		then
+			source_base=$root_tip
+		else
+			source_base=$(published_tip "$source_rows" "$1")
+			test -n "$source_base" ||
+				die "cannot recover source boundary for '$name'"
+		fi
+		printf '%s\t%s\n' "$name" "$source_base"
+	done <"$rows" >"$output"
+)
+
+replace_plan_row () (
+	input=$1
+	output=$2
+	topic=$3
+	tip=$4
+	prerequisites=$5
+	action=$6
+	after=${7:-}
+	case "$action" in
+	add)
+		! awk -F '\t' -v topic="$topic" '$1 == topic { found=1 }
+			END { exit !found }' "$input" ||
+			die "plan already contains '$topic'; use --action alter"
+		;;
+	alter|reorder)
+		awk -F '\t' -v topic="$topic" '$1 == topic { found=1 }
+			END { exit !found }' "$input" ||
+			die "plan does not contain '$topic'; use --action add"
+		;;
+	remove)
+		awk -F '\t' -v topic="$topic" '$1 == topic { found=1 }
+			END { exit !found }' "$input" ||
+			die "plan does not contain '$topic'"
+		;;
+	*) die "unknown plan action '$action'" ;;
+	esac
+	: >"$output.without"
+	while IFS="$tab" read -r name old_tip old_prerequisites
+	do
+		test "$name" = "$topic" && continue
+		printf '%s\t%s\t%s\n' "$name" "$old_tip" "$old_prerequisites" \
+			>>"$output.without"
+	done <"$input"
+	if test "$action" = remove
+	then
+		cp "$output.without" "$output"
+		rm -f "$output.without"
+		return
+	fi
+	row=$(printf '%s\t%s\t%s\n' "$topic" "$tip" "$prerequisites")
+	if test -z "$after"
+	then
+		if test "$action" = alter
+		then
+			: >"$output"
+			while IFS="$tab" read -r name old_tip old_prerequisites
+			do
+				if test "$name" = "$topic"
+				then
+					printf '%s\n' "$row" >>"$output"
+				else
+					printf '%s\t%s\t%s\n' "$name" "$old_tip" \
+						"$old_prerequisites" >>"$output"
+				fi
+			done <"$input"
+			rm -f "$output.without"
+			return
+		fi
+		cat "$output.without" >"$output"
+		printf '%s\n' "$row" >>"$output"
+		rm -f "$output.without"
+		return
+	fi
+	: >"$output"
+	inserted=
+	if test "$after" = root
+	then
+		printf '%s\n' "$row" >>"$output"
+		inserted=t
+	fi
+	while IFS="$tab" read -r name old_tip old_prerequisites
+	do
+		printf '%s\t%s\t%s\n' "$name" "$old_tip" "$old_prerequisites" \
+			>>"$output"
+		if test "$name" = "$after"
+		then
+			printf '%s\n' "$row" >>"$output"
+			inserted=t
+		fi
+	done <"$output.without"
+	test -n "$inserted" ||
+		die "plan has no --after topic '$after'"
+	rm -f "$output.without"
+)
+
+replace_plan_source_base () (
+	input=$1
+	output=$2
+	topic=$3
+	source_base=$4
+	action=$5
+	: >"$output"
+	while IFS="$tab" read -r name old_source_base
+	do
+		test "$name" = "$topic" && continue
+		printf '%s\t%s\n' "$name" "$old_source_base" >>"$output"
+	done <"$input"
+	if test "$action" != remove
+	then
+		test -n "$source_base" ||
+			die "plan action '$action' has no source boundary for '$topic'"
+		printf '%s\t%s\n' "$topic" "$source_base" >>"$output"
+	fi
+)
+
+propose_plan () {
+	remote=origin
+	lane=
+	topic=
+	source_tip=
+	review_pr=
+	merge=
+	after=
+	action=
+	plan_branch=
+	expected_meta=
+	bootstrap_authorization=
+	no_push=
+	while test $# -gt 0
+	do
+		case "$1" in
+		--remote) require_arg "$@"; remote=$2; shift 2 ;;
+		--lane) require_arg "$@"; lane=$2; shift 2 ;;
+		--topic) require_arg "$@"; topic=$2; shift 2 ;;
+		--source-tip) require_arg "$@"; source_tip=$2; shift 2 ;;
+		--review-pr) require_arg "$@"; review_pr=$2; shift 2 ;;
+		--merge) require_arg "$@"; merge=$2; shift 2 ;;
+		--after) require_arg "$@"; after=$2; shift 2 ;;
+		--action) require_arg "$@"; action=$2; shift 2 ;;
+		--expected-meta) require_arg "$@"; expected_meta=$2; shift 2 ;;
+		--plan-branch) require_arg "$@"; plan_branch=$2; shift 2 ;;
+		--bootstrap-authorization)
+			require_arg "$@"
+			bootstrap_authorization=$2
+			shift 2
+			;;
+		--no-push) no_push=t; shift ;;
+		*) die "unknown propose-plan option '$1'" ;;
+		esac
+	done
+	test -n "$lane" && test -n "$topic" && test -n "$action" ||
+		die "propose-plan requires --lane, --topic, and --action"
+	topic=${topic#refs/heads/}
+	case "$lane" in
+	codex)
+		is_stable_topic_name "$topic" ||
+			die "'$topic' is not a production Codex topic"
+		;;
+	codex-unstable)
+		is_unstable_topic_name "$topic" ||
+			die "'$topic' is not an unstable Codex topic"
+		;;
+	*) die "unknown Codex lane '$lane'" ;;
+	esac
+	case "$action" in
+	auto|add|alter|remove|reorder) ;;
+	*) die "unknown plan action '$action'" ;;
+	esac
+	case "$action" in
+	auto|add|alter)
+		if test -n "$bootstrap_authorization"
+		then
+			test "$action" != auto ||
+				die "pre-v3 bootstrap requires an explicit alter action"
+			test -z "$review_pr" ||
+				die "pre-v3 bootstrap does not accept --review-pr"
+		else
+			test -n "$review_pr" ||
+				die "--action $action requires --review-pr"
+			case "$review_pr" in
+			*[!0-9]*|'') die "--review-pr must be a pull request number" ;;
+			esac
+		fi
+		;;
+	remove|reorder)
+		test -z "$source_tip" && test -z "$review_pr" &&
+			test -z "$bootstrap_authorization" ||
+			die "--action $action does not accept source review or bootstrap options"
+		;;
+	esac
+	if test -n "$bootstrap_authorization"
+	then
+		test "$(printf '%s\n' "$bootstrap_authorization" | wc -l |
+			tr -d ' ')" = 1 ||
+			die "--bootstrap-authorization must be one line"
+	fi
+	case "$action" in
+	auto|add|alter)
+		test -z "$merge" && test -z "$after" ||
+			die "--action $action derives order and prerequisite from the reviewed topic"
+		;;
+	remove)
+		test -z "$merge" && test -z "$after" ||
+			die "--action remove does not accept --merge or --after"
+		;;
+	reorder)
+		test -z "$merge" ||
+			die "--action reorder does not accept --merge"
+		test -n "$after" ||
+			die "--action reorder requires --after"
+		;;
+	esac
+	if test -n "$merge"
+	then
+		merge=${merge#refs/heads/}
+	fi
+	if test -n "$after" && test "$after" != root
+	then
+		after=${after#refs/heads/}
+	fi
+	test "$after" != "$topic" ||
+		die "a topic cannot be ordered after itself"
+
+	make_tmp_dir
+	require_full_repository
+	fetch_heads "$remote"
+	meta_oid=$(resolve_commit "$(remote_ref "$remote" meta)")
+	if test -n "$expected_meta"
+	then
+		require_full_commit_oid "$expected_meta"
+		test "$meta_oid" = "$expected_meta" ||
+			die "meta moved from expected $expected_meta to $meta_oid"
+	fi
+	git show "$meta_oid:$meta_config_path" >"$tmp_dir/base-config" \
+		2>/dev/null ||
+		die "meta has no $meta_config_path"
+	base_ref=$(config_get_one "$tmp_dir/base-config" codex.base-ref)
+	base_name=${base_ref#refs/heads/}
+	codex_ref=$(config_get_one "$tmp_dir/base-config" codex.output-ref)
+	codex_name=${codex_ref#refs/heads/}
+	base_oid=$(resolve_commit "$(remote_ref "$remote" "$base_name")")
+	codex_oid=$(resolve_commit "$(remote_ref "$remote" "$codex_name")")
+	mkdir -p "$tmp_dir/published-state" ||
+		die "could not prepare published plan state"
+	read_meta_config "$meta_oid" "$base_name" "$codex_name" \
+		"$tmp_dir/published-state"
+	version=$(state_value "$tmp_dir/published-state" config-version)
+	stable_rows=$tmp_dir/stable-rows
+	unstable_rows=$tmp_dir/unstable-rows
+	stable_source_bases=$tmp_dir/stable-source-bases
+	unstable_source_bases=$tmp_dir/unstable-source-bases
+	has_unstable=
+	has_existing_plan=
+	if git cat-file -e "$meta_oid:$stable_plan_path" 2>/dev/null
+	then
+		has_existing_plan=t
+		read_lane_plan "$meta_oid" codex "$base_name" "$base_oid" \
+			"$remote" "$tmp_dir/existing-topics" \
+			"$tmp_dir/existing-plan"
+		cp "$tmp_dir/existing-plan/desired-prerequisites" "$stable_rows"
+		cp "$tmp_dir/existing-plan/desired-source-bases" \
+			"$stable_source_bases"
+		if git cat-file -e "$meta_oid:$unstable_plan_path" 2>/dev/null
+		then
+			has_unstable=t
+			read_lane_plan "$meta_oid" codex-unstable "$codex_name" \
+				"$codex_oid" "$remote" \
+				"$tmp_dir/existing-unstable-topics" \
+				"$tmp_dir/existing-unstable-plan"
+			cp "$tmp_dir/existing-unstable-plan/desired-prerequisites" \
+				"$unstable_rows"
+			cp "$tmp_dir/existing-unstable-plan/desired-source-bases" \
+				"$unstable_source_bases"
+		fi
+	else
+		test "$version" = 1 || test "$version" = 2 ||
+			die "cannot bootstrap plans from config version '$version'"
+		published_plan_rows "$tmp_dir/published-state" codex \
+			"$stable_rows"
+		published_source_base_rows "$tmp_dir/published-state" codex \
+			"$base_name" "$stable_source_bases"
+		if test -f "$tmp_dir/published-state/published-unstable-oid"
+		then
+			has_unstable=t
+			published_plan_rows "$tmp_dir/published-state" \
+				codex-unstable "$unstable_rows"
+			published_source_base_rows "$tmp_dir/published-state" \
+				codex-unstable "$codex_name" "$unstable_source_bases"
+		fi
+	fi
+	if test -n "$bootstrap_authorization"
+	then
+		test "$action" = alter ||
+			die "pre-v3 bootstrap may alter only an already-published topic"
+		test "$version" = 1 || test "$version" = 2 ||
+			die "pre-v3 bootstrap requires a v1/v2 controller"
+		if test -n "$has_existing_plan"
+		then
+			test "$(plan_trailer_optional "$meta_oid" \
+				Codex-Plan-Bootstrap "Codex-Plan-Bootstrap")" = true ||
+				die "pre-v3 bootstrap may continue only from an earlier bootstrap commit"
+		fi
+		test -z "$plan_branch" ||
+			die "pre-v3 bootstrap publishes meta directly, not a plan branch"
+	fi
+	if test "$lane" = codex-unstable
+	then
+		test -n "$has_unstable" ||
+			die "codex-unstable is not enabled in published meta"
+		rows=$unstable_rows
+		source_bases=$unstable_source_bases
+		published_rows=$tmp_dir/published-state/published-unstable-topics
+		lane_base=$codex_name
+		lane_base_oid=$codex_oid
+		lane_published_base_oid=$(state_value "$tmp_dir/published-state" \
+			published-unstable-base-oid)
+	else
+		rows=$stable_rows
+		source_bases=$stable_source_bases
+		published_rows=$tmp_dir/published-state/published-topics
+		lane_base=$base_name
+		lane_base_oid=$base_oid
+		lane_published_base_oid=$(state_value "$tmp_dir/published-state" \
+			published-base-oid)
+	fi
+	current_tip=$(plan_tip "$rows" "$topic")
+	current_prerequisites=$(plan_prerequisites "$rows" "$topic")
+	if test "$action" = auto
+	then
+		if test -n "$current_tip"
+		then
+			action=alter
+		else
+			action=add
+		fi
+	fi
+	case "$action" in
+	add)
+		test -z "$current_tip" ||
+			die "plan already contains '$topic'; use --action alter"
+		;;
+	alter)
+		test -n "$current_tip" ||
+			die "plan does not contain '$topic'; use --action add"
+		merge=$current_prerequisites
+		;;
+	reorder)
+		test -n "$current_tip" ||
+			die "plan does not contain '$topic'"
+		source_tip=$current_tip
+		merge=$current_prerequisites
+		;;
+	remove)
+		test -n "$current_tip" ||
+			die "plan does not contain '$topic'"
+		;;
+	esac
+	if test "$action" = add || test "$action" = alter
+	then
+		live=$(git rev-parse --verify \
+			"$(remote_ref "$remote" "$topic")^{commit}" 2>/dev/null) ||
+			die "topic ref '$topic' does not exist"
+		if test -z "$source_tip"
+		then
+			source_tip=$live
+		else
+			require_full_commit_oid "$source_tip"
+		fi
+		test "$live" = "$source_tip" ||
+			die "topic ref '$topic' is $live, not requested source tip $source_tip"
+		if test -z "$bootstrap_authorization"
+		then
+			validate_topic_review --pull-request "$review_pr" \
+				--lane "$lane" --topic "$topic" \
+				--source-tip "$source_tip"
+		fi
+	fi
+	new_source_base=
+	case "$action" in
+	add)
+		inferred=$(infer_added_plan_boundary "$rows" "$published_rows" \
+			"$lane_base" "$lane_base_oid" \
+			"$lane_published_base_oid" "$source_tip")
+		IFS="$tab" read -r merge new_source_base <<-EOF
+		$inferred
+		EOF
+		;;
+	alter)
+		set -- $merge
+		test $# = 1 ||
+			die "altered pinned topic '$topic' has a merge-shaped prerequisite"
+		new_source_base=$(infer_altered_plan_boundary "$rows" \
+			"$source_bases" "$published_rows" "$lane_base" \
+			"$lane_base_oid" "$lane_published_base_oid" "$topic" \
+			"$merge" "$source_tip")
+		;;
+	reorder)
+		new_source_base=$(plan_source_base "$source_bases" "$topic")
+		;;
+	remove) ;;
+	esac
+	replace_plan_row "$rows" "$rows.next" "$topic" "$source_tip" \
+		"$merge" "$action" "$after"
+	mv "$rows.next" "$rows"
+	replace_plan_source_base "$source_bases" "$source_bases.next" \
+		"$topic" "$new_source_base" "$action"
+	mv "$source_bases.next" "$source_bases"
+	write_lane_plan codex "$base_name" "$stable_rows" \
+		"$stable_source_bases" "$tmp_dir/$stable_plan_path"
+	if test -n "$has_unstable"
+	then
+		write_lane_plan codex-unstable "$codex_name" "$unstable_rows" \
+			"$unstable_source_bases" "$tmp_dir/$unstable_plan_path"
+	fi
+
+	index=$tmp_dir/plan.index
+	GIT_INDEX_FILE=$index git read-tree "$meta_oid" ||
+		die "could not prepare plan commit index"
+	stable_blob=$(git hash-object -w "$tmp_dir/$stable_plan_path") ||
+		die "could not write $stable_plan_path blob"
+	GIT_INDEX_FILE=$index git update-index --add --cacheinfo \
+		100644 "$stable_blob" "$stable_plan_path" ||
+		die "could not stage $stable_plan_path"
+	if test -n "$has_unstable"
+	then
+		unstable_blob=$(git hash-object -w "$tmp_dir/$unstable_plan_path") ||
+			die "could not write $unstable_plan_path blob"
+		GIT_INDEX_FILE=$index git update-index --add --cacheinfo \
+			100644 "$unstable_blob" "$unstable_plan_path" ||
+			die "could not stage $unstable_plan_path"
+	fi
+	tree=$(GIT_INDEX_FILE=$index git write-tree) ||
+		die "could not write pinned plan tree"
+	message=$tmp_dir/plan-message
+	{
+		printf 'Codex plan: %s %s in %s\n\n' \
+			"$action" "$topic" "$lane"
+		printf 'Codex-Plan-Lane: %s\n' "$lane"
+		printf 'Codex-Plan-Action: %s\n' "$action"
+		printf 'Codex-Plan-Topic: %s\n' "$topic"
+			case "$action" in
+			add|alter)
+				printf 'Codex-Plan-Source-Tip: %s\n' "$source_tip"
+				printf 'Codex-Plan-Merge: %s\n' "$merge"
+				printf 'Codex-Plan-Source-Base: %s\n' \
+					"$new_source_base"
+				if test -n "$bootstrap_authorization"
+				then
+					printf 'Codex-Plan-Bootstrap: true\n'
+					printf 'Codex-Plan-Authorization: %s\n' \
+						"$bootstrap_authorization"
+				else
+					printf 'Codex-Plan-Review: %s\n' "$review_pr"
+				fi
+				;;
+			esac
+		test -z "$after" ||
+			printf 'Codex-Plan-After: %s\n' "$after"
+	} >"$message"
+	plan_commit=$(
+		env GIT_AUTHOR_NAME="$bot_name" GIT_AUTHOR_EMAIL="$bot_email" \
+			GIT_COMMITTER_NAME="$bot_name" \
+			GIT_COMMITTER_EMAIL="$bot_email" \
+			git commit-tree "$tree" -p "$meta_oid" <"$message"
+	) || die "could not create pinned plan commit"
+
+	read_lane_plan "$plan_commit" codex "$base_name" "$base_oid" - \
+		"$tmp_dir/proposed-topics" "$tmp_dir/proposed-plan"
+	proposed_unstable_state=-
+	if test -n "$has_unstable"
+	then
+		read_lane_plan "$plan_commit" codex-unstable "$codex_name" \
+			"$codex_oid" - "$tmp_dir/proposed-unstable-topics" \
+			"$tmp_dir/proposed-unstable-plan"
+		proposed_unstable_state=$tmp_dir/proposed-unstable-plan
+	fi
+	validate_pinned_plan_policy "$tmp_dir/proposed-plan" \
+		"$proposed_unstable_state" "$base_name" "$version"
+	{
+		cut -f2 "$stable_rows"
+		test -z "$has_unstable" || cut -f2 "$unstable_rows"
+	} | LC_ALL=C sort -u >"$tmp_dir/pin-tips"
+	: >"$tmp_dir/missing-pins"
+	while IFS= read -r tip
+	do
+		test -n "$tip" || continue
+		require_full_commit_oid "$tip"
+		pin_ref=$(pin_ref_for_tip "$tip")
+		pin_name=${pin_ref#refs/heads/}
+		pin_oid=$(git rev-parse --verify \
+			"$(remote_ref "$remote" "$pin_name")^{commit}" \
+			2>/dev/null || :)
+		if test -n "$pin_oid"
+		then
+			test "$pin_oid" = "$tip" ||
+				die "immutable pin '$pin_ref' names $pin_oid, not $tip"
+		else
+			printf '%s\t%s\n' "$tip" "$pin_ref" \
+				>>"$tmp_dir/missing-pins"
+		fi
+	done <"$tmp_dir/pin-tips"
+
+	if test -n "$bootstrap_authorization"
+	then
+		if test -n "$no_push"
+		then
+			say "proposed pre-v3 bootstrap commit $plan_commit"
+			while IFS="$tab" read -r tip pin_ref
+			do
+				say "pin $pin_ref $tip"
+			done <"$tmp_dir/missing-pins"
+			return
+		fi
+		require_bootstrap_pin_guard
+		set -- --atomic \
+			"--force-with-lease=refs/heads/meta:$meta_oid"
+		while IFS="$tab" read -r tip pin_ref
+		do
+			set -- "$@" "--force-with-lease=$pin_ref:"
+		done <"$tmp_dir/missing-pins"
+		set -- "$@" "$remote" "$plan_commit:refs/heads/meta"
+		while IFS="$tab" read -r tip pin_ref
+		do
+			set -- "$@" "$tip:$pin_ref"
+		done <"$tmp_dir/missing-pins"
+		git push "$@" ||
+			die "could not atomically publish pre-v3 pinned-plan bootstrap"
+		fetch_heads "$remote"
+		test "$(git rev-parse "$(remote_ref "$remote" meta)")" = \
+			"$plan_commit" ||
+			die "remote meta does not name the bootstrap commit"
+		validate_plan_transition --remote "$remote" \
+			--base-commit "$meta_oid" --head-commit "$plan_commit"
+		say "published pre-v3 pinned-plan bootstrap $plan_commit"
+		return
+	fi
+
+	if test -z "$plan_branch"
+	then
+		short=${source_tip:-$meta_oid}
+		short=$(printf '%.12s' "$short")
+		slug=${topic##*/}
+		plan_branch=codex-plan/$lane-$slug-$short
+	fi
+	plan_branch=${plan_branch#refs/heads/}
+	case "$plan_branch" in
+	codex-plan/*/*)
+		die "plan branch '$plan_branch' has a nested suffix"
+		;;
+	codex-plan/*) ;;
+	*) die "plan branch '$plan_branch' is not under codex-plan/" ;;
+	esac
+	git check-ref-format "refs/heads/$plan_branch" >/dev/null 2>&1 ||
+		die "plan branch '$plan_branch' is invalid"
+
+	if test -n "$no_push"
+	then
+		say "proposed pinned plan commit $plan_commit"
+		say "plan branch refs/heads/$plan_branch"
+		while IFS="$tab" read -r tip pin_ref
+		do
+			say "pin $pin_ref $tip"
+		done <"$tmp_dir/missing-pins"
+		return
+	fi
+
+	plan_old=$(git rev-parse --verify \
+		"$(remote_ref "$remote" "$plan_branch")^{commit}" 2>/dev/null || :)
+	if test -n "$plan_old"
+	then
+		lease=--force-with-lease=refs/heads/$plan_branch:$plan_old
+	else
+		lease=--force-with-lease=refs/heads/$plan_branch:
+	fi
+	set -- --atomic "$lease"
+	while IFS="$tab" read -r tip pin_ref
+	do
+		set -- "$@" "--force-with-lease=$pin_ref:"
+	done <"$tmp_dir/missing-pins"
+	set -- "$@" "$remote" "$plan_commit:refs/heads/$plan_branch"
+	while IFS="$tab" read -r tip pin_ref
+	do
+		set -- "$@" "$tip:$pin_ref"
+	done <"$tmp_dir/missing-pins"
+	git push "$@" ||
+		die "could not atomically publish immutable pins and plan branch"
+	fetch_heads "$remote"
+	test "$(git rev-parse "$(remote_ref "$remote" "$plan_branch")")" = \
+		"$plan_commit" ||
+		die "remote plan branch does not name the proposed commit"
+	validate_plan_transition --remote "$remote" --base-commit "$meta_oid" \
+		--head-commit "$plan_commit"
+	body=$tmp_dir/plan-body
+	{
+		printf 'Bot-generated pinned plan transition.\n\n'
+		printf -- '- Lane: `%s`\n' "$lane"
+		printf -- '- Action: `%s`\n' "$action"
+		printf -- '- Topic: `refs/heads/%s`\n' "$topic"
+		if test "$action" != remove
+		then
+			printf -- '- Source tip: `%s`\n' "$source_tip"
+			printf -- '- Prerequisite: `refs/heads/%s`\n' "$merge"
+		fi
+		test -z "$review_pr" ||
+			printf -- '- Reviewed topic PR: `#%s`\n' "$review_pr"
+		printf '\nThe plan blob and immutable `codex-pins/*` refs are authoritative.\n'
+	} >"$body"
+	pr_url=$(gh pr create --repo openai/git --base meta \
+		--head "$plan_branch" \
+		--title "Codex plan: $action $topic in $lane" \
+		--body-file "$body") ||
+		die "plan branch was published, but its pull request could not be created"
+	say "opened pinned plan pull request $pr_url"
+	gh pr merge "$pr_url" --repo openai/git --auto --rebase \
+		--match-head-commit "$plan_commit" ||
+		die "plan pull request was opened, but auto-merge could not be requested"
+	say "requested auto-merge for pinned plan $plan_commit"
+}
+
 prepare_input_graph () {
 	inputs=$1
 	graph=$2
 	mkdir -p "$graph" || die "could not prepare input graph verification"
 	awk -F '\t' '
-		$1 == "controller" || $1 == "base" || $1 == "codex" ||
+		$1 == "controller" || $1 == "plan" || $1 == "pin" ||
+		$1 == "base" || $1 == "codex" ||
 		$1 == "topic" || $1 == "unstable" ||
-		$1 == "unstable-topic" || $1 == "lane-mode" {
+		$1 == "unstable-plan" || $1 == "unstable-topic" ||
+		$1 == "lane-mode" {
 			if (NF != 3) exit 1
 			next
 		}
@@ -4163,7 +6616,7 @@ prepare_input_graph () {
 			END { print count + 0 }' "$inputs")" = 1 ||
 			die "input snapshot must contain exactly one '$kind' record"
 	done
-	for kind in unstable lane-mode admission unstable-admission
+	for kind in plan unstable unstable-plan lane-mode admission unstable-admission
 	do
 		test "$(awk -F '\t' -v kind="$kind" '$1 == kind { count++ }
 			END { print count + 0 }' "$inputs")" -le 1 ||
@@ -4209,6 +6662,69 @@ prepare_input_graph () {
 		die "could not retain the snapshotted Codex output name"
 	read_meta_config "$controller_oid" "$base_name" "$codex_name" "$graph"
 	config_version=$(state_value "$graph" config-version)
+	if awk -F '\t' '$1 == "plan" { found=1 } END { exit !found }' \
+		"$inputs"
+	then
+		test -z "$lane_mode" ||
+			die "pinned plans cannot use an unstable lane mode"
+		plan_blob=$(awk -F '\t' '$1 == "plan" { print $3 }' "$inputs")
+		test -n "$plan_blob" ||
+			die "pinned input snapshot has no production plan"
+		read_lane_plan "$controller_oid" codex "$base_name" "$base_oid" \
+			- "$graph/plan-topics" "$graph/pinned-plan"
+		test "$plan_blob" = "$(state_value "$graph/pinned-plan" plan-blob)" ||
+			die "input snapshot does not match its pinned production plan blob"
+		awk -F '\t' '$1 == "topic" {
+			name=$2
+			sub("^refs/heads/", "", name)
+			printf "%s\t%s\n", name, $3
+		}' "$inputs" >"$graph/snapshot-topics" ||
+			die "could not read pinned topics from the input snapshot"
+		cmp -s "$graph/snapshot-topics" "$graph/plan-topics" ||
+			die "input snapshot topics do not match the pinned production plan"
+		{
+			cut -f2 "$graph/plan-topics"
+			awk -F '\t' '$1 == "unstable-topic" { print $3 }' "$inputs"
+		} | LC_ALL=C sort -u |
+		while IFS= read -r oid
+		do
+			printf 'pin\t%s\t%s\n' "$(pin_ref_for_tip "$oid")" "$oid"
+		done >"$graph/expected-pins"
+		awk -F '\t' '$1 == "pin" { print }' "$inputs" |
+			LC_ALL=C sort >"$graph/snapshot-pins"
+		cmp -s "$graph/expected-pins" "$graph/snapshot-pins" ||
+			die "input snapshot does not retain every immutable plan pin"
+		cp "$graph/plan-topics" "$graph/topics" ||
+			die "could not retain pinned production topics"
+			cp "$graph/pinned-plan/desired-prerequisites" \
+				"$graph/desired-prerequisites" ||
+				die "could not retain pinned production prerequisites"
+			cp "$graph/pinned-plan/desired-source-bases" \
+				"$graph/desired-source-bases" ||
+				die "could not retain pinned production source boundaries"
+		cp "$graph/pinned-plan/desired-order" "$graph/desired-order" ||
+			die "could not retain pinned production order"
+		cp "$graph/pinned-plan/plan-blob" "$graph/plan-blob" ||
+			die "could not retain pinned production plan"
+		: >"$graph/pinned-plan-mode"
+		printf '%s\n' "$base_name" >"$graph/base-name"
+		printf '%s\n' "$base_oid" >"$graph/base-oid"
+		printf '%s\n' "$base_oid" >"$graph/source-base-oid"
+		codex_oid=$(awk -F '\t' '$1 == "codex" { print $3 }' "$inputs")
+		test "$codex_oid" = "$(state_value "$graph" published-codex-oid)" ||
+			die "pinned input snapshot moves generated codex outside published state"
+		awk -F '\t' '$1 == "unstable-topic" {
+			name=$2
+			sub("^refs/heads/", "", name)
+			printf "%s\t%s\n", name, $3
+		}' "$inputs" >"$graph/unstable-current-topics" ||
+			die "could not prepare pinned unstable ownership verification"
+		validate_lane_isolation "$graph" "$graph/topics" \
+			"$graph/unstable-current-topics" "$codex_oid"
+		prepare_pinned_plan "$base_name" "$base_oid" "$graph/topics" \
+			"$graph"
+		return
+	fi
 	unstable_count=$(awk -F '\t' '$1 == "unstable" { count++ }
 		END { print count + 0 }' "$inputs")
 	case "$config_version:$lane_mode" in
@@ -4345,6 +6861,67 @@ prepare_unstable_input_graph () (
 	unstable_oid=$(awk -F '\t' '$1 == "unstable" { print $3 }' "$inputs")
 	test -n "$unstable_oid" ||
 		die "unstable topics have no snapshotted output ref"
+	if awk -F '\t' '$1 == "unstable-plan" { found=1 }
+		END { exit !found }' "$inputs"
+	then
+		test -z "$mode" ||
+			die "pinned unstable plans cannot use a lane mode"
+		controller_oid=$(awk -F '\t' '$1 == "controller" { print $3 }' \
+			"$inputs")
+		codex_oid=$(awk -F '\t' '$1 == "codex" { print $3 }' "$inputs")
+		plan_blob=$(awk -F '\t' '$1 == "unstable-plan" { print $3 }' \
+			"$inputs")
+		test -n "$plan_blob" ||
+			die "pinned input snapshot has no unstable plan"
+		read_lane_plan "$controller_oid" codex-unstable codex \
+			"$codex_oid" - "$graph/plan-topics" "$graph/pinned-plan"
+		test "$plan_blob" = "$(state_value "$graph/pinned-plan" plan-blob)" ||
+			die "input snapshot does not match its pinned unstable plan blob"
+		awk -F '\t' '$1 == "unstable-topic" {
+			name=$2
+			sub("^refs/heads/", "", name)
+			printf "%s\t%s\n", name, $3
+		}' "$inputs" >"$graph/snapshot-topics" ||
+			die "could not read pinned unstable topics from the input snapshot"
+		cmp -s "$graph/snapshot-topics" "$graph/plan-topics" ||
+			die "input snapshot topics do not match the pinned unstable plan"
+		cp "$graph/plan-topics" "$graph/topics" ||
+			die "could not retain pinned unstable topics"
+		cp "$stable_graph/published-unstable-source-topics" \
+			"$graph/published-source-topics" ||
+			die "could not retain published unstable source boundaries"
+			cp "$graph/pinned-plan/desired-prerequisites" \
+				"$graph/desired-prerequisites" ||
+				die "could not retain pinned unstable prerequisites"
+			cp "$graph/pinned-plan/desired-source-bases" \
+				"$graph/desired-source-bases" ||
+				die "could not retain pinned unstable source boundaries"
+		cp "$graph/pinned-plan/desired-order" "$graph/desired-order" ||
+			die "could not retain pinned unstable order"
+		cp "$graph/pinned-plan/plan-blob" "$graph/plan-blob" ||
+			die "could not retain pinned unstable plan"
+		: >"$graph/pinned-plan-mode"
+		printf '%s\n' codex >"$graph/base-name"
+		printf '%s\n' "$stable_candidate" >"$graph/base-oid"
+		printf '%s\n' codex-unstable >"$graph/codex-name"
+		printf '%s\n' "$(state_value "$stable_graph" \
+			published-unstable-base-oid)" >"$graph/published-base-oid"
+		printf '%s\n' "$(state_value "$stable_graph" \
+			published-unstable-oid)" >"$graph/published-codex-oid"
+		printf '%s\n' "$codex_oid" >"$graph/source-base-oid"
+		test "$unstable_oid" = \
+			"$(state_value "$stable_graph" published-unstable-oid)" ||
+			die "pinned input snapshot moves generated codex-unstable outside published state"
+		if test -s "$graph/topics"
+		then
+			prepare_pinned_plan codex "$stable_candidate" \
+				"$graph/topics" "$graph"
+		else
+			: >"$graph/plan"
+			: >"$graph/results"
+		fi
+		return
+	fi
 	awk -F '\t' '$1 == "unstable-admission" { print }' "$inputs" \
 		>"$graph/snapshot-admissions" ||
 		die "could not inspect reviewed unstable Codex admissions"
@@ -4443,9 +7020,14 @@ topic_control_paths_unchanged () (
 		.github/CODEX.md \
 		.github/rulesets/codex-branch.json \
 		.github/rulesets/codex-meta.json \
+		.github/rulesets/codex-pins.json \
+		.github/rulesets/codex-pins-immutable.json \
+		.github/rulesets/codex-plan-branches.json \
 		.github/rulesets/codex-topics.json \
 		.github/rulesets/codex-unstable-branch.json \
 		.github/workflows/codex-admission.yml \
+		.github/workflows/codex-plan-admission.yml \
+		.github/workflows/codex-plan-propose.yml \
 		.github/workflows/codex-topic.yml \
 		.github/workflows/codex.yml \
 		.github/workflows/codex-branch.sh \
@@ -4453,6 +7035,8 @@ topic_control_paths_unchanged () (
 		codex \
 		publish \
 		rebuild \
+		codex.plan \
+		codex-unstable.plan \
 		codex.config \
 		t/t9905-codex-branch.sh &&
 	git diff --quiet "$base_oid" "$head_oid" -- \
@@ -4503,6 +7087,66 @@ verify_unstable_control_paths () (
 	done <"$state/plan"
 )
 
+validate_pinned_plan_policy () {
+	stable_state=$1
+	unstable_state=$2
+	base_name=$3
+	version=$4
+	automation_count=0
+	while IFS="$tab" read -r name source_tip prerequisites
+	do
+		source_base=$(plan_source_base \
+			"$stable_state/desired-source-bases" "$name")
+		test -n "$source_base" ||
+			die "pinned plan has no source boundary for '$name'"
+		case "$name" in
+		??/codex/automation)
+			automation_count=$((automation_count + 1))
+			test "$prerequisites" = "$base_name" ||
+				die "automation topic '$name' must be based directly on $base_name"
+			make_tmp_dir
+			git diff --name-only "$source_base" "$source_tip" \
+				>"$tmp_dir/automation-paths" ||
+				die "could not inspect automation topic '$name'"
+			printf '%s\n' .github/workflows/codex.yml \
+				>"$tmp_dir/expected-automation-paths"
+			cmp -s "$tmp_dir/expected-automation-paths" \
+				"$tmp_dir/automation-paths" ||
+				die "automation topic '$name' must change only .github/workflows/codex.yml"
+			if test "$version" = 3
+			then
+				automation_workflow_is_current "$source_tip" ||
+					die "automation topic '$name' does not contain the current Refresh codex workflow"
+			else
+				automation_workflow_matches "$source_tip" ||
+					die "automation topic '$name' does not contain the canonical Refresh codex workflow"
+			fi
+			;;
+		*)
+			topic_control_paths_unchanged "$source_base" "$source_tip" ||
+				die "topic '$name' changes a protected controller or CI file"
+			;;
+		esac
+	done <"$stable_state/desired-prerequisites"
+	test "$automation_count" = 1 ||
+		die "exactly one active ??/codex/automation topic is required"
+
+	test "$unstable_state" = - && return
+	while IFS="$tab" read -r name source_tip prerequisites
+	do
+		source_base=$(plan_source_base \
+			"$unstable_state/desired-source-bases" "$name")
+		test -n "$source_base" ||
+			die "pinned unstable plan has no source boundary for '$name'"
+		topic_control_paths_unchanged "$source_base" "$source_tip" ||
+			die "unstable topic '$name' changes a protected controller or CI file"
+		git diff --quiet "$source_base" "$source_tip" -- \
+			':(glob).github/workflows/*.yml' \
+			':(glob).github/workflows/*.yaml' ||
+			die "unstable topic '$name' changes a GitHub Actions workflow"
+	done <"$unstable_state/desired-prerequisites"
+}
+
 verify_control_paths () {
 	inputs=$1
 	updates=$2
@@ -4510,6 +7154,8 @@ verify_control_paths () {
 	graph=$4
 	require_automation=$5
 	base_oid=$(awk -F '\t' '$1 == "base" { print $3 }' "$inputs")
+	base_ref=$(awk -F '\t' '$1 == "base" { print $2 }' "$inputs")
+	base_name=${base_ref#refs/heads/}
 	if test -f "$graph/published-codex-oid"
 	then
 		published_codex=$(state_value "$graph" published-codex-oid)
@@ -4528,10 +7174,72 @@ verify_control_paths () {
 		fi
 	fi
 
-	if test -z "$require_automation"
+	if test -z "$require_automation" &&
+		! test -f "$graph/pinned-plan-mode"
 	then
 		legacy_control_paths_unchanged "$base_oid" "$candidate" ||
 			die "candidate changes meta-only controller files"
+		return
+	fi
+
+	if test -f "$graph/pinned-plan-mode"
+	then
+		meta_control_paths_unchanged "$base_oid" "$candidate" ||
+			die "candidate changes a protected controller or CI file"
+		automation_workflow_matches "$candidate" ||
+			die "candidate does not contain the canonical Refresh codex workflow"
+		release_workflow_is_reviewed "$candidate" ||
+			die "candidate release workflow must use the reviewed Codex branch triggers and must not obtain promotion credentials"
+		automation_count=0
+		while IFS="$tab" read -r name source_tip prerequisites
+		do
+			case "$name" in
+			??/codex/automation)
+				automation_count=$((automation_count + 1))
+				test "$prerequisites" = master ||
+					die "automation topic '$name' must be based directly on master"
+				source_base=$(plan_source_base \
+					"$graph/desired-source-bases" "$name")
+				test -n "$source_base" ||
+					die "pinned plan has no source boundary for automation topic '$name'"
+				make_tmp_dir
+				git diff --name-only "$source_base" "$source_tip" \
+					>"$tmp_dir/automation-paths" ||
+					die "could not inspect automation topic '$name'"
+				printf '%s\n' .github/workflows/codex.yml \
+					>"$tmp_dir/expected-automation-paths"
+				cmp -s "$tmp_dir/expected-automation-paths" \
+					"$tmp_dir/automation-paths" ||
+					die "automation topic '$name' must change only .github/workflows/codex.yml"
+				if test "$(state_value "$graph" config-version)" != 3
+				then
+					automation_workflow_is_current "$source_tip" ||
+						die "pre-v3 pinned plan must pin the current automation workflow before refresh"
+				else
+					automation_workflow_matches "$source_tip" ||
+						die "automation topic '$name' does not contain the canonical Refresh codex workflow"
+				fi
+				continue
+				;;
+			esac
+			for prerequisite in $prerequisites
+			do
+				if test "$prerequisite" = "$base_name"
+				then
+					dependency_source=$base_oid
+				else
+					dependency_source=$(plan_tip \
+						"$graph/desired-prerequisites" "$prerequisite")
+					test -n "$dependency_source" ||
+						die "pinned plan has no source for prerequisite '$prerequisite'"
+				fi
+				topic_control_paths_unchanged "$dependency_source" \
+					"$source_tip" ||
+					die "topic '$name' changes a protected controller or CI file"
+			done
+		done <"$graph/desired-prerequisites"
+		test "$automation_count" = 1 ||
+			die "exactly one active ??/codex/automation topic is required"
 		return
 	fi
 
@@ -4600,6 +7308,28 @@ verify_control_paths () {
 		die "exactly one active ??/codex/automation topic is required"
 }
 
+candidate_generated_tip () (
+	base_oid=$1
+	head_oid=$2
+	name=$3
+	for commit in $(git rev-list --first-parent --reverse \
+		"$base_oid..$head_oid")
+	do
+		marker=$(git show -s \
+			--format='%(trailers:key=Codex-Integration,valueonly)' \
+			"$commit") || return 1
+		case "$marker" in
+		"$name@"*)
+			set -- $(git show -s --format=%P "$commit")
+			test $# = 2 || return 1
+			printf '%s\n' "$2"
+			return 0
+			;;
+		esac
+	done
+	return 1
+)
+
 verify_meta_update () (
 	inputs=$1
 	updates=$2
@@ -4638,6 +7368,73 @@ verify_meta_update () (
 		END { exit !(NR == 1 && valid == 1) }
 	' "$graph/meta-config-entry" ||
 		die "next meta state must contain $meta_config_path as one regular blob"
+
+	if test -f "$graph/pinned-plan-mode"
+	then
+		: >"$graph/expected-meta-v3-topics"
+		while IFS="$tab" read -r name source_tip
+		do
+			generated_tip=$(candidate_generated_tip \
+				"$(state_value "$graph" base-oid)" "$candidate" "$name") ||
+				die "candidate has no generated integration for '$name'"
+			prerequisites=$(plan_prerequisites \
+				"$graph/desired-prerequisites" "$name")
+			printf '%s\t%s\t%s\t%s\n' "$name" "$source_tip" \
+				"$generated_tip" "$prerequisites" \
+				>>"$graph/expected-meta-v3-topics"
+		done <"$graph/topics"
+		LC_ALL=C sort -o "$graph/expected-meta-v3-topics" \
+			"$graph/expected-meta-v3-topics"
+		base_ref=$(awk -F '\t' '$1 == "base" { print $2 }' "$inputs")
+		base_oid=$(awk -F '\t' '$1 == "base" { print $3 }' "$inputs")
+		codex_ref=$(awk -F '\t' '$1 == "codex" { print $2 }' "$inputs")
+		base_name=${base_ref#refs/heads/}
+		codex_name=${codex_ref#refs/heads/}
+		plan_blob=$(awk -F '\t' '$1 == "plan" { print $3 }' "$inputs")
+		test -n "$plan_blob" ||
+			die "pinned input snapshot has no production plan blob"
+		if test -n "$unstable_candidate" &&
+			! is_null_oid "$unstable_candidate"
+		then
+			test -n "$unstable_graph" ||
+				die "unstable output has no verified pinned graph"
+			: >"$graph/expected-meta-v3-unstable-topics"
+			while IFS="$tab" read -r name source_tip
+			do
+				generated_tip=$(candidate_generated_tip "$candidate" \
+					"$unstable_candidate" "$name") ||
+					die "unstable candidate has no generated integration for '$name'"
+				prerequisites=$(plan_prerequisites \
+					"$unstable_graph/desired-prerequisites" "$name")
+				printf '%s\t%s\t%s\t%s\n' "$name" \
+					"$source_tip" "$generated_tip" "$prerequisites" \
+					>>"$graph/expected-meta-v3-unstable-topics"
+			done <"$unstable_graph/topics"
+			LC_ALL=C sort -o "$graph/expected-meta-v3-unstable-topics" \
+				"$graph/expected-meta-v3-unstable-topics"
+			unstable_plan_blob=$(awk -F '\t' \
+				'$1 == "unstable-plan" { print $3 }' "$inputs")
+			test -n "$unstable_plan_blob" ||
+				die "pinned input snapshot has no unstable plan blob"
+			write_meta_config_v3 "$base_name" "$base_oid" "$codex_name" \
+				"$candidate" "$graph/expected-meta-v3-topics" \
+				"$graph/expected-meta-config" "$plan_blob" \
+				"$graph/expected-meta-v3-unstable-topics" \
+				"$candidate" "$unstable_candidate" \
+				"$unstable_plan_blob"
+		else
+			write_meta_config_v3 "$base_name" "$base_oid" "$codex_name" \
+				"$candidate" "$graph/expected-meta-v3-topics" \
+				"$graph/expected-meta-config" "$plan_blob"
+		fi
+		git show "$new_meta:$meta_config_path" \
+			>"$graph/actual-meta-config" 2>/dev/null ||
+			die "next meta state has no $meta_config_path"
+		cmp -s "$graph/expected-meta-config" \
+			"$graph/actual-meta-config" ||
+			die "next meta state does not describe the verified pinned output"
+		return
+	fi
 
 	: >"$graph/expected-meta-topics"
 	while IFS="$tab" read -r name old
@@ -4766,9 +7563,12 @@ verify_output () {
 	LC_ALL=C sort -c "$updates" || die "updates are not canonically sorted"
 	test "$(cut -f1 "$updates" | sort -u | wc -l | tr -d ' ')" = \
 		"$(wc -l <"$updates" | tr -d ' ')" || die "updates contain duplicate refs"
-	awk -F '\t' -v recovery="$stable_recovery" '
-		$1 == "controller" || $1 == "codex" || $1 == "topic" ||
-		(recovery == "" && ($1 == "unstable" || $1 == "unstable-topic")) {
+	pinned_inputs=$(awk -F '\t' '$1 == "plan" { print $3 }' "$inputs")
+	awk -F '\t' -v recovery="$stable_recovery" -v pinned="$pinned_inputs" '
+		$1 == "controller" || $1 == "codex" ||
+		(pinned == "" && $1 == "topic") ||
+		(recovery == "" && ($1 == "unstable" ||
+			(pinned == "" && $1 == "unstable-topic"))) {
 			print $2
 		}
 	' "$inputs" \
@@ -4846,6 +7646,13 @@ verify_output () {
 			fi
 			;;
 		refs/heads/??/codex/*-unstable)
+			if test -n "$unstable_graph" &&
+				test -f "$unstable_graph/pinned-plan-mode"
+			then
+				test "$new" = "$old" ||
+					die "pinned unstable source ref '$ref' must be a no-op lease"
+				continue
+			fi
 			test -n "$unstable_candidate" &&
 				! is_null_oid "$unstable_candidate" ||
 				die "unstable topic update has no unstable output"
@@ -4857,6 +7664,12 @@ verify_output () {
 		refs/heads/??/codex/?*)
 			is_stable_topic_name "${ref#refs/heads/}" ||
 				die "unstable topic '$ref' entered the stable update set"
+			if test -f "$tmp_dir/topic-graph/pinned-plan-mode"
+			then
+				test "$new" = "$old" ||
+					die "pinned source ref '$ref' must be a no-op lease"
+				continue
+			fi
 			git merge-base --is-ancestor "$base_oid" "$new" ||
 				die "rewritten '$ref' is not based on master"
 			git merge-base --is-ancestor "$new" "$candidate" ||
@@ -4865,28 +7678,31 @@ verify_output () {
 		*) die "unexpected update ref '$ref'" ;;
 		esac
 	done <"$updates"
-	while IFS="$tab" read -r name old prerequisite old_base prerequisite_tip
-	do
-		ref=refs/heads/$name
-		new=$(awk -F '\t' -v ref="$ref" '$1 == ref { print $3 }' \
-			"$updates")
-		prerequisites=$(planned_prerequisites "$tmp_dir/topic-graph" "$name")
-		for prerequisite in $prerequisites
+	if ! test -f "$tmp_dir/topic-graph/pinned-plan-mode"
+	then
+		while IFS="$tab" read -r name old prerequisite old_base prerequisite_tip
 		do
-			if test "$prerequisite" = "$base_name"
-			then
-				new_prerequisite=$base_oid
-			else
-				prerequisite_ref=refs/heads/$prerequisite
-				new_prerequisite=$(awk -F '\t' -v ref="$prerequisite_ref" \
-					'$1 == ref { print $3 }' "$updates")
-				test -n "$new_prerequisite" ||
-					die "updates contain no configured prerequisite '$prerequisite_ref'"
-			fi
-			git merge-base --is-ancestor "$new_prerequisite" "$new" ||
-				die "rewrite lost configured dependency '$prerequisite' -> '$name'"
-		done
-	done <"$tmp_dir/topic-graph/plan"
+			ref=refs/heads/$name
+			new=$(awk -F '\t' -v ref="$ref" '$1 == ref { print $3 }' \
+				"$updates")
+			prerequisites=$(planned_prerequisites "$tmp_dir/topic-graph" "$name")
+			for prerequisite in $prerequisites
+			do
+				if test "$prerequisite" = "$base_name"
+				then
+					new_prerequisite=$base_oid
+				else
+					prerequisite_ref=refs/heads/$prerequisite
+					new_prerequisite=$(awk -F '\t' -v ref="$prerequisite_ref" \
+						'$1 == ref { print $3 }' "$updates")
+					test -n "$new_prerequisite" ||
+						die "updates contain no configured prerequisite '$prerequisite_ref'"
+				fi
+				git merge-base --is-ancestor "$new_prerequisite" "$new" ||
+					die "rewrite lost configured dependency '$prerequisite' -> '$name'"
+			done
+		done <"$tmp_dir/topic-graph/plan"
+	fi
 
 	# Reconstruct the canonical integration order independently from the
 	# artifact producer.  The source trees alone cannot prove that every topic
@@ -4902,12 +7718,41 @@ verify_output () {
 		die "could not prepare rewritten topic verification"
 	while IFS="$tab" read -r name old
 	do
-		ref=refs/heads/$name
-		new=$(awk -F '\t' -v ref="$ref" '$1 == ref { print $3 }' \
-			"$updates")
-		test -n "$new" || die "updates contain no rewritten tip for '$name'"
+		if test -f "$tmp_dir/topic-graph/pinned-plan-mode"
+		then
+			new=$(candidate_generated_tip "$base_oid" "$candidate" "$name") ||
+				die "candidate has no generated tip for pinned topic '$name'"
+		else
+			ref=refs/heads/$name
+			new=$(awk -F '\t' -v ref="$ref" '$1 == ref { print $3 }' \
+				"$updates")
+			test -n "$new" ||
+				die "updates contain no rewritten tip for '$name'"
+		fi
 		result_record "$tmp_dir/topic-graph/results" "$name" "$new"
 	done <"$tmp_dir/topic-graph/topics"
+	if test -f "$tmp_dir/topic-graph/pinned-plan-mode"
+	then
+		while IFS="$tab" read -r name old prerequisite old_base prerequisite_tip
+		do
+			new=$(result_lookup "$tmp_dir/topic-graph/results" "$name")
+			prerequisites=$(planned_prerequisites "$tmp_dir/topic-graph" "$name")
+			for prerequisite in $prerequisites
+			do
+				if test "$prerequisite" = "$base_name"
+				then
+					new_prerequisite=$base_oid
+				else
+					new_prerequisite=$(result_lookup \
+						"$tmp_dir/topic-graph/results" "$prerequisite")
+					test -n "$new_prerequisite" ||
+						die "pinned topic '$name' has no generated prerequisite '$prerequisite'"
+				fi
+				git merge-base --is-ancestor "$new_prerequisite" "$new" ||
+					die "pinned rewrite lost dependency '$prerequisite' -> '$name'"
+			done
+		done <"$tmp_dir/topic-graph/plan"
+	fi
 	if test -f "$tmp_dir/topic-graph/merge-graph"
 	then
 		verify_merge_topology "$base_oid" "$tmp_dir/topic-graph"
@@ -4925,11 +7770,18 @@ verify_output () {
 			die "could not prepare rewritten unstable topic verification"
 		while IFS="$tab" read -r name old
 		do
-			ref=refs/heads/$name
-			new=$(awk -F '\t' -v ref="$ref" \
-				'$1 == ref { print $3 }' "$updates")
-			test -n "$new" ||
-				die "updates contain no rewritten unstable tip for '$name'"
+			if test -f "$unstable_graph/pinned-plan-mode"
+			then
+				new=$(candidate_generated_tip "$candidate" \
+					"$unstable_candidate" "$name") ||
+					die "unstable candidate has no generated tip for pinned topic '$name'"
+			else
+				ref=refs/heads/$name
+				new=$(awk -F '\t' -v ref="$ref" \
+					'$1 == ref { print $3 }' "$updates")
+				test -n "$new" ||
+					die "updates contain no rewritten unstable tip for '$name'"
+			fi
 			result_record "$unstable_graph/results" "$name" "$new"
 		done <"$unstable_graph/topics"
 		if test -f "$unstable_graph/merge-graph"
@@ -6132,6 +8984,9 @@ initialize) initialize_config "$@" ;;
 refresh) local_refresh "$@" ;;
 rewrite) rewrite "$@" ;;
 verify-inputs) verify_inputs "$@" ;;
+validate-plan-transition) validate_plan_transition "$@" ;;
+validate-topic-review) validate_topic_review "$@" ;;
+propose-plan) propose_plan "$@" ;;
 verify-output) verify_output "$@" ;;
 stage) stage_candidate "$@" ;;
 promote) promote "$@" ;;

--- a/.github/workflows/codex-plan-admission.yml
+++ b/.github/workflows/codex-plan-admission.yml
@@ -1,0 +1,156 @@
+name: Codex plan admission
+
+on:
+  # The protected default-branch trampoline calls this only from a
+  # pull_request_target event.  Never call it from pull_request or
+  # pull_request_review, whose workflow file can come from the proposal.
+  workflow_call:
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: codex-plan-admission-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: Verify pinned manifest
+    if: github.event.pull_request.base.ref == 'meta'
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check out only the trusted meta base
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          repository: ${{ github.repository }}
+          ref: ${{ github.event.pull_request.base.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Verify reviewed pinned plan
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PULL_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PULL_DRAFT: ${{ github.event.pull_request.draft }}
+          PULL_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+
+          die () {
+            printf '%s\n' "$*" >&2
+            exit 1
+          }
+
+
+          test "$GITHUB_REPOSITORY" = openai/git ||
+            die "unexpected repository '$GITHUB_REPOSITORY'"
+          test "$BASE_REF" = meta ||
+            die "Codex plan admission only runs against meta"
+          case "$PULL_NUMBER" in
+          ''|*[!0-9]*) die "invalid pull request number '$PULL_NUMBER'" ;;
+          esac
+
+          basic=$(printf 'x-access-token:%s' "$GH_TOKEN" |
+            base64 | tr -d '\n')
+          git -c http.extraheader="AUTHORIZATION: basic $basic" \
+            fetch --force --prune origin \
+            '+refs/heads/*:refs/remotes/origin/*' \
+            "$HEAD_SHA"
+          test "$(git rev-parse HEAD)" = "$BASE_SHA" ||
+            die "trusted checkout does not match the pull request base"
+          test "$(git rev-parse refs/remotes/origin/meta)" = "$BASE_SHA" ||
+            die "meta changed while Codex plan admission was starting"
+          git cat-file -e "$HEAD_SHA^{commit}" ||
+            die "could not fetch the pinned plan head"
+
+          changed=$(git diff-tree --no-commit-id --name-only -r \
+            "$BASE_SHA" "$HEAD_SHA")
+          if ! printf '%s\n' "$changed" |
+            grep -Eq '^(codex\.plan|codex-unstable\.plan)$'
+          then
+            printf '%s\n' \
+              "No Codex plan changed; ordinary meta review applies."
+            exit 0
+          fi
+
+          test "$HEAD_REPOSITORY" = "$GITHUB_REPOSITORY" ||
+            die "Codex plan branches must belong to openai/git"
+          case "$HEAD_REF" in
+          codex-plan/*/*)
+            die "Codex plan branch '$HEAD_REF' has a nested suffix"
+            ;;
+          codex-plan/*) ;;
+          *) die "Codex plan branch '$HEAD_REF' is not bot-owned" ;;
+          esac
+          test "$PULL_DRAFT" = false ||
+            die "draft Codex plan pull requests cannot be admitted"
+
+          sh .github/workflows/codex-branch.sh validate-plan-transition \
+            --remote origin --base-commit "$BASE_SHA" \
+            --head-commit "$HEAD_SHA"
+
+          bootstrap=$(git show -s \
+            --format='%(trailers:key=Codex-Plan-Bootstrap,valueonly)' \
+            "$HEAD_SHA" | sed -n '1p')
+          test -z "$bootstrap" ||
+            die "pre-v3 bootstrap is a deployment-only direct transition"
+
+          action=$(git show -s \
+            --format='%(trailers:key=Codex-Plan-Action,valueonly)' \
+            "$HEAD_SHA" | sed -n '1p')
+          case "$action" in
+          add|alter)
+            lane=$(git show -s \
+              --format='%(trailers:key=Codex-Plan-Lane,valueonly)' \
+              "$HEAD_SHA" | sed -n '1p')
+            topic=$(git show -s \
+              --format='%(trailers:key=Codex-Plan-Topic,valueonly)' \
+              "$HEAD_SHA" | sed -n '1p')
+            source_tip=$(git show -s \
+              --format='%(trailers:key=Codex-Plan-Source-Tip,valueonly)' \
+              "$HEAD_SHA" | sed -n '1p')
+            review_pr=$(git show -s \
+              --format='%(trailers:key=Codex-Plan-Review,valueonly)' \
+              "$HEAD_SHA" | sed -n '1p')
+            sh .github/workflows/codex-branch.sh validate-topic-review \
+              --pull-request "$review_pr" --lane "$lane" \
+              --topic "$topic" --source-tip "$source_tip"
+            ;;
+          remove|reorder)
+            printf '%s\n' \
+              "Explicit plan policy change; ordinary meta review applies."
+            ;;
+          *) die "Codex plan transition has unknown action '$action'" ;;
+          esac
+
+          # Re-fetch before the mechanical approval.  Strict required
+          # checks make GitHub rerun this trusted-base gate if meta moves.
+          git -c http.extraheader="AUTHORIZATION: basic $basic" \
+            fetch --force --prune origin \
+            '+refs/heads/*:refs/remotes/origin/*'
+          test "$(git rev-parse refs/remotes/origin/meta)" = "$BASE_SHA" ||
+            die "meta changed while Codex plan admission was running"
+          test "$(git rev-parse "refs/remotes/origin/$HEAD_REF")" = \
+            "$HEAD_SHA" ||
+            die "Codex plan branch moved while admission was running"
+          sh .github/workflows/codex-branch.sh validate-plan-transition \
+            --remote origin --base-commit "$BASE_SHA" \
+            --head-commit "$HEAD_SHA"
+          case "$action" in
+          add|alter)
+            sh .github/workflows/codex-branch.sh validate-topic-review \
+              --pull-request "$review_pr" --lane "$lane" \
+              --topic "$topic" --source-tip "$source_tip"
+            gh pr review "$PULL_NUMBER" --repo "$GITHUB_REPOSITORY" \
+              --approve \
+              --body "Mechanical projection of reviewed topic PR #$review_pr at $source_tip."
+            ;;
+          remove|reorder)
+            :
+            ;;
+          esac

--- a/.github/workflows/codex-plan-propose.yml
+++ b/.github/workflows/codex-plan-propose.yml
@@ -1,0 +1,111 @@
+name: Propose Codex plan
+
+on:
+  workflow_call:
+    inputs:
+      lane:
+        description: Target lane
+        required: true
+        type: string
+      topic:
+        description: Exact ??/codex/* topic branch
+        required: true
+        type: string
+      action:
+        description: auto for a reviewed topic, or an explicit plan operation
+        required: true
+        type: string
+      source_tip:
+        description: Full reviewed topic SHA for add or alter
+        required: false
+        type: string
+      review_pr:
+        description: Reviewed topic PR number for add or alter
+        required: false
+        type: string
+      merge:
+        description: Lane root or same-lane prerequisite
+        required: false
+        type: string
+      after:
+        description: Existing topic after which to place this topic, or root
+        required: false
+        type: string
+      plan_branch:
+        description: Optional codex-plan/* branch name
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  propose:
+    name: Create immutable pins and plan PR
+    runs-on: ubuntu-24.04
+    environment: codex-plan
+    steps:
+      - name: Pin trusted meta
+        id: meta
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          sha=$(gh api "repos/$GITHUB_REPOSITORY/git/ref/heads/meta" \
+            --jq .object.sha)
+          case "$sha" in
+          ''|*[!0-9a-f]*) exit 1 ;;
+          esac
+          test "${#sha}" = 40
+          printf 'sha=%s\n' "$sha" >>"$GITHUB_OUTPUT"
+
+      - name: Mint the dedicated Codex plan App token
+        id: plan-app
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          app-id: 1144995
+          private-key: ${{ secrets.CODEX_PLAN_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: git
+          permission-contents: write
+          permission-pull-requests: write
+
+      - name: Check out trusted meta
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          ref: ${{ steps.meta.outputs.sha }}
+          fetch-depth: 0
+          token: ${{ steps.plan-app.outputs.token }}
+          persist-credentials: false
+
+      - name: Propose one pinned plan transition
+        env:
+          GH_TOKEN: ${{ steps.plan-app.outputs.token }}
+          LANE: ${{ inputs.lane }}
+          TOPIC: ${{ inputs.topic }}
+          ACTION: ${{ inputs.action }}
+          SOURCE_TIP: ${{ inputs.source_tip }}
+          REVIEW_PR: ${{ inputs.review_pr }}
+          MERGE: ${{ inputs.merge }}
+          AFTER: ${{ inputs.after }}
+          PLAN_BRANCH: ${{ inputs.plan_branch }}
+          EXPECTED_META: ${{ steps.meta.outputs.sha }}
+        run: |
+          set -euo pipefail
+          test "$GITHUB_REPOSITORY" = openai/git
+          gh auth setup-git
+          set -- sh .github/workflows/codex-branch.sh propose-plan \
+            --remote origin --lane "$LANE" --topic "$TOPIC" \
+            --action "$ACTION" --expected-meta "$EXPECTED_META"
+          test -z "$SOURCE_TIP" ||
+            set -- "$@" --source-tip "$SOURCE_TIP"
+          test -z "$REVIEW_PR" ||
+            set -- "$@" --review-pr "$REVIEW_PR"
+          test -z "$MERGE" ||
+            set -- "$@" --merge "$MERGE"
+          test -z "$AFTER" ||
+            set -- "$@" --after "$AFTER"
+          test -z "$PLAN_BRANCH" ||
+            set -- "$@" --plan-branch "$PLAN_BRANCH"
+          "$@"

--- a/t/t9905-codex-branch.sh
+++ b/t/t9905-codex-branch.sh
@@ -14,6 +14,8 @@ codex_entrypoint=${CODEX_ENTRYPOINT:-$codex_root/codex}
 codex_rebuild=${CODEX_REBUILD:-$codex_root/rebuild}
 codex_publish=${CODEX_PUBLISH:-$codex_root/publish}
 codex_admission_workflow=$codex_root/.github/workflows/codex-admission.yml
+codex_plan_admission_workflow=$codex_root/.github/workflows/codex-plan-admission.yml
+codex_plan_propose_workflow=$codex_root/.github/workflows/codex-plan-propose.yml
 codex_bot_name='chatgpt-codex-connector[bot]'
 codex_bot_email='199175422+chatgpt-codex-connector[bot]@users.noreply.github.com'
 
@@ -76,55 +78,164 @@ write_automation_workflow () {
 
 write_reviewed_automation_workflow () {
 	cat >"$1" <<-'EOF'
-	name: Refresh codex
+name: Refresh codex
 
-	on:
-	  workflow_dispatch:
-	  pull_request:
-	    branches:
-	      - codex
-	      - codex-unstable
-	    types:
-	      - opened
-	      - reopened
-	      - synchronize
-	      - ready_for_review
-	  merge_group:
-	    types:
-	      - checks_requested
+on:
+  workflow_dispatch:
+    inputs:
+      operation:
+        description: Refresh, remove, reorder, or internal topic review
+        type: choice
+        options:
+          - refresh
+          - remove
+          - reorder
+          - topic-review
+        default: refresh
+      lane:
+        description: codex or codex-unstable for a plan operation
+        required: false
+        type: string
+      topic:
+        description: Exact topic branch for a plan operation
+        required: false
+        type: string
+      source_tip:
+        description: Exact reviewed source SHA for internal topic review
+        required: false
+        type: string
+      review_pr:
+        description: Topic PR number for internal topic review
+        required: false
+        type: string
+      after:
+        description: Existing topic or root for reorder
+        required: false
+        type: string
+      plan_branch:
+        description: Optional codex-plan/* branch name
+        required: false
+        type: string
+  pull_request_review:
+    types:
+      - submitted
+  pull_request_target:
+    branches:
+      - meta
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
 
-	permissions:
-	  actions: read
-	  contents: read
-	  pull-requests: read
+permissions:
+  actions: read
+  contents: read
+  pull-requests: read
 
-	jobs:
-	  refresh:
-	    if: github.event_name == 'workflow_dispatch'
-	    uses: openai/git/.github/workflows/codex.yml@meta
-	  admission:
-	    name: Codex admission
-	    if: >-
-	      (github.event_name == 'pull_request' &&
-	       github.event.pull_request.base.ref == 'codex') ||
-	      (github.event_name == 'merge_group' &&
-	       github.event.merge_group.base_ref == 'refs/heads/codex')
-	    permissions:
-	      contents: read
-	      pull-requests: read
-	    uses: openai/git/.github/workflows/codex-admission.yml@meta
-	  unstable_admission:
-	    name: Codex unstable admission
-	    if: >-
-	      (github.event_name == 'pull_request' &&
-	       github.event.pull_request.base.ref == 'codex-unstable') ||
-	      (github.event_name == 'merge_group' &&
-	       github.event.merge_group.base_ref == 'refs/heads/codex-unstable')
-	    permissions:
-	      contents: read
-	      pull-requests: read
-	    uses: openai/git/.github/workflows/codex-admission.yml@meta
+jobs:
+  refresh:
+    if: >-
+      github.event_name == 'workflow_dispatch' &&
+      inputs.operation == 'refresh'
+    uses: openai/git/.github/workflows/codex.yml@meta
+  topic_plan_dispatch:
+    name: Queue reviewed topic plan
+    if: >-
+      github.event_name == 'pull_request_review' &&
+      github.event.review.state == 'approved' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      (github.event.pull_request.base.ref == 'codex' ||
+       github.event.pull_request.base.ref == 'codex-unstable')
+    runs-on: ubuntu-24.04
+    permissions:
+      actions: write
+      contents: read
+    env:
+      GH_TOKEN: ${{ github.token }}
+      DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+      LANE: ${{ github.event.pull_request.base.ref }}
+      TOPIC: ${{ github.event.pull_request.head.ref }}
+      SOURCE_TIP: ${{ github.event.pull_request.head.sha }}
+      REVIEW_PR: ${{ github.event.pull_request.number }}
+    steps:
+      - name: Queue trusted plan proposal
+        run: |
+          set -euo pipefail
+          test "$GITHUB_REPOSITORY" = openai/git
+          test "$DEFAULT_BRANCH" = codex
+          gh workflow run codex.yml --repo "$GITHUB_REPOSITORY" \
+            --ref "$DEFAULT_BRANCH" \
+            -f operation=topic-review \
+            -f lane="$LANE" \
+            -f topic="$TOPIC" \
+            -f source_tip="$SOURCE_TIP" \
+            -f review_pr="$REVIEW_PR"
+  topic_plan_propose:
+    name: Propose reviewed topic plan
+    if: >-
+      github.event_name == 'workflow_dispatch' &&
+      github.ref == 'refs/heads/codex' &&
+      inputs.operation == 'topic-review'
+    permissions:
+      contents: read
+      pull-requests: read
+    uses: openai/git/.github/workflows/codex-plan-propose.yml@meta
+    with:
+      lane: ${{ inputs.lane }}
+      topic: ${{ inputs.topic }}
+      action: auto
+      source_tip: ${{ inputs.source_tip }}
+      review_pr: ${{ inputs.review_pr }}
+  policy_plan_propose:
+    name: Propose explicit plan policy
+    if: >-
+      github.event_name == 'workflow_dispatch' &&
+      github.ref == 'refs/heads/codex' &&
+      (inputs.operation == 'remove' || inputs.operation == 'reorder')
+    permissions:
+      contents: read
+      pull-requests: read
+    uses: openai/git/.github/workflows/codex-plan-propose.yml@meta
+    with:
+      lane: ${{ inputs.lane }}
+      topic: ${{ inputs.topic }}
+      action: ${{ inputs.operation }}
+      after: ${{ inputs.after }}
+      plan_branch: ${{ inputs.plan_branch }}
+  plan_admission:
+    name: Codex plan admission
+    if: >-
+      github.event_name == 'pull_request_target' &&
+      github.event.pull_request.base.ref == 'meta'
+    permissions:
+      contents: read
+      pull-requests: write
+    uses: openai/git/.github/workflows/codex-plan-admission.yml@meta
 	EOF
+}
+
+install_reviewed_automation_topic () {
+	topic=${1:-aa/codex/automation} &&
+	style=${2:-current} &&
+	git switch -c "$topic" master &&
+	mkdir -p .github/workflows &&
+	case "$style" in
+	current)
+		write_reviewed_automation_workflow .github/workflows/codex.yml
+		;;
+	previous)
+		write_stable_reviewed_automation_workflow \
+			.github/workflows/codex.yml
+		;;
+	*) return 1 ;;
+	esac &&
+	git add .github/workflows/codex.yml &&
+	git commit -m "reviewed automation topic" &&
+	automation_tip=$(git rev-parse HEAD) &&
+	automation_tree=$(git rev-parse "$automation_tip^{tree}") &&
+	automation_codex_tip=$(make_test_integration "$topic" \
+		"$automation_tip" master "$automation_tree")
 }
 
 write_stable_reviewed_automation_workflow () {
@@ -292,6 +403,46 @@ write_dual_guarded_release_workflow () {
 	    steps:
 	      - run: echo version
 	EOF
+}
+
+install_bootstrap_pin_guard_gh () {
+	directory=$1 &&
+	mkdir -p "$directory" &&
+	cat >"$directory/gh" <<-'EOF' &&
+	#!/bin/sh
+
+	set -eu
+
+	test "${1:-}" = api || exit 90
+	shift
+	endpoint=
+	while test $# -gt 0
+	do
+		case "$1" in
+		repos/openai/git/rulesets\?*) endpoint=list ;;
+		repos/openai/git/rulesets/123) endpoint=detail ;;
+		esac
+		shift
+	done
+	test -n "$endpoint" || exit 91
+	case "$endpoint" in
+	list)
+		if test "${FAKE_BOOTSTRAP_PIN_GUARD:-active}" = active
+		then
+			printf '%s\n' 123
+		fi
+		;;
+	detail)
+		if test "${FAKE_BOOTSTRAP_PIN_GUARD:-active}" = active
+		then
+			printf '%s\n' true
+		else
+			printf '%s\n' false
+		fi
+		;;
+	esac
+	EOF
+	chmod +x "$directory/gh"
 }
 
 install_admission_gh () {
@@ -1063,6 +1214,157 @@ install_unstable_meta_state () (
 	rm -f "$state_topics" "$state_config" "$state_index"
 )
 
+write_pinned_plan () (
+	lane=$1
+	base_branch=$2
+	rows=$3
+	output=$4
+	base_tip=$(git rev-parse "$base_branch") &&
+	{
+		printf "[plan]\n" &&
+		printf "\tversion = 1\n" &&
+		printf "\tlane = %s\n" "$lane" &&
+		printf "\tbase-ref = refs/heads/%s\n" "$base_branch" &&
+		while IFS="$(printf '\t')" read -r name source_tip codex_tip prerequisite
+		do
+			printf "\ttopic = refs/heads/%s\n" "$name"
+		done <"$rows" &&
+		while IFS="$(printf '\t')" read -r name source_tip codex_tip prerequisite
+		do
+			printf "\n[branch \"%s\"]\n" "$name" &&
+			printf "\tremote = .\n" &&
+			printf "\tsource-ref = refs/heads/%s\n" "$name" &&
+			printf "\tsource-tip = %s\n" "$source_tip" &&
+			if test "$prerequisite" = "$base_branch"
+			then
+				source_base=$base_tip
+			else
+				source_base=$(awk -F "$(printf '\t')" \
+					-v name="$prerequisite" \
+					'$1 == name { print $2; exit }' "$rows") &&
+				test -n "$source_base"
+			fi &&
+			printf "\tsource-base = %s\n" "$source_base" &&
+			printf "\tmerge = refs/heads/%s\n" "$prerequisite"
+		done <"$rows"
+	} >"$output"
+)
+
+install_pinned_meta_state () (
+	meta_branch=$1
+	base_branch=$2
+	stable_branch=$3
+	unstable_branch=${4:-}
+	if test -n "$unstable_branch"
+	then
+		install_unstable_meta_state "$meta_branch" "$base_branch" \
+			"$stable_branch" "$unstable_branch"
+	else
+		install_meta_state "$meta_branch" "$base_branch" "$stable_branch"
+	fi &&
+	meta_parent=$(git rev-parse "$meta_branch") &&
+	old_config=.codex-pinned-old-config &&
+	stable_rows=.codex-pinned-stable-rows &&
+	unstable_rows=.codex-pinned-unstable-rows &&
+	stable_plan=.codex-pinned-stable-plan &&
+	unstable_plan=.codex-pinned-unstable-plan &&
+	state_config=.codex-pinned-state-config &&
+	state_index=.codex-pinned-state-index &&
+	git show "$meta_parent:codex.config" >"$old_config" &&
+	base_tip=$(git config --file "$old_config" --get codex.base-tip) &&
+	stable_tip=$(git config --file "$old_config" --get codex.output-tip) &&
+	: >"$stable_rows" &&
+	: >"$unstable_rows" &&
+	git config --file "$old_config" --get-regexp '^branch\..*\.codex-tip$' |
+	while IFS=' ' read -r key codex_tip
+	do
+		name=${key#branch.} &&
+		name=${name%.codex-tip} &&
+		source_tip=$(git rev-parse "$name") &&
+		prerequisite=$(git config --file "$old_config" \
+			--get "branch.$name.merge") &&
+		prerequisite=${prerequisite#refs/heads/} &&
+		case "$name" in
+		*-unstable)
+			printf "%s\t%s\t%s\t%s\n" "$name" "$source_tip" \
+				"$codex_tip" "$prerequisite" >>"$unstable_rows"
+			;;
+		*)
+			printf "%s\t%s\t%s\t%s\n" "$name" "$source_tip" \
+				"$codex_tip" "$prerequisite" >>"$stable_rows"
+			;;
+		esac
+	done &&
+	LC_ALL=C sort -o "$stable_rows" "$stable_rows" &&
+	LC_ALL=C sort -o "$unstable_rows" "$unstable_rows" &&
+	cat "$stable_rows" "$unstable_rows" |
+	while IFS="$(printf '\t')" read -r name source_tip codex_tip prerequisite
+	do
+		git update-ref "refs/heads/codex-pins/$source_tip" "$source_tip"
+	done &&
+	write_pinned_plan codex "$base_branch" "$stable_rows" "$stable_plan" &&
+	stable_plan_blob=$(git hash-object -w "$stable_plan") &&
+	if test -n "$unstable_branch"
+	then
+		write_pinned_plan codex-unstable codex "$unstable_rows" \
+			"$unstable_plan" &&
+		unstable_plan_blob=$(git hash-object -w "$unstable_plan") &&
+		unstable_tip=$(git config --file "$old_config" \
+			--get codex-unstable.output-tip)
+	else
+		unstable_plan_blob=
+	fi &&
+	{
+		printf "[codex]\n" &&
+		printf "\tversion = 3\n" &&
+		printf "\tbase-ref = refs/heads/%s\n" "$base_branch" &&
+		printf "\tbase-tip = %s\n" "$base_tip" &&
+		printf "\toutput-ref = refs/heads/%s\n" "$stable_branch" &&
+		printf "\toutput-tip = %s\n" "$stable_tip" &&
+		printf "\tapplied-plan = %s\n" "$stable_plan_blob" &&
+		if test -n "$unstable_branch"
+		then
+			printf "\n[codex-unstable]\n" &&
+			printf "\tbase-ref = refs/heads/%s\n" "$stable_branch" &&
+			printf "\tbase-tip = %s\n" "$stable_tip" &&
+			printf "\toutput-ref = refs/heads/codex-unstable\n" &&
+			printf "\toutput-tip = %s\n" "$unstable_tip" &&
+			printf "\tapplied-plan = %s\n" "$unstable_plan_blob"
+		fi &&
+		cat "$stable_rows" "$unstable_rows" |
+		while IFS="$(printf '\t')" read -r name source_tip codex_tip prerequisite
+		do
+			printf "\n[branch \"%s\"]\n" "$name" &&
+			printf "\tremote = .\n" &&
+			printf "\tsource-ref = refs/heads/%s\n" "$name" &&
+			printf "\tsource-tip = %s\n" "$source_tip" &&
+			printf "\tmerge = refs/heads/%s\n" "$prerequisite" &&
+			printf "\tcodex-tip = %s\n" "$codex_tip"
+		done
+	} >"$state_config" &&
+	blob=$(git hash-object -w "$state_config") &&
+	helper_blob=$(git hash-object -w "$codex_branch") &&
+	rm -f "$state_index" &&
+	GIT_INDEX_FILE=$state_index git read-tree "$meta_parent^{tree}" &&
+	GIT_INDEX_FILE=$state_index git update-index --add --cacheinfo \
+		100644,"$blob",codex.config &&
+	GIT_INDEX_FILE=$state_index git update-index --add --cacheinfo \
+		100644,"$stable_plan_blob",codex.plan &&
+	if test -n "$unstable_branch"
+	then
+		GIT_INDEX_FILE=$state_index git update-index --add --cacheinfo \
+			100644,"$unstable_plan_blob",codex-unstable.plan
+	fi &&
+	GIT_INDEX_FILE=$state_index git update-index --add --cacheinfo \
+		100755,"$helper_blob",.github/workflows/codex-branch.sh &&
+	tree=$(GIT_INDEX_FILE=$state_index git write-tree) &&
+	meta_tip=$(printf "%s\n" "meta: initialize pinned Codex plans" |
+		git commit-tree "$tree" -p "$meta_parent") &&
+	git update-ref "refs/heads/$meta_branch" "$meta_tip" "$meta_parent" &&
+	rm -f "$old_config" "$stable_rows" "$unstable_rows" \
+		"$stable_plan" "$unstable_plan" "$state_config" "$state_index"
+)
+
 create_unstable_sentinel () (
 	base=$(git rev-parse "$1") &&
 	tree=$(git rev-parse "$base^{tree}") &&
@@ -1319,105 +1621,76 @@ test_expect_success 'refresh only prepares an immutable local-publish artifact' 
 	done
 '
 
-test_expect_success 'reviewed admission requires one app-authenticated queue entry' '
-	test -f "$codex_admission_workflow" &&
-	test_grep "name: Verify reviewed topic" \
-		"$codex_admission_workflow" &&
-	test_grep "pull_request)" "$codex_admission_workflow" &&
-	test_grep "merge_group)" "$codex_admission_workflow" &&
-	test_grep "codex.output-tip" "$codex_admission_workflow" &&
-	test_grep "codex-unstable.output-tip" "$codex_admission_workflow" &&
-	test_grep "case \\\"\\\$GITHUB_REF\\\" in" \
-		"$codex_admission_workflow" &&
-	test_grep "refs/heads/gh-readonly-queue/" \
-		"$codex_admission_workflow" &&
-	test_grep "pull-requests: read" "$codex_admission_workflow" &&
-	! grep -E "contents: write|pull-requests: write|statuses: write|id-token|actions/checkout|git push" \
-		"$codex_admission_workflow" &&
-	test_grep "  pull_request:" "$codex_branch" &&
-	test_grep "  merge_group:" "$codex_branch" &&
-	test_grep "codex-admission.yml@meta" "$codex_branch" &&
+test_expect_success 'generated lanes are output-only and meta gates review in the admission check' '
+	for lane in codex codex-unstable
+	do
+		rules="$codex_root/.github/rulesets/$lane-branch.json" &&
+		jq -e --arg ref "refs/heads/$lane" "
+			.conditions.ref_name.include == [\$ref] and
+			([.rules[].type] | sort) ==
+				[\"creation\",\"deletion\",\"update\"] and
+			(.rules[] | select(.type == \"update\") |
+			 .parameters.update_allows_fetch_and_merge == false) and
+			([.rules[] | select(.type == \"merge_queue\" or
+			 .type == \"required_status_checks\" or
+			 .type == \"pull_request\")] | length) == 0
+		" "$rules" || return 1
+	done &&
 	jq -e "
-		(.rules[] | select(.type == \"merge_queue\") |
-		 .parameters.merge_method == \"MERGE\" and
-		 .parameters.grouping_strategy == \"ALLGREEN\" and
-		 .parameters.max_entries_to_build == 1 and
-		 .parameters.max_entries_to_merge == 1 and
-		 .parameters.min_entries_to_merge == 1) and
+		(.rules[] | select(.type == \"pull_request\") |
+		 .parameters.required_approving_review_count == 1 and
+		 .parameters.require_last_push_approval == true and
+		 .parameters.dismiss_stale_reviews_on_push == true) and
 		(.rules[] | select(.type == \"required_status_checks\") |
-		 .parameters.strict_required_status_checks_policy == false and
+		 .parameters.strict_required_status_checks_policy == true and
 		 .parameters.required_status_checks == [{
-		   \"context\": \"Codex admission / Verify reviewed topic\",
+		   \"context\": \"Codex plan admission / Verify pinned manifest\",
 		   \"integration_id\": 15368
-		 }])
-	" "$codex_root/.github/rulesets/codex-branch.json" &&
-	if test -n "${CODEX_AUTOMATION_TOPIC:-}"
-	then
-		test_grep "  pull_request:" "$CODEX_AUTOMATION_TOPIC" &&
-		test_grep "  merge_group:" "$CODEX_AUTOMATION_TOPIC" &&
-		test_grep "codex-admission.yml@meta" "$CODEX_AUTOMATION_TOPIC"
-	fi &&
-	if test -n "${CODEX_RELEASE_TOPIC:-}"
-	then
-		test_grep "  publication:" "$CODEX_RELEASE_TOPIC" &&
-		test_grep "    needs: publication" "$CODEX_RELEASE_TOPIC" &&
-		test_grep "codex.output-tip" "$CODEX_RELEASE_TOPIC" &&
-		! grep -F "git/ref/heads/codex" "$CODEX_RELEASE_TOPIC" &&
-		test_grep "git/ref/heads/meta" "$CODEX_RELEASE_TOPIC" &&
-		if grep -F "codex-unstable" "$CODEX_RELEASE_TOPIC" >/dev/null
-		then
-			test_grep "codex-unstable.output-tip" \
-				"$CODEX_RELEASE_TOPIC" &&
-			test_grep "case \\\"\\\$GITHUB_REF\\\" in" \
-				"$CODEX_RELEASE_TOPIC" &&
-			test_grep "github.event.deleted == false" \
-				"$CODEX_RELEASE_TOPIC"
-		fi
-	fi
+		 }]) and
+		([.bypass_actors[] | select(.actor_type == \"Integration\")] |
+		 length) == 0
+	" "$codex_root/.github/rulesets/codex-meta.json"
 '
 
-test_expect_success 'admission workflow executes both pull-request and queue checks' '
-	install_admission_gate_gh "$TRASH_DIRECTORY/admission-gate-bin" &&
-	sed -n "/^        run: |\$/,/^        [^ ]/p" \
-		"$codex_admission_workflow" |
-	sed "1d; s/^          //" >"$TRASH_DIRECTORY/admission-gate.sh" &&
-	test_grep "set -euo pipefail" "$TRASH_DIRECTORY/admission-gate.sh" &&
-	bash -n "$TRASH_DIRECTORY/admission-gate.sh" &&
-	run_admission_gate success pull_request >pull.out &&
-	test_grep "Approved pull request #42" pull.out &&
-	run_admission_gate legacy-release pull_request >legacy-release.out &&
-	test_grep "Approved pull request #42" legacy-release.out &&
-	run_admission_gate pending pull_request >pending-pull.out &&
-	test_grep "Approved pull request #42" pending-pull.out &&
-	run_admission_gate success merge_group >queue.out &&
-	test_grep "Approved pull request #42" queue.out &&
-	run_admission_gate same-tip-alias merge_group >alias.out &&
-	test_grep "Approved pull request #42" alias.out &&
-	run_admission_gate newer-master merge_group >newer-master.out &&
-	test_grep "Approved pull request #42" newer-master.out &&
-	for mode in pending wrong-parent unapproved multiple-pulls \
-		changed-topic changed-workflow hidden-prerequisite \
-		hidden-wip hidden-stale hidden-unstable hidden-enrolled-unstable
-	do
-		test_expect_code 1 run_admission_gate "$mode" merge_group \
-			>"queue-$mode.out" 2>"queue-$mode.err" || return 1
-	done &&
-	test_grep "pending topic" queue-pending.err &&
-	test_grep "unenrolled history" queue-hidden-prerequisite.err &&
-	for mode in dual-release-legacy-guard dual-release-no-delete \
-		dual-release-wrong-key
-	do
-		test_expect_code 1 run_admission_gate "$mode" merge_group \
-			>"$mode.out" 2>"$mode.err" &&
-		test_grep "controller-only release guard" "$mode.err" || return 1
-	done &&
-	test_expect_code 1 \
-		run_admission_gate success pull_request \
-			bb/codex/reviewed-unstable \
-		>unstable-pull.out 2>unstable-pull.err &&
-	test_grep "not eligible for production codex" unstable-pull.err
+test_expect_success 'plan admission checks the exact reviewed head from trusted meta' '
+	test_path_is_file "$codex_plan_admission_workflow" &&
+	test_grep "name: Codex plan admission" \
+		"$codex_plan_admission_workflow" &&
+	test_grep "  workflow_call:" "$codex_plan_admission_workflow" &&
+	! grep -F "  pull_request_review:" \
+		"$codex_plan_admission_workflow" &&
+	test_grep "pull_request_review:" "$codex_branch" &&
+	test_grep "pull_request_target:" "$codex_branch" &&
+	test_grep "topic_plan_dispatch:" "$codex_branch" &&
+	test_grep "actions: write" "$codex_branch" &&
+	test_grep "gh workflow run codex.yml" "$codex_branch" &&
+	test_grep "inputs.operation == .*topic-review" "$codex_branch" &&
+	sed -n "/^  topic_plan_dispatch:/,/^  topic_plan_propose:/p" "$codex_branch" >review-dispatch &&
+	! grep -E "codex-plan-propose|environment:|CODEX_PLAN_APP_PRIVATE_KEY|contents: write|pull-requests: write" review-dispatch &&
+	test_grep "action: auto" "$codex_branch" &&
+	test_grep "policy_plan_propose:" "$codex_branch" &&
+	test_grep "inputs.operation" "$codex_branch" &&
+	test_grep "codex-plan-admission.yml@meta" "$codex_branch" &&
+	! grep -E "^[[:space:]]+paths(-ignore)?:" \
+		"$codex_plan_admission_workflow" &&
+	test_grep "contents: read" "$codex_plan_admission_workflow" &&
+	test_grep "pull-requests: write" "$codex_plan_admission_workflow" &&
+	! grep -E "contents: write|statuses: write|id-token|git push" \
+		"$codex_plan_admission_workflow" &&
+	test_grep "github.event.pull_request.base.sha" \
+		"$codex_plan_admission_workflow" &&
+	test_grep "validate-plan-transition" \
+		"$codex_plan_admission_workflow" &&
+	test_grep "validate-topic-review" \
+		"$codex_plan_admission_workflow" &&
+	test_grep "ordinary meta review applies" \
+		"$codex_plan_admission_workflow" &&
+	test_grep "gh pr review" "$codex_plan_admission_workflow" &&
+	test_grep "Codex plan branch moved while admission was running" \
+		"$codex_plan_admission_workflow" &&
+	test_grep "meta changed while Codex plan admission was running" \
+		"$codex_plan_admission_workflow"
 '
-
 test_expect_success 'dual-lane release gate selects only the exact published output' '
 	write_dual_guarded_release_workflow \
 		"$TRASH_DIRECTORY/codex-release.yml" &&
@@ -2073,7 +2346,9 @@ test_expect_success 'the reviewed automation trampoline cannot be downgraded' '
 					--require-automation &&
 				git show "$(cat result):.github/workflows/codex.yml" \
 					>candidate-workflow &&
-				test_grep "  merge_group:" candidate-workflow
+				test_grep "  pull_request_target:" candidate-workflow &&
+				test_grep "codex-plan-admission.yml@meta" \
+					candidate-workflow
 			else
 				test_expect_code 1 \
 					sh "$codex_branch" rewrite --remote origin \
@@ -5772,56 +6047,55 @@ test_expect_success PYTHON 'publish-run authenticates the artifact and promotes 
 	)
 '
 
-test_expect_success 'unstable rules require one app-authenticated queue entry' '
-	rules="$codex_root/.github/rulesets/codex-unstable-branch.json" &&
-	test_path_is_file "$rules" &&
+test_expect_success 'pins are App-created, immutable, and plan branches are App-owned' '
 	jq -e "
-		(.conditions.ref_name.include == [\"refs/heads/codex-unstable\"]) and
-		(.rules[] | select(.type == \"merge_queue\") |
-		 .parameters.merge_method == \"MERGE\" and
-		 .parameters.grouping_strategy == \"ALLGREEN\" and
-		 .parameters.max_entries_to_build == 1 and
-		 .parameters.max_entries_to_merge == 1 and
-		 .parameters.min_entries_to_merge == 1) and
-		(.rules[] | select(.type == \"required_status_checks\") |
-		 .parameters.required_status_checks == [{
-		   \"context\": \"Codex unstable admission / Verify reviewed topic\",
-		   \"integration_id\": 15368
-		 }])
-	" "$rules" &&
-	test_grep "codex-unstable.output-tip" "$codex_admission_workflow" &&
-	test_grep "codex-unstable.base-tip" "$codex_admission_workflow"
+		.conditions.ref_name.include == [\"refs/heads/codex-pins/*\"] and
+		[.rules[].type] == [\"creation\"] and
+		(any(.bypass_actors[]; .actor_type == \"Integration\" and
+		 .actor_id == 1144995))
+	" "$codex_root/.github/rulesets/codex-pins.json" &&
+	jq -e "
+		.conditions.ref_name.include == [\"refs/heads/codex-pins/*\"] and
+		([.rules[].type] | sort) == [\"deletion\",\"update\"] and
+		(.rules[] | select(.type == \"update\") |
+		 .parameters.update_allows_fetch_and_merge == false) and
+		([.bypass_actors[] | select(.actor_type == \"Integration\")] |
+		 length) == 0
+	" "$codex_root/.github/rulesets/codex-pins-immutable.json" &&
+	jq -e "
+		.conditions.ref_name.include == [\"refs/heads/codex-plan/*\"] and
+		([.rules[].type] | sort) ==
+			[\"creation\",\"deletion\",\"update\"] and
+		(.rules[] | select(.type == \"update\") |
+		 .parameters.update_allows_fetch_and_merge == false) and
+		(any(.bypass_actors[]; .actor_type == \"Integration\" and
+		 .actor_id == 1144995))
+	" "$codex_root/.github/rulesets/codex-plan-branches.json" &&
+	test_grep "codex-plan/\*/\*" "$codex_branch" &&
+	test_grep "codex-plan/\*/\*" "$codex_plan_admission_workflow"
 '
 
-test_expect_success 'unstable admission executes both lane-specific checks' '
-	install_admission_gate_gh "$TRASH_DIRECTORY/admission-gate-bin" &&
-	sed -n "/^        run: |\$/,/^        [^ ]/p" \
-		"$codex_admission_workflow" |
-	sed "1d; s/^          //" >"$TRASH_DIRECTORY/admission-gate.sh" &&
-	run_admission_gate success pull_request \
-		bb/codex/reviewed-unstable codex-unstable >unstable-pull.out &&
-	test_grep "Approved pull request #42" unstable-pull.out &&
-	run_admission_gate success merge_group \
-		bb/codex/reviewed-unstable codex-unstable >unstable-queue.out &&
-	test_grep "Approved pull request #42" unstable-queue.out &&
-	run_admission_gate descendant-checkpoint merge_group \
-		bb/codex/reviewed-unstable codex-unstable \
-		>unstable-descendant-queue.out &&
-	test_grep "Approved pull request #42" \
-		unstable-descendant-queue.out &&
-	for mode in pending wrong-parent unapproved multiple-pulls \
-		changed-topic changed-workflow hidden-prerequisite
-	do
-		test_expect_code 1 run_admission_gate "$mode" merge_group \
-			bb/codex/reviewed-unstable codex-unstable \
-			>"unstable-$mode.out" 2>"unstable-$mode.err" || return 1
-	done &&
-	test_expect_code 1 run_admission_gate success pull_request \
-		bb/codex/reviewed codex-unstable \
-		>stable-in-unstable.out 2>stable-in-unstable.err &&
-	test_grep "unstable" stable-in-unstable.err
+test_expect_success 'plan producer uses the dedicated App from trusted meta' '
+	test_path_is_file "$codex_plan_propose_workflow" &&
+	test_grep "name: Propose Codex plan" \
+		"$codex_plan_propose_workflow" &&
+	test_grep "  workflow_call:" \
+		"$codex_plan_propose_workflow" &&
+	test_grep "environment: codex-plan" \
+		"$codex_plan_propose_workflow" &&
+	test_grep "actions/create-github-app-token@" \
+		"$codex_plan_propose_workflow" &&
+	test_grep "app-id: 1144995" \
+		"$codex_plan_propose_workflow" &&
+	test_grep "CODEX_PLAN_APP_PRIVATE_KEY" \
+		"$codex_plan_propose_workflow" &&
+	test_grep "steps.meta.outputs.sha" "$codex_plan_propose_workflow" &&
+	test_grep "expected-meta" "$codex_plan_propose_workflow" &&
+	test_grep "propose-plan" "$codex_plan_propose_workflow" &&
+	test_grep "review-pr" "$codex_plan_propose_workflow" &&
+	test_grep "plan-branch" "$codex_plan_propose_workflow" &&
+	! grep -F "\$\${" "$codex_plan_propose_workflow"
 '
-
 test_expect_success 'unadmitted unstable checkpoints leave v1 output unchanged' '
 	setup_pending_admission inert-unstable-checkpoints &&
 	enrolled=$(git --git-dir=inert-unstable-checkpoints.git \
@@ -7986,6 +8260,630 @@ test_expect_success 'verify-output rejects a flattened unstable fan-in merge' '
 			>flattened.out 2>flattened.err &&
 		test_grep "merge rewrite.*topology" flattened.err
 	)
+'
+
+test_expect_success 'pinned plans keep source refs immutable while rebuilding outputs' '
+	git init --bare pinned-plan.git &&
+	test_create_repo pinned-plan-source &&
+	(
+		cd pinned-plan-source &&
+		git remote add origin ../pinned-plan.git &&
+		write base shared &&
+		git add shared &&
+		install_rerere_train &&
+		git commit -m "pinned base" &&
+		install_reviewed_automation_topic &&
+		git switch -c aa/codex/enrolled "$automation_tip" &&
+		write enrolled enrolled-file &&
+		git add enrolled-file &&
+		git commit -m "pinned stable topic" &&
+		stable_topic=$(git rev-parse HEAD) &&
+		stable_tree=$(git rev-parse "$stable_topic^{tree}") &&
+		codex_tip=$(make_test_integration aa/codex/enrolled \
+			"$stable_topic" "$automation_codex_tip" "$stable_tree") &&
+		git branch codex "$codex_tip" &&
+		create_unstable_sentinel codex &&
+		git branch meta master &&
+		install_pinned_meta_state meta master codex codex-unstable &&
+		git switch -c tb/codex/preview-unstable codex &&
+		write preview preview-file &&
+		git add preview-file &&
+		git commit -m "pinned preview topic" &&
+		git switch -c preview-side-a codex &&
+		write side-a side-a-file &&
+		git add side-a-file &&
+		git commit -m "preview side a" &&
+		git switch tb/codex/preview-unstable &&
+		git merge --no-ff preview-side-a -m "merge preview side a" &&
+		git switch -c preview-side-b codex &&
+		write side-b side-b-file &&
+		git add side-b-file &&
+		git commit -m "preview side b" &&
+		git switch tb/codex/preview-unstable &&
+		git merge --no-ff preview-side-b -m "merge preview side b" &&
+		pin=$(git rev-parse HEAD) &&
+		git update-ref "refs/heads/codex-pins/$pin" "$pin" &&
+		git switch meta &&
+		printf "%s\t%s\t%s\t%s\n" \
+			tb/codex/preview-unstable "$pin" "$pin" codex \
+			>pinned.rows &&
+		write_pinned_plan codex-unstable codex pinned.rows \
+			codex-unstable.plan &&
+		git add codex-unstable.plan &&
+		git commit -m "meta: pin preview topic" &&
+		git push origin --all
+	) &&
+	git clone pinned-plan.git pinned-plan-runner &&
+	(
+		cd pinned-plan-runner &&
+		fetch_all &&
+		pin=$(git rev-parse origin/tb/codex/preview-unstable) &&
+		sh "$codex_branch" rewrite --remote origin \
+			--base master --codex codex --result result \
+			--updates updates --inputs inputs --failure failure &&
+		tab=$(printf "\t") &&
+		! grep \
+			"^refs/heads/tb/codex/preview-unstable$tab" updates &&
+		test_grep "pin$tab""refs/heads/codex-pins/$pin$tab$pin" \
+			inputs &&
+		meta=$(updated_tip meta updates) &&
+		unstable=$(updated_tip codex-unstable updates) &&
+		test "$(git show "$meta:codex.config" |
+			git config --file /dev/stdin \
+				--get branch.tb/codex/preview-unstable.source-tip)" = \
+			"$pin" &&
+		generated=$(git show "$meta:codex.config" |
+			git config --file /dev/stdin \
+				--get branch.tb/codex/preview-unstable.codex-tip) &&
+		test "$generated" = "$pin" &&
+		test "$(git rev-list --min-parents=2 \
+			"origin/codex..$generated" | wc -l | tr -d " ")" = 2 &&
+		git merge-base --is-ancestor "$generated" "$unstable" &&
+		sh "$codex_branch" verify-output --inputs inputs \
+			--updates updates --result result
+	)
+'
+
+test_expect_success 'a v2 controller can bootstrap both pinned plans in one meta change' '
+	git init --bare pinned-bootstrap.git &&
+	test_create_repo pinned-bootstrap-source &&
+	(
+		cd pinned-bootstrap-source &&
+		git remote add origin ../pinned-bootstrap.git &&
+		write base shared &&
+		git add shared &&
+		install_rerere_train &&
+		git commit -m "bootstrap base" &&
+		install_reviewed_automation_topic &&
+		git switch -c aa/codex/enrolled "$automation_tip" &&
+		write enrolled enrolled-file &&
+		git add enrolled-file &&
+		git commit -m "bootstrap stable topic" &&
+		stable_topic=$(git rev-parse HEAD) &&
+		stable_tree=$(git rev-parse "$stable_topic^{tree}") &&
+		codex_tip=$(make_test_integration aa/codex/enrolled \
+			"$stable_topic" "$automation_codex_tip" "$stable_tree") &&
+		git branch codex "$codex_tip" &&
+		create_unstable_sentinel codex &&
+		git branch meta master &&
+		install_unstable_meta_state meta master codex codex-unstable &&
+		git switch aa/codex/enrolled &&
+		write advanced advanced-file &&
+		git add advanced-file &&
+		git commit -m "unplanned stable advance" &&
+		git switch -c tb/codex/preview-unstable codex &&
+		write preview preview-file &&
+		git add preview-file &&
+		git commit -m "bootstrap preview topic" &&
+		preview_tip=$(git rev-parse HEAD) &&
+		git update-ref "refs/heads/codex-pins/$automation_tip" \
+			"$automation_tip" &&
+		git update-ref "refs/heads/codex-pins/$stable_topic" \
+			"$stable_topic" &&
+		git update-ref "refs/heads/codex-pins/$preview_tip" \
+			"$preview_tip" &&
+		git switch meta &&
+		printf "%s\t%s\t%s\t%s\n" aa/codex/automation \
+			"$automation_tip" "$automation_tip" master >stable.rows &&
+		printf "%s\t%s\t%s\t%s\n" aa/codex/enrolled \
+			"$stable_topic" "$stable_topic" aa/codex/automation \
+			>>stable.rows &&
+		printf "%s\t%s\t%s\t%s\n" tb/codex/preview-unstable \
+			"$preview_tip" "$preview_tip" codex >unstable.rows &&
+		write_pinned_plan codex master stable.rows codex.plan &&
+		write_pinned_plan codex-unstable codex unstable.rows \
+			codex-unstable.plan &&
+		git add codex.plan codex-unstable.plan &&
+		git commit -m "meta: bootstrap pinned plans" &&
+		git push origin --all
+	) &&
+	git clone pinned-bootstrap.git pinned-bootstrap-runner &&
+	(
+		cd pinned-bootstrap-runner &&
+		fetch_all &&
+		sh "$codex_branch" rewrite --remote origin \
+			--base master --codex codex --result result \
+			--updates updates --inputs inputs --failure failure &&
+		meta=$(updated_tip meta updates) &&
+		test "$(git show "$meta:codex.config" |
+			git config --file /dev/stdin --get codex.version)" = 3 &&
+		test_grep "plan$(printf "\t")codex.plan" inputs &&
+		test_grep "unstable-plan$(printf "\t")codex-unstable.plan" \
+			inputs &&
+		sh "$codex_branch" verify-output --inputs inputs \
+			--updates updates --result result
+	)
+'
+
+test_expect_success 'propose-plan atomically creates immutable pins and a plan PR head' '
+	git init --bare proposed-plan.git &&
+	test_create_repo proposed-plan-source &&
+	(
+		cd proposed-plan-source &&
+		git remote add origin ../proposed-plan.git &&
+		write base shared &&
+		git add shared &&
+		install_rerere_train &&
+		git commit -m "proposal base" &&
+		install_reviewed_automation_topic &&
+		git switch -c aa/codex/enrolled "$automation_tip" &&
+		write enrolled enrolled-file &&
+		git add enrolled-file &&
+		git commit -m "proposal stable topic" &&
+		stable_topic=$(git rev-parse HEAD) &&
+		stable_tree=$(git rev-parse "$stable_topic^{tree}") &&
+		codex_tip=$(make_test_integration aa/codex/enrolled \
+			"$stable_topic" "$automation_codex_tip" "$stable_tree") &&
+		git branch codex "$codex_tip" &&
+		create_unstable_sentinel codex &&
+		git branch meta master &&
+		install_unstable_meta_state meta master codex codex-unstable &&
+		git switch -c tb/codex/preview-unstable codex &&
+		write preview preview-file &&
+		git add preview-file &&
+		git commit -m "proposal preview topic" &&
+		git push origin --all
+	) &&
+	git clone proposed-plan.git proposed-plan-runner &&
+	(
+		cd proposed-plan-runner &&
+		fetch_all &&
+		mkdir plan-bin &&
+		cat >plan-bin/gh <<-\EOF &&
+		#!/bin/sh
+		case " $* " in
+		*"/pulls/999/reviews?"*)
+			printf "%s\t%s\t%s\t%s\n" reviewer APPROVED \
+				"$FAKE_TIP" MEMBER
+			exit 0
+			;;
+		*"/pulls/999 "*)
+			printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\n" \
+				open false codex-unstable openai/git \
+				"$FAKE_TOPIC" "$FAKE_TIP" author
+			exit 0
+			;;
+		esac
+		if test "$1" = pr && test "$2" = view
+		then
+			printf "%s\n" APPROVED
+			exit 0
+		fi
+		if test "$1" = pr && test "$2" = merge
+		then
+			exit 0
+		fi
+		test "$1" = pr &&
+		test "$2" = create &&
+		printf "%s\n" https://github.com/openai/git/pull/999
+		EOF
+		chmod +x plan-bin/gh &&
+		preview=$(git rev-parse origin/tb/codex/preview-unstable) &&
+		before_topic=$(git rev-parse origin/tb/codex/preview-unstable) &&
+		FAKE_TOPIC=tb/codex/preview-unstable FAKE_TIP="$preview" \
+		PATH="$PWD/plan-bin:$PATH" sh "$codex_branch" propose-plan \
+			--remote origin --lane codex-unstable \
+			--topic tb/codex/preview-unstable \
+			--source-tip "$preview" --review-pr 999 --action auto \
+			--plan-branch codex-plan/preview >out &&
+		fetch_all &&
+		plan=$(git rev-parse origin/codex-plan/preview) &&
+		test "$(git show -s --format=%P "$plan")" = \
+			"$(git rev-parse origin/meta)" &&
+		git cat-file -e "$plan:codex.plan" &&
+		git cat-file -e "$plan:codex-unstable.plan" &&
+		test "$(git rev-parse \
+			origin/codex-pins/$preview)" = "$preview" &&
+		test "$(git rev-parse \
+			origin/tb/codex/preview-unstable)" = "$before_topic" &&
+		sh "$codex_branch" validate-plan-transition --remote origin \
+			--base-commit origin/meta --head-commit "$plan" &&
+		test_grep "opened pinned plan pull request" out
+	)
+'
+
+test_expect_success 'a pinned root keeps its reviewed boundary after base and source refs move' '
+	git init --bare pinned-root-boundary.git &&
+	test_create_repo pinned-root-boundary-source &&
+	(
+		cd pinned-root-boundary-source &&
+		git remote add origin ../pinned-root-boundary.git &&
+		write base shared &&
+		git add shared &&
+		install_rerere_train &&
+		git commit -m "boundary base" &&
+		install_reviewed_automation_topic &&
+		git switch -c aa/codex/enrolled "$automation_tip" &&
+		write enrolled enrolled-file &&
+		git add enrolled-file &&
+		git commit -m "boundary enrolled topic" &&
+		enrolled=$(git rev-parse HEAD) &&
+		enrolled_tree=$(git rev-parse "$enrolled^{tree}") &&
+		codex_tip=$(make_test_integration aa/codex/enrolled \
+			"$enrolled" "$automation_codex_tip" "$enrolled_tree") &&
+		git branch codex "$codex_tip" &&
+		git branch meta master &&
+		install_meta_state meta master codex &&
+		git switch -c bb/codex/new-root master &&
+		write topic new-root-file &&
+		git add new-root-file &&
+		git commit -m "reviewed new root" &&
+		git push origin --all
+	) &&
+	git clone pinned-root-boundary.git pinned-root-boundary-runner &&
+	(
+		cd pinned-root-boundary-runner &&
+		fetch_all &&
+		mkdir plan-bin &&
+		cat >plan-bin/gh <<-\EOF &&
+		#!/bin/sh
+		case " $* " in
+		*"/pulls/1000/reviews?"*)
+			printf "%s\t%s\t%s\t%s\n" reviewer APPROVED \
+				"$FAKE_TIP" MEMBER
+			exit 0
+			;;
+		*"/pulls/1000 "*)
+			printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\n" \
+				open false codex openai/git \
+				"$FAKE_TOPIC" "$FAKE_TIP" author
+			exit 0
+			;;
+		esac
+		if test "$1" = pr && test "$2" = view
+		then
+			printf "%s\n" APPROVED
+			exit 0
+		fi
+		if test "$1" = pr && test "$2" = merge
+		then
+			exit 0
+		fi
+		test "$1" = pr &&
+		test "$2" = create &&
+		printf "%s\n" https://github.com/openai/git/pull/1000
+		EOF
+		chmod +x plan-bin/gh &&
+		reviewed=$(git rev-parse origin/bb/codex/new-root) &&
+		FAKE_TOPIC=bb/codex/new-root FAKE_TIP="$reviewed" \
+		PATH="$PWD/plan-bin:$PATH" sh "$codex_branch" propose-plan \
+			--remote origin --lane codex --topic bb/codex/new-root \
+			--source-tip "$reviewed" --review-pr 1000 --action add \
+			--plan-branch codex-plan/new-root >plan.out &&
+		fetch_all &&
+		plan=$(git rev-parse origin/codex-plan/new-root) &&
+		git push origin "$plan:refs/heads/meta" &&
+		(
+			cd ../pinned-root-boundary-source &&
+			git switch master &&
+			write advanced advanced-base &&
+			git add advanced-base &&
+			git commit -m "advance base after review" &&
+			git push origin master
+		) &&
+		fetch_all &&
+		sh "$codex_branch" rewrite --remote origin \
+			--base master --codex codex --result result \
+			--updates updates --inputs inputs --failure failure &&
+		candidate=$(cat result) &&
+		test "$(git show "$candidate:advanced-base")" = advanced &&
+		test "$(git show "$candidate:new-root-file")" = topic &&
+		apply_test_updates origin updates &&
+		fetch_all &&
+		(
+			cd ../pinned-root-boundary-source &&
+			git switch bb/codex/new-root &&
+			write unreviewed unreviewed-file &&
+			git add unreviewed-file &&
+			git commit -m "unreviewed topic advance" &&
+			git push origin bb/codex/new-root
+		) &&
+		fetch_all &&
+		sh "$codex_branch" rewrite --remote origin \
+			--base master --codex codex --result next-result \
+			--updates next-updates --inputs next-inputs \
+			--failure next-failure &&
+		test "$candidate" = "$(cat next-result)" &&
+		test_grep "pin$(printf "\t")refs/heads/codex-pins/$reviewed" \
+			next-inputs &&
+		! git ls-tree -r --name-only "$(cat next-result)" |
+			grep -F unreviewed-file
+	)
+'
+
+test_expect_success 'pre-v3 bootstrap records authorization and can pin each explicit override' '
+	git init --bare pinned-bootstrap-command.git &&
+	test_create_repo pinned-bootstrap-command-source &&
+	(
+		cd pinned-bootstrap-command-source &&
+		git remote add origin ../pinned-bootstrap-command.git &&
+		write base shared &&
+		git add shared &&
+		install_rerere_train &&
+		git commit -m "bootstrap command base" &&
+		install_reviewed_automation_topic aa/codex/automation previous &&
+		git switch -c aa/codex/enrolled master &&
+		write enrolled enrolled-file &&
+		git add enrolled-file &&
+		git commit -m "bootstrap command stable topic" &&
+		stable=$(git rev-parse HEAD) &&
+		codex_tree=$(git merge-tree --write-tree \
+			"$automation_codex_tip" "$stable") &&
+		codex_tip=$(make_test_integration aa/codex/enrolled \
+			"$stable" "$automation_codex_tip" "$codex_tree") &&
+		git branch codex "$codex_tip" &&
+		git switch -c tb/codex/preview-unstable codex &&
+		write old preview-file &&
+		git add preview-file &&
+		git commit -m "old preview" &&
+		old_preview=$(git rev-parse HEAD) &&
+		old_tree=$(git rev-parse "$old_preview^{tree}") &&
+		unstable=$(make_test_unstable_integration \
+			tb/codex/preview-unstable "$old_preview" codex \
+			"$old_tree") &&
+		git branch codex-unstable "$unstable" &&
+		git branch meta master &&
+		install_unstable_meta_state meta master codex codex-unstable &&
+		git switch tb/codex/preview-unstable &&
+		write new new-preview-file &&
+		git add new-preview-file &&
+		git commit -m "authorized preview override" &&
+		git push origin --all
+	) &&
+	git clone pinned-bootstrap-command.git pinned-bootstrap-command-runner &&
+	(
+		cd pinned-bootstrap-command-runner &&
+		fetch_all &&
+		install_bootstrap_pin_guard_gh "$PWD/bootstrap-bin" &&
+		new_preview=$(git rev-parse origin/tb/codex/preview-unstable) &&
+		before_meta=$(git rev-parse origin/meta) &&
+		test_expect_code 1 env FAKE_BOOTSTRAP_PIN_GUARD=missing \
+			PATH="$PWD/bootstrap-bin:$PATH" \
+			sh "$codex_branch" propose-plan --remote origin \
+			--lane codex-unstable \
+			--topic tb/codex/preview-unstable \
+			--source-tip "$new_preview" --action alter \
+			--bootstrap-authorization "user-approved bootstrap" \
+			>unguarded.out 2>unguarded.err &&
+		test_grep "pre-v3 bootstrap requires active immutable Codex pin guard" \
+			unguarded.err &&
+		fetch_all &&
+		test "$before_meta" = "$(git rev-parse origin/meta)" &&
+		test_must_fail git show-ref --verify \
+			"refs/remotes/origin/codex-pins/$new_preview" &&
+		PATH="$PWD/bootstrap-bin:$PATH" \
+		sh "$codex_branch" propose-plan --remote origin \
+			--lane codex-unstable \
+			--topic tb/codex/preview-unstable \
+			--source-tip "$new_preview" --action alter \
+			--bootstrap-authorization "user-approved bootstrap" \
+			>bootstrap.out &&
+		fetch_all &&
+		meta=$(git rev-parse origin/meta) &&
+		test "$(git show -s \
+			--format="%(trailers:key=Codex-Plan-Bootstrap,valueonly)" \
+			"$meta")" = true &&
+		test "$(git show -s \
+			--format="%(trailers:key=Codex-Plan-Authorization,valueonly)" \
+			"$meta")" = "user-approved bootstrap" &&
+		test "$(git show "$meta:codex-unstable.plan" |
+			git config --file /dev/stdin \
+				--get branch.tb/codex/preview-unstable.source-tip)" = \
+			"$new_preview" &&
+		test "$(git rev-parse \
+			"origin/codex-pins/$new_preview")" = "$new_preview" &&
+		test_must_fail git show-ref --verify \
+			refs/remotes/origin/codex-plan/preview &&
+		test_expect_code 1 sh "$codex_branch" rewrite \
+			--remote origin --base master --codex codex \
+			--result blocked-result --updates blocked-updates \
+			--inputs blocked-inputs --failure blocked-failure \
+			>blocked.out 2>blocked.err &&
+		test_grep "pre-v3 pinned plan must pin the current automation workflow" \
+			blocked.err &&
+		(
+			cd ../pinned-bootstrap-command-source &&
+			git switch aa/codex/automation &&
+			write_reviewed_automation_workflow \
+				.github/workflows/codex.yml &&
+			git add .github/workflows/codex.yml &&
+			git commit -m "authorized automation trampoline" &&
+			git push origin aa/codex/automation
+		) &&
+		fetch_all &&
+		new_automation=$(git rev-parse origin/aa/codex/automation) &&
+		PATH="$PWD/bootstrap-bin:$PATH" \
+		sh "$codex_branch" propose-plan --remote origin \
+			--lane codex --topic aa/codex/automation \
+			--source-tip "$new_automation" --action alter \
+			--bootstrap-authorization "user-approved bootstrap" \
+			>second-bootstrap.out &&
+		fetch_all &&
+		second_meta=$(git rev-parse origin/meta) &&
+		test "$(git show -s --format=%P "$second_meta")" = "$meta" &&
+		test "$(git show "$second_meta:codex.plan" |
+			git config --file /dev/stdin \
+				--get branch.aa/codex/automation.source-tip)" = \
+			"$new_automation" &&
+		test "$(git rev-parse \
+			"origin/codex-pins/$new_automation")" = \
+			"$new_automation" &&
+		sh "$codex_branch" rewrite --remote origin \
+			--base master --codex codex --result result \
+			--updates updates --inputs inputs --failure failure &&
+		sh "$codex_branch" verify-output --inputs inputs \
+			--updates updates --result result &&
+		test_grep "published pre-v3 pinned-plan bootstrap" \
+			bootstrap.out &&
+		test_grep "published pre-v3 pinned-plan bootstrap" \
+			second-bootstrap.out
+	)
+'
+
+test_expect_success 'explicit reorder and remove stay plan-only policy changes' '
+	git init --bare pinned-plan-policy.git &&
+	test_create_repo pinned-plan-policy-source &&
+	(
+		cd pinned-plan-policy-source &&
+		git remote add origin ../pinned-plan-policy.git &&
+		write base shared &&
+		git add shared &&
+		install_rerere_train &&
+		git commit -m "policy base" &&
+		install_reviewed_automation_topic &&
+		git switch -c aa/codex/enrolled master &&
+		write enrolled enrolled-file &&
+		git add enrolled-file &&
+		git commit -m "policy enrolled topic" &&
+		enrolled=$(git rev-parse HEAD) &&
+		enrolled_tree=$(git merge-tree --write-tree \
+			"$automation_codex_tip" "$enrolled") &&
+		codex_tip=$(make_test_integration aa/codex/enrolled \
+			"$enrolled" "$automation_codex_tip" "$enrolled_tree") &&
+		git switch -c bb/codex/root master &&
+		write root root-file &&
+		git add root-file &&
+		git commit -m "policy independent root" &&
+		root=$(git rev-parse HEAD) &&
+		root_tree=$(git merge-tree --write-tree "$codex_tip" "$root") &&
+		codex_tip=$(make_test_integration bb/codex/root "$root" \
+			"$codex_tip" "$root_tree") &&
+		git branch codex "$codex_tip" &&
+		git branch meta master &&
+		install_pinned_meta_state meta master codex &&
+		git push origin --all
+	) &&
+	git clone pinned-plan-policy.git pinned-plan-policy-runner &&
+	(
+		cd pinned-plan-policy-runner &&
+		fetch_all &&
+		mkdir plan-bin &&
+		cat >plan-bin/gh <<-\EOF &&
+		#!/bin/sh
+		if test "$1" = pr && test "$2" = merge
+		then
+			exit 0
+		fi
+		test "$1" = pr &&
+		test "$2" = create &&
+		printf "%s\n" https://github.com/openai/git/pull/1001
+		EOF
+		chmod +x plan-bin/gh &&
+		test_expect_code 1 env PATH="$PWD/plan-bin:$PATH" \
+			sh "$codex_branch" propose-plan --remote origin \
+				--lane codex --topic aa/codex/automation \
+				--action remove \
+				--plan-branch codex-plan/remove-automation \
+				>remove-automation.out 2>remove-automation.err &&
+		test_grep "exactly one active .*automation topic is required" \
+			remove-automation.err &&
+		test_must_fail git show-ref --verify \
+			refs/remotes/origin/codex-plan/remove-automation &&
+		PATH="$PWD/plan-bin:$PATH" sh "$codex_branch" propose-plan \
+			--remote origin --lane codex --topic bb/codex/root \
+			--action reorder --after root \
+			--plan-branch codex-plan/reorder-root >reorder.out &&
+		fetch_all &&
+		reorder=$(git rev-parse origin/codex-plan/reorder-root) &&
+		sh "$codex_branch" validate-plan-transition --remote origin \
+			--base-commit origin/meta --head-commit "$reorder" &&
+		git show "$reorder:codex.plan" |
+			git config --file /dev/stdin --get-all plan.topic \
+			>reordered-topics &&
+		printf "%s\n" refs/heads/bb/codex/root \
+			refs/heads/aa/codex/automation \
+			refs/heads/aa/codex/enrolled >expected-topics &&
+		test_cmp expected-topics reordered-topics &&
+		git push origin "$reorder:refs/heads/meta" &&
+		fetch_all &&
+		PATH="$PWD/plan-bin:$PATH" sh "$codex_branch" propose-plan \
+			--remote origin --lane codex --topic bb/codex/root \
+			--action remove \
+			--plan-branch codex-plan/remove-root >remove.out &&
+		fetch_all &&
+		remove=$(git rev-parse origin/codex-plan/remove-root) &&
+		sh "$codex_branch" validate-plan-transition --remote origin \
+			--base-commit origin/meta --head-commit "$remove" &&
+		git show "$remove:codex.plan" >removed.plan &&
+		test_must_fail git config --file removed.plan \
+			--get branch.bb/codex/root.source-tip &&
+		test_grep "opened pinned plan pull request" reorder.out &&
+		test_grep "opened pinned plan pull request" remove.out
+	)
+'
+
+test_expect_success 'topic review requires the exact approved head' '
+	mkdir topic-review-bin &&
+	cat >topic-review-bin/gh <<-\EOF &&
+	#!/bin/sh
+	case " $* " in
+	*"pulls/42/reviews?"*)
+		printf "%s\t%s\t%s\t%s\n" reviewer APPROVED \
+			"$FAKE_REVIEW_HEAD" MEMBER
+		exit 0
+		;;
+	*"pulls/42 "*)
+		printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\n" \
+			open false codex openai/git aa/codex/reviewed \
+			"$FAKE_HEAD" author
+		exit 0
+		;;
+	esac
+	if test "$1" = pr && test "$2" = view
+	then
+		printf "%s\n" "$FAKE_DECISION"
+		exit 0
+	fi
+	exit 1
+	EOF
+	chmod +x topic-review-bin/gh &&
+	test_commit review-source &&
+	source=$(git rev-parse HEAD) &&
+	test_commit review-moved &&
+	moved=$(git rev-parse HEAD) &&
+	test_commit review-old &&
+	old=$(git rev-parse HEAD) &&
+	test_expect_code 1 env PATH="$PWD/topic-review-bin:$PATH" \
+		FAKE_HEAD="$moved" FAKE_REVIEW_HEAD="$source" \
+		FAKE_DECISION=APPROVED sh "$codex_branch" \
+		validate-topic-review --pull-request 42 --lane codex \
+			--topic aa/codex/reviewed --source-tip "$source" \
+		>moved.out 2>moved.err &&
+	test_grep "moved from $source to $moved" moved.err &&
+	test_expect_code 1 env PATH="$PWD/topic-review-bin:$PATH" \
+		FAKE_HEAD="$source" FAKE_REVIEW_HEAD="$source" \
+		FAKE_DECISION=REVIEW_REQUIRED sh "$codex_branch" \
+		validate-topic-review --pull-request 42 --lane codex \
+			--topic aa/codex/reviewed --source-tip "$source" \
+		>decision.out 2>decision.err &&
+	test_grep "is not approved" decision.err &&
+	test_expect_code 1 env PATH="$PWD/topic-review-bin:$PATH" \
+		FAKE_HEAD="$source" FAKE_REVIEW_HEAD="$old" \
+		FAKE_DECISION=APPROVED sh "$codex_branch" \
+		validate-topic-review --pull-request 42 --lane codex \
+			--topic aa/codex/reviewed --source-tip "$source" \
+		>stale.out 2>stale.err &&
+	test_grep "has no current approval for $source" stale.err
 '
 
 test_done


### PR DESCRIPTION
Move codex and codex-unstable admission to ordered manifests on meta. Add/alter transitions are projections of an exact-head approved topic PR, retained by immutable codex-pins refs; remove/reorder remain explicit meta-reviewed policy changes. Generated lane branches become output-only, and codex.config v3 records the applied plan and generated tips.

The migration path is deliberately bounded: pre-v3 bootstrap accepts only explicit already-published overrides, requires the active immutable-pin guard before pushing, and refuses the first v3 refresh until the current automation trampoline is pinned. This PR does not commit plan files or activate the new rulesets.

Tested:
- full t/t9905-codex-branch.sh: 115/115
- shell syntax, workflow YAML, ruleset JSON, and git diff --check
- exact 8358fcbf28d67510f3f8430e4db38010ba5b51f7 bootstrap projection with --no-push

<!-- codex-thread: 019fd7bf-0f33-7242-b609-d983521a8b30 -->