### PR TITLE
ci: scan approved Codex topics from trusted branch

### DIFF
--- a/.github/CODEX.md
+++ b/.github/CODEX.md
@@ -38,8 +38,10 @@ active topics belong in `codex`.
 
 An add or alter has one human decision: the topic PR. The pull request is
 review-only because the output-lane rulesets reject ordinary updates. When an
-approval is submitted, GitHub loads the review-event workflow from the
-trusted default branch rather than from the topic head. That trusted run:
+approval is submitted, a scheduled scanner on the trusted default branch
+notices the exact approved head and runs the plan producer. Operators can
+dispatch the same scan immediately when waiting five minutes is undesirable.
+That trusted run:
 
 1. rechecks that the PR is open, same-repository, non-draft, aimed at the
    matching lane, and overall `APPROVED`;
@@ -89,8 +91,8 @@ git push -u origin HEAD
 ```
 
 Open the topic PR against `codex` or `codex-unstable` and obtain approval.
-Do not click merge; the output branch cannot accept it. The approval event
-creates the pinned plan PR automatically.
+Do not click merge; the output branch cannot accept it. The next trusted
+scan creates the pinned plan PR automatically.
 
 For a local diagnostic of the same projection:
 
@@ -139,11 +141,11 @@ closed instead of flattening the reviewed DAG.
 
 Exactly one stable topic named `??/codex/automation` must be based directly
 on `master` and change only `.github/workflows/codex.yml`. Its canonical
-workflow is the default-branch trampoline that:
+default-branch trampoline:
 
 - dispatches ordinary refresh;
-- turns an approved topic PR into a trusted default-branch dispatch, which
-  then creates the automatic add/alter proposal;
+- scans exact approved topic PRs from the trusted default branch and creates
+  one automatic add/alter proposal at a time;
 - offers explicit remove/reorder dispatch inputs; and
 - runs plan admission through `pull_request_target` while loading the
   reusable implementation from `meta`.
@@ -153,11 +155,11 @@ that trampoline. During migration, the controller accepts the previous
 trampoline as published history, but it refuses the first v3 refresh until the
 plan pins the current trampoline.
 
-The topic head never supplies executable workflow code. The trusted
-`pull_request_review` run only queues `codex.yml` at `refs/heads/codex`; the
-resulting default-branch dispatch calls the reusable producer from `meta`.
-That producer revalidates the PR before the `codex-plan` environment is
-opened.
+No topic merge ref runs the pinning path. The default-branch scanner checks
+each open approved PR with the trusted `meta` controller, skips tips already
+present in the active plans or represented by an open plan PR, and only then
+calls the reusable producer from `meta`. The producer revalidates the exact
+approval again before it writes a pin or plan branch.
 
 ## One-time v2 to v3 rollout
 

--- a/.github/workflows/codex-branch.sh
+++ b/.github/workflows/codex-branch.sh
@@ -376,16 +376,18 @@ write_automation_workflow () {
 name: Refresh codex
 
 on:
+  schedule:
+    - cron: '*/5 * * * *'
   workflow_dispatch:
     inputs:
       operation:
-        description: Refresh, remove, reorder, or internal topic review
+        description: Refresh, scan, remove, or reorder a pinned topic
         type: choice
         options:
           - refresh
+          - scan
           - remove
           - reorder
-          - topic-review
         default: refresh
       lane:
         description: codex or codex-unstable for a plan operation
@@ -393,14 +395,6 @@ on:
         type: string
       topic:
         description: Exact topic branch for a plan operation
-        required: false
-        type: string
-      source_tip:
-        description: Exact reviewed source SHA for internal topic review
-        required: false
-        type: string
-      review_pr:
-        description: Topic PR number for internal topic review
         required: false
         type: string
       after:
@@ -411,9 +405,6 @@ on:
         description: Optional codex-plan/* branch name
         required: false
         type: string
-  pull_request_review:
-    types:
-      - submitted
   pull_request_target:
     branches:
       - meta
@@ -432,56 +423,174 @@ jobs:
   refresh:
     if: >-
       github.event_name == 'workflow_dispatch' &&
+      github.ref == 'refs/heads/codex' &&
       inputs.operation == 'refresh'
     uses: openai/git/.github/workflows/codex.yml@meta
-  topic_plan_dispatch:
-    name: Queue reviewed topic plan
+  topic_plan_scan:
+    name: Find one approved topic plan
     if: >-
-      github.event_name == 'pull_request_review' &&
-      github.event.review.state == 'approved' &&
-      github.event.pull_request.head.repo.full_name == github.repository &&
-      (github.event.pull_request.base.ref == 'codex' ||
-       github.event.pull_request.base.ref == 'codex-unstable')
+      github.event_name == 'schedule' ||
+      (github.event_name == 'workflow_dispatch' &&
+       github.ref == 'refs/heads/codex' &&
+       inputs.operation == 'scan')
     runs-on: ubuntu-24.04
     permissions:
-      actions: write
       contents: read
+      pull-requests: read
+    concurrency:
+      group: codex-topic-plan-scan
+      cancel-in-progress: false
+    outputs:
+      lane: ${{ steps.reviewed.outputs.lane }}
+      topic: ${{ steps.reviewed.outputs.topic }}
+      source_tip: ${{ steps.reviewed.outputs.source_tip }}
+      review_pr: ${{ steps.reviewed.outputs.review_pr }}
     env:
       GH_TOKEN: ${{ github.token }}
-      DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
-      LANE: ${{ github.event.pull_request.base.ref }}
-      TOPIC: ${{ github.event.pull_request.head.ref }}
-      SOURCE_TIP: ${{ github.event.pull_request.head.sha }}
-      REVIEW_PR: ${{ github.event.pull_request.number }}
     steps:
-      - name: Queue trusted plan proposal
+      - name: Pin trusted meta
+        id: meta
         run: |
           set -euo pipefail
           test "$GITHUB_REPOSITORY" = openai/git
-          test "$DEFAULT_BRANCH" = codex
-          gh workflow run codex.yml --repo "$GITHUB_REPOSITORY" \
-            --ref "$DEFAULT_BRANCH" \
-            -f operation=topic-review \
-            -f lane="$LANE" \
-            -f topic="$TOPIC" \
-            -f source_tip="$SOURCE_TIP" \
-            -f review_pr="$REVIEW_PR"
+          test "$GITHUB_REF" = refs/heads/codex
+          sha=$(gh api "repos/$GITHUB_REPOSITORY/git/ref/heads/meta" \
+            --jq .object.sha)
+          case "$sha" in
+          ''|*[!0-9a-f]*) exit 1 ;;
+          esac
+          test "${#sha}" = 40
+          printf 'sha=%s\n' "$sha" >>"$GITHUB_OUTPUT"
+
+      - name: Check out trusted meta
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          repository: ${{ github.repository }}
+          ref: ${{ steps.meta.outputs.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Find one exact approved topic PR
+        id: reviewed
+        env:
+          META_SHA: ${{ steps.meta.outputs.sha }}
+        run: |
+          set -euo pipefail
+
+          die () {
+            printf '%s\n' "$*" >&2
+            exit 1
+          }
+
+          test "$GITHUB_REPOSITORY" = openai/git
+          test "$GITHUB_REF" = refs/heads/codex ||
+            die "topic scan must run from the trusted default branch"
+          test "$(git rev-parse HEAD)" = "$META_SHA" ||
+            die "trusted checkout does not match pinned meta"
+          gh auth setup-git
+          mkdir -p "$RUNNER_TEMP/codex-plan-scan"
+          for lane in codex codex-unstable
+          do
+            case "$lane" in
+            codex) plan=codex.plan ;;
+            codex-unstable) plan=codex-unstable.plan ;;
+            esac
+            test -f "$plan" ||
+              die "trusted meta has no $plan"
+            gh pr list --repo "$GITHUB_REPOSITORY" --state open \
+              --base "$lane" --limit 1000 \
+              --json number,isDraft,headRefName,headRefOid,headRepository,reviewDecision |
+              jq -r --arg lane "$lane" '
+                .[] |
+                select(.isDraft | not) |
+                select(.reviewDecision == "APPROVED") |
+                select(.headRepository.nameWithOwner == "openai/git") |
+                [$lane, .headRefName, .headRefOid,
+                 (.number | tostring)] | @tsv
+              '
+          done | sort -k4,4n >"$RUNNER_TEMP/codex-plan-scan/candidates"
+
+          while IFS=$'\t' read -r lane topic source_tip review_pr
+          do
+            test -n "$review_pr" || continue
+            case "$review_pr" in
+            *[!0-9]*) die "approved topic PR has invalid number '$review_pr'" ;;
+            esac
+            case "$source_tip" in
+            *[!0-9a-f]*|'') die "approved topic PR has invalid source SHA" ;;
+            esac
+            test "${#source_tip}" = 40 ||
+              die "approved topic PR has invalid source SHA"
+            git check-ref-format "refs/heads/$topic" >/dev/null 2>&1 ||
+              die "approved topic PR has invalid branch '$topic'"
+            case "$topic" in
+            ??/codex/*) ;;
+            *) continue ;;
+            esac
+            suffix=${topic#??/codex/}
+            case "$suffix" in
+            ''|*/*|*-wip|*-stale) continue ;;
+            esac
+            case "$lane" in
+            codex)
+              case "$topic" in
+              *-unstable) continue ;;
+              esac
+              plan=codex.plan
+              ;;
+            codex-unstable)
+              case "$topic" in
+              *-unstable) ;;
+              *) continue ;;
+              esac
+              plan=codex-unstable.plan
+              ;;
+            *) die "approved topic PR has invalid lane '$lane'" ;;
+            esac
+            pinned=$(git config --no-includes \
+              --file "$plan" \
+              --get "branch.$topic.source-tip" || :)
+            test "$pinned" = "$source_tip" && continue
+            short=$(printf '%.12s' "$source_tip")
+            slug=${topic##*/}
+            plan_branch=codex-plan/$lane-$slug-$short
+            pending=$(gh pr list --repo "$GITHUB_REPOSITORY" \
+              --state open --base meta --head "$plan_branch" \
+              --json number --jq '.[0].number // empty') ||
+              die "could not inspect pending Codex plan PR"
+            test -n "$pending" && continue
+            if ! sh .github/workflows/codex-branch.sh propose-plan \
+              --remote origin --lane "$lane" --topic "$topic" \
+              --action auto --source-tip "$source_tip" \
+              --review-pr "$review_pr" --expected-meta "$META_SHA" \
+              --no-push >/dev/null
+            then
+              printf 'skipping approved topic PR #%s: preflight failed\n' \
+                "$review_pr" >&2
+              continue
+            fi
+            {
+              printf 'lane=%s\n' "$lane"
+              printf 'topic=%s\n' "$topic"
+              printf 'source_tip=%s\n' "$source_tip"
+              printf 'review_pr=%s\n' "$review_pr"
+            } >>"$GITHUB_OUTPUT"
+            exit 0
+          done <"$RUNNER_TEMP/codex-plan-scan/candidates"
   topic_plan_propose:
     name: Propose reviewed topic plan
-    if: >-
-      github.event_name == 'workflow_dispatch' &&
-      github.ref == 'refs/heads/codex' &&
-      inputs.operation == 'topic-review'
+    needs: topic_plan_scan
+    if: needs.topic_plan_scan.outputs.review_pr != ''
     permissions:
       contents: read
       pull-requests: read
     uses: openai/git/.github/workflows/codex-plan-propose.yml@meta
     with:
-      lane: ${{ inputs.lane }}
-      topic: ${{ inputs.topic }}
+      lane: ${{ needs.topic_plan_scan.outputs.lane }}
+      topic: ${{ needs.topic_plan_scan.outputs.topic }}
       action: auto
-      source_tip: ${{ inputs.source_tip }}
-      review_pr: ${{ inputs.review_pr }}
+      source_tip: ${{ needs.topic_plan_scan.outputs.source_tip }}
+      review_pr: ${{ needs.topic_plan_scan.outputs.review_pr }}
   policy_plan_propose:
     name: Propose explicit plan policy
     if: >-

--- a/t/t9905-codex-branch.sh
+++ b/t/t9905-codex-branch.sh
@@ -77,142 +77,10 @@ write_automation_workflow () {
 }
 
 write_reviewed_automation_workflow () {
-	cat >"$1" <<-'EOF'
-name: Refresh codex
-
-on:
-  workflow_dispatch:
-    inputs:
-      operation:
-        description: Refresh, remove, reorder, or internal topic review
-        type: choice
-        options:
-          - refresh
-          - remove
-          - reorder
-          - topic-review
-        default: refresh
-      lane:
-        description: codex or codex-unstable for a plan operation
-        required: false
-        type: string
-      topic:
-        description: Exact topic branch for a plan operation
-        required: false
-        type: string
-      source_tip:
-        description: Exact reviewed source SHA for internal topic review
-        required: false
-        type: string
-      review_pr:
-        description: Topic PR number for internal topic review
-        required: false
-        type: string
-      after:
-        description: Existing topic or root for reorder
-        required: false
-        type: string
-      plan_branch:
-        description: Optional codex-plan/* branch name
-        required: false
-        type: string
-  pull_request_review:
-    types:
-      - submitted
-  pull_request_target:
-    branches:
-      - meta
-    types:
-      - opened
-      - reopened
-      - synchronize
-      - ready_for_review
-
-permissions:
-  actions: read
-  contents: read
-  pull-requests: read
-
-jobs:
-  refresh:
-    if: >-
-      github.event_name == 'workflow_dispatch' &&
-      inputs.operation == 'refresh'
-    uses: openai/git/.github/workflows/codex.yml@meta
-  topic_plan_dispatch:
-    name: Queue reviewed topic plan
-    if: >-
-      github.event_name == 'pull_request_review' &&
-      github.event.review.state == 'approved' &&
-      github.event.pull_request.head.repo.full_name == github.repository &&
-      (github.event.pull_request.base.ref == 'codex' ||
-       github.event.pull_request.base.ref == 'codex-unstable')
-    runs-on: ubuntu-24.04
-    permissions:
-      actions: write
-      contents: read
-    env:
-      GH_TOKEN: ${{ github.token }}
-      DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
-      LANE: ${{ github.event.pull_request.base.ref }}
-      TOPIC: ${{ github.event.pull_request.head.ref }}
-      SOURCE_TIP: ${{ github.event.pull_request.head.sha }}
-      REVIEW_PR: ${{ github.event.pull_request.number }}
-    steps:
-      - name: Queue trusted plan proposal
-        run: |
-          set -euo pipefail
-          test "$GITHUB_REPOSITORY" = openai/git
-          test "$DEFAULT_BRANCH" = codex
-          gh workflow run codex.yml --repo "$GITHUB_REPOSITORY" \
-            --ref "$DEFAULT_BRANCH" \
-            -f operation=topic-review \
-            -f lane="$LANE" \
-            -f topic="$TOPIC" \
-            -f source_tip="$SOURCE_TIP" \
-            -f review_pr="$REVIEW_PR"
-  topic_plan_propose:
-    name: Propose reviewed topic plan
-    if: >-
-      github.event_name == 'workflow_dispatch' &&
-      github.ref == 'refs/heads/codex' &&
-      inputs.operation == 'topic-review'
-    permissions:
-      contents: read
-      pull-requests: read
-    uses: openai/git/.github/workflows/codex-plan-propose.yml@meta
-    with:
-      lane: ${{ inputs.lane }}
-      topic: ${{ inputs.topic }}
-      action: auto
-      source_tip: ${{ inputs.source_tip }}
-      review_pr: ${{ inputs.review_pr }}
-  policy_plan_propose:
-    name: Propose explicit plan policy
-    if: >-
-      github.event_name == 'workflow_dispatch' &&
-      github.ref == 'refs/heads/codex' &&
-      (inputs.operation == 'remove' || inputs.operation == 'reorder')
-    permissions:
-      contents: read
-      pull-requests: read
-    uses: openai/git/.github/workflows/codex-plan-propose.yml@meta
-    with:
-      lane: ${{ inputs.lane }}
-      topic: ${{ inputs.topic }}
-      action: ${{ inputs.operation }}
-      after: ${{ inputs.after }}
-      plan_branch: ${{ inputs.plan_branch }}
-  plan_admission:
-    name: Codex plan admission
-    if: >-
-      github.event_name == 'pull_request_target' &&
-      github.event.pull_request.base.ref == 'meta'
-    permissions:
-      contents: read
-      pull-requests: write
-    uses: openai/git/.github/workflows/codex-plan-admission.yml@meta
-	EOF
+	output=$1 &&
+	sed -n '/^write_automation_workflow () {$/,/^}$/p' \
+		"$codex_branch" |
+	sed '1,2d;$d' | sed '$d;s/^\t//' >"$output"
 }
 
 install_reviewed_automation_topic () {
@@ -1652,21 +1520,34 @@ test_expect_success 'generated lanes are output-only and meta gates review in th
 	" "$codex_root/.github/rulesets/codex-meta.json"
 '
 
-test_expect_success 'plan admission checks the exact reviewed head from trusted meta' '
+test_expect_success 'plan admission checks exact reviewed heads from trusted meta' '
 	test_path_is_file "$codex_plan_admission_workflow" &&
 	test_grep "name: Codex plan admission" \
 		"$codex_plan_admission_workflow" &&
 	test_grep "  workflow_call:" "$codex_plan_admission_workflow" &&
 	! grep -F "  pull_request_review:" \
 		"$codex_plan_admission_workflow" &&
-	test_grep "pull_request_review:" "$codex_branch" &&
+	test_grep "schedule:" "$codex_branch" &&
+	test_grep "cron: .*/5" "$codex_branch" &&
+	! grep -F "pull_request_review:" "$codex_branch" &&
+	! grep -F "workflow_run:" "$codex_branch" &&
 	test_grep "pull_request_target:" "$codex_branch" &&
-	test_grep "topic_plan_dispatch:" "$codex_branch" &&
-	test_grep "actions: write" "$codex_branch" &&
-	test_grep "gh workflow run codex.yml" "$codex_branch" &&
-	test_grep "inputs.operation == .*topic-review" "$codex_branch" &&
-	sed -n "/^  topic_plan_dispatch:/,/^  topic_plan_propose:/p" "$codex_branch" >review-dispatch &&
-	! grep -E "codex-plan-propose|environment:|CODEX_PLAN_APP_PRIVATE_KEY|contents: write|pull-requests: write" review-dispatch &&
+	test_grep "topic_plan_scan:" "$codex_branch" &&
+	test_grep "github.event_name == .schedule." "$codex_branch" &&
+	test_grep "topic scan must run from the trusted default branch" \
+		"$codex_branch" &&
+	test_grep "git/ref/heads/meta" "$codex_branch" &&
+	test_grep "Check out trusted meta" "$codex_branch" &&
+	test_grep "steps.meta.outputs.sha" "$codex_branch" &&
+	test_grep "base .*lane.* --limit 1000" "$codex_branch" &&
+	test_grep "propose-plan" "$codex_branch" &&
+	test_grep "expected-meta" "$codex_branch" &&
+	test_grep "no-push" "$codex_branch" &&
+	! grep -F "actions: write" "$codex_branch" &&
+	! grep -F "gh workflow run codex.yml" "$codex_branch" &&
+	sed -n "/^  topic_plan_scan:/,/^  topic_plan_propose:/p" "$codex_branch" >review-scan &&
+	! grep -E "codex-plan-propose|environment:|CODEX_PLAN_APP_PRIVATE_KEY|contents: write|pull-requests: write" review-scan &&
+	test_grep "needs: topic_plan_scan" "$codex_branch" &&
 	test_grep "action: auto" "$codex_branch" &&
 	test_grep "policy_plan_propose:" "$codex_branch" &&
 	test_grep "inputs.operation" "$codex_branch" &&


### PR DESCRIPTION
The pinned-plan controller should not start from `pull_request_review`: GitHub loads that workflow from the PR merge ref, so a topic can change the first hop.

This follow-up moves automatic add/alter discovery to a trusted default-branch scanner. It pins and checks out `meta`, preflights each approved candidate with `propose-plan --no-push`, skips stale or policy-invalid candidates, then calls the existing exact-head producer. `scan` dispatch is an optional immediate shortcut; remove/reorder stay explicit.

Validated locally:
- `sh -n .github/workflows/codex-branch.sh`
- `sh -n t/t9905-codex-branch.sh`
- generated workflow YAML parse
- `git diff --check`
- `t/t9905-codex-branch.sh -i` (115/115)

<!-- codex-thread: 019fd7bf-0f33-7242-b609-d983521a8b30 -->