### PR TITLE
Codex plan: alter tb/codex/status-preview-unstable in codex-unstable

### DIFF
--- a/codex-unstable.plan
+++ b/codex-unstable.plan
@@ -7,6 +7,6 @@
 [branch "tb/codex/status-preview-unstable"]
 	remote = .
 	source-ref = refs/heads/tb/codex/status-preview-unstable
-	source-tip = dad9e3b3b355162874a9031ffca1e1211bd3ce50
+	source-tip = f92dd57ecdaea8626c7ea72bb72e2ca9a7772716
 	source-base = 00ee4fe98b17036715a005ff47027f00a646d099
 	merge = refs/heads/codex


### PR DESCRIPTION
Bot-generated pinned plan transition.

- Lane: `codex-unstable`
- Action: `alter`
- Topic: `refs/heads/tb/codex/status-preview-unstable`
- Source tip: `f92dd57ecdaea8626c7ea72bb72e2ca9a7772716`
- Prerequisite: `refs/heads/codex`
- Reviewed topic PR: `#47`

The plan blob and immutable `codex-pins/*` refs are authoritative.
