### PR TITLE
Codex plan: alter tb/codex/status-preview-unstable in codex-unstable

### DIFF
--- a/codex-unstable.plan
+++ b/codex-unstable.plan
@@ -7,6 +7,6 @@
 [branch "tb/codex/status-preview-unstable"]
 	remote = .
 	source-ref = refs/heads/tb/codex/status-preview-unstable
-	source-tip = ae4dc5f961e952d077b7783bf67344314b13b7c6
-	source-base = 71a27108a1835b8d45bf1ade49706e4ff18a5e1d
+	source-tip = cfb9444894e47c61ebd228b5222a4c72e273bf15
+	source-base = 00ee4fe98b17036715a005ff47027f00a646d099
 	merge = refs/heads/codex


### PR DESCRIPTION
Bot-generated pinned plan transition.

- Lane: `codex-unstable`
- Action: `alter`
- Topic: `refs/heads/tb/codex/status-preview-unstable`
- Source tip: `cfb9444894e47c61ebd228b5222a4c72e273bf15`
- Prerequisite: `refs/heads/codex`
- Reviewed topic PR: `#21`

The plan blob and immutable `codex-pins/*` refs are authoritative.
