### PR TITLE
pack-objects: trace pack bytes written

### DIFF
--- a/builtin/pack-objects.c
+++ b/builtin/pack-objects.c
@@ -1390,9 +1390,10 @@ static void write_pack_file(void)
 			display_progress(progress_state, written);
 		}
 
+		/* Every finalization path appends the pack checksum. */
+		bytes_written += hashfile_total(f) +
+			the_repository->hash_algo->rawsz;
 		if (pack_to_stdout) {
-			bytes_written += hashfile_total(f) +
-				the_repository->hash_algo->rawsz;
 			/*
 			 * We never fsync when writing to stdout since we may
 			 * not be writing to an actual pack file. For instance,
@@ -1513,9 +1514,8 @@ static void write_pack_file(void)
 		    written, nr_result);
 	trace2_data_intmax("pack-objects", the_repository,
 			   "write_pack_file/wrote", nr_result);
-	if (pack_to_stdout)
-		trace2_data_intmax("pack-objects", the_repository,
-				   "written/bytes", bytes_written);
+	trace2_data_intmax("pack-objects", the_repository,
+			   "write_pack_file/wrote_bytes", bytes_written);
 }
 
 static int no_try_delta(const char *path)

--- a/builtin/pack-objects.c
+++ b/builtin/pack-objects.c
@@ -1348,6 +1348,7 @@ static void write_pack_file(void)
 	do {
 		unsigned char hash[GIT_MAX_RAWSZ];
 		char *pack_tmp_name = NULL;
+		off_t pack_bytes;
 
 		if (pack_to_stdout) {
 			/*
@@ -1390,8 +1391,7 @@ static void write_pack_file(void)
 			display_progress(progress_state, written);
 		}
 
-		/* Every finalization path appends the pack checksum. */
-		bytes_written += hashfile_total(f) +
+		pack_bytes = hashfile_total(f) +
 			the_repository->hash_algo->rawsz;
 		if (pack_to_stdout) {
 			/*
@@ -1423,6 +1423,7 @@ static void write_pack_file(void)
 				write_bitmap_index = 0;
 			}
 		}
+		bytes_written += pack_bytes;
 
 		if (!pack_to_stdout) {
 			struct stat st;

--- a/builtin/pack-objects.c
+++ b/builtin/pack-objects.c
@@ -1337,6 +1337,7 @@ static void write_pack_file(void)
 	uint32_t nr_remaining = nr_result;
 	time_t last_mtime = 0;
 	struct object_entry **write_order;
+	off_t bytes_written = 0;
 
 	if (progress > pack_to_stdout)
 		progress_state = start_progress(the_repository,
@@ -1390,6 +1391,8 @@ static void write_pack_file(void)
 		}
 
 		if (pack_to_stdout) {
+			bytes_written += hashfile_total(f) +
+				the_repository->hash_algo->rawsz;
 			/*
 			 * We never fsync when writing to stdout since we may
 			 * not be writing to an actual pack file. For instance,
@@ -1510,6 +1513,9 @@ static void write_pack_file(void)
 		    written, nr_result);
 	trace2_data_intmax("pack-objects", the_repository,
 			   "write_pack_file/wrote", nr_result);
+	if (pack_to_stdout)
+		trace2_data_intmax("pack-objects", the_repository,
+				   "written/bytes", bytes_written);
 }
 
 static int no_try_delta(const char *path)

--- a/t/t5300-pack-object.sh
+++ b/t/t5300-pack-object.sh
@@ -40,7 +40,21 @@ test_expect_success 'pack-object traces bytes written to stdout' '
 	$commit
 	EOF
 	bytes=$(test_file_size pack.pack) &&
-	test_grep "\"key\":\"written/bytes\",\"value\":\"$bytes\"" pack.trace
+	test_grep "\"key\":\"write_pack_file/wrote_bytes\",\"value\":\"$bytes\"" pack.trace
+'
+
+test_expect_success 'pack-object traces bytes written to split pack files' '
+	test_when_finished "rm -f split.trace traced-pack-*" &&
+	GIT_TRACE2_EVENT="$PWD/split.trace" \
+		git -c pack.packSizeLimit=3m pack-objects --quiet traced-pack <obj-list &&
+	test 2 = $(ls traced-pack-*.pack | wc -l) &&
+	bytes=0 &&
+	for pack in traced-pack-*.pack
+	do
+		pack_size=$(test_file_size "$pack") &&
+		bytes=$((bytes + pack_size)) || return 1
+	done &&
+	test_grep "\"key\":\"write_pack_file/wrote_bytes\",\"value\":\"$bytes\"" split.trace
 '
 
 test_expect_success 'setup pack-object <stdin' '

--- a/t/t5300-pack-object.sh
+++ b/t/t5300-pack-object.sh
@@ -33,6 +33,16 @@ test_expect_success 'setup' '
 	} >expect
 '
 
+test_expect_success 'pack-object traces bytes written to stdout' '
+	test_when_finished "rm -f pack.trace pack.pack" &&
+	GIT_TRACE2_EVENT="$PWD/pack.trace" \
+		git pack-objects --quiet --revs --stdout >pack.pack <<-EOF &&
+	$commit
+	EOF
+	bytes=$(test_file_size pack.pack) &&
+	test_grep "\"key\":\"written/bytes\",\"value\":\"$bytes\"" pack.trace
+'
+
 test_expect_success 'setup pack-object <stdin' '
 	git init pack-object-stdin &&
 	test_commit -C pack-object-stdin one &&


### PR DESCRIPTION
Author: Frielbot

Emit `pack-objects:write_pack_file/wrote_bytes` after `write_pack_file()` writes a pack. The value includes the pack checksum and sums the sizes of every pack when `pack.packSizeLimit` splits the output.

The Trace2 datum is emitted for stdout and on-disk packs. Tests compare the datum with stdout output and the sum of two split `.pack` files.
