### PR TITLE
Codex plan: alter tb/codex/fsmonitor-hardlink-inodes-unstable in codex-unstable

### DIFF
--- a/codex-unstable.plan
+++ b/codex-unstable.plan
@@ -15,6 +15,6 @@
 [branch "tb/codex/fsmonitor-hardlink-inodes-unstable"]
 	remote = .
 	source-ref = refs/heads/tb/codex/fsmonitor-hardlink-inodes-unstable
-	source-tip = 4b4ca0e10d36c162c7fb3a2e7665805b8c17a840
+	source-tip = 5f2a52ecb8c0510c3ae225baae4c8b7d75f3228a
 	source-base = cbf6ae4e9b3c705182b1e2573cee19aae7d4b877
 	merge = refs/heads/tb/codex/status-preview-unstable


### PR DESCRIPTION
Bot-generated pinned plan transition.

- Lane: `codex-unstable`
- Action: `alter`
- Topic: `refs/heads/tb/codex/fsmonitor-hardlink-inodes-unstable`
- Source tip: `5f2a52ecb8c0510c3ae225baae4c8b7d75f3228a`
- Prerequisite: `refs/heads/tb/codex/status-preview-unstable`
- Reviewed topic PR: `#56`

The plan blob and immutable `codex-pins/*` refs are authoritative.
