### PR TITLE
Codex plan: add tb/codex/parallel-packfile-uris in codex

### DIFF
--- a/codex.plan
+++ b/codex.plan
@@ -9,6 +9,7 @@
 	topic = refs/heads/tb/codex/lto-pgo
 	topic = refs/heads/tb/codex/packfile-uri-concurrency
 	topic = refs/heads/af/codex/pack-bytes
+	topic = refs/heads/tb/codex/parallel-packfile-uris
 
 [branch "tb/codex/automation"]
 	remote = .
@@ -58,3 +59,10 @@
 	source-tip = 9abdcdc650f32a4b03c31d0595e0b29892749574
 	source-base = a97fcc37c2bc6340a8d7ce78dedf227aac4e9aa7
 	merge = refs/heads/master
+
+[branch "tb/codex/parallel-packfile-uris"]
+	remote = .
+	source-ref = refs/heads/tb/codex/parallel-packfile-uris
+	source-tip = a08b8d8bb7e3082e9d8e3d29e1535579234784be
+	source-base = 4cc8b3223b233aa3b795b1265e6e7cf3d63c7170
+	merge = refs/heads/tb/codex/packfile-uri-concurrency


### PR DESCRIPTION
Bot-generated pinned plan transition.

- Lane: `codex`
- Action: `add`
- Topic: `refs/heads/tb/codex/parallel-packfile-uris`
- Source tip: `a08b8d8bb7e3082e9d8e3d29e1535579234784be`
- Prerequisite: `refs/heads/tb/codex/packfile-uri-concurrency`
- Reviewed topic PR: `#65`

The plan blob and immutable `codex-pins/*` refs are authoritative.
