### PR TITLE
Codex plan: alter tb/codex/status-preview-unstable in codex-unstable

### DIFF
--- a/codex-unstable.plan
+++ b/codex-unstable.plan
@@ -7,6 +7,6 @@
 [branch "tb/codex/status-preview-unstable"]
 	remote = .
 	source-ref = refs/heads/tb/codex/status-preview-unstable
-	source-tip = e1061758ba6094e5b71718a8d9b90d8474765e06
+	source-tip = 597f818f548d971aa3329a9a03f4f1201333f629
 	source-base = 71a27108a1835b8d45bf1ade49706e4ff18a5e1d
 	merge = refs/heads/codex


### PR DESCRIPTION
Bot-generated pinned plan transition.

- Lane: `codex-unstable`
- Action: `alter`
- Topic: `refs/heads/tb/codex/status-preview-unstable`
- Source tip: `597f818f548d971aa3329a9a03f4f1201333f629`
- Prerequisite: `refs/heads/codex`
- Reviewed topic PR: `#21`

The plan blob and immutable `codex-pins/*` refs are authoritative.
