### PR TITLE
codex: recover pinned plans after master moves

### DIFF
--- a/.github/CODEX.md
+++ b/.github/CODEX.md
@@ -133,14 +133,18 @@ nothing.
 
 If a replay conflicts, the controller leaves published refs unchanged and
 prints the pinned recovery command. Resolve only in that disposable worktree,
-then run a fresh rebuild. For a pinned merge-shaped source, the controller
-uses its reviewed `source-base` as the exact old root and preserves the DAG
-across a moved generated base only when the two changed-path sets are
-disjoint. A linear dependent topic can extend that graph when its reviewed
-boundary is the exact pinned source tip of a prerequisite already rooted in
-the graph. An overlapping base move, an unrelated boundary, or another
-merge-shaped source with a different reviewed root fails closed; restack and
-obtain a new exact-head review instead of flattening or guessing.
+then run the printed `continue` and `publish-topics` commands. For pinned
+plans, `publish-topics` keeps source refs immutable and freezes the verified
+candidate, inputs, updates, and bundle in a local recovery session; stage
+that exact session, wait for fresh staging CI, and promote it atomically. For
+a pinned merge-shaped source, the controller uses its reviewed `source-base`
+as the exact old root and preserves the DAG across a moved generated base
+only when the two changed-path sets are disjoint. A linear dependent topic
+can extend that graph when its reviewed boundary is the exact pinned source
+tip of a prerequisite already rooted in the graph. An overlapping base move,
+an unrelated boundary, or another merge-shaped source with a different
+reviewed root fails closed; restack and obtain a new exact-head review instead
+of flattening or guessing.
 
 ## Required automation topic
 

--- a/.github/workflows/codex-branch.sh
+++ b/.github/workflows/codex-branch.sh
@@ -9858,7 +9858,12 @@ continue_rewrite () {
 		return 1
 	fi
 
-	say "All topic branches were rewritten. Review them, then publish atomically with:"
+	if test -f "$state/pinned-plan-mode"
+	then
+		say "All topic branches were rewritten. Review them, then freeze the candidate with:"
+	else
+		say "All topic branches were rewritten. Review them, then publish atomically with:"
+	fi
 	say
 	say "  $(shell_quote "$script_path") publish-topics --worktree $(shell_quote "$worktree")"
 }
@@ -9904,6 +9909,11 @@ publish_topics () {
 		fi
 		die "rewritten topic graph failed candidate validation; no refs were updated"
 	fi
+	if test -f "$state/pinned-plan-mode"
+	then
+		prepare_unstable_candidate "$worktree" "$state" "$candidate" \
+			"$tmp_dir/codex-conflict.md"
+	fi
 	stable_recovery=
 	if test "$(state_value "$state" config-version)" = 2
 	then
@@ -9930,6 +9940,59 @@ publish_topics () {
 		"$candidate_worktree" >/dev/null ||
 		die "could not remove the candidate verification worktree"
 	temporary_worktree=
+
+	if test -f "$state/pinned-plan-mode"
+	then
+		(
+			cd "$worktree" || exit 1
+			verify_inputs --remote "$remote" --base "$base_name" \
+				--codex "$codex_name" "$state/inputs"
+		) || die "pinned recovery inputs moved; no refs were updated"
+		choose_local_rebuild_session
+		mkdir -p "$session" ||
+			die "could not create pinned recovery session"
+		chmod 700 "$session" ||
+			die "could not protect pinned recovery session"
+		recovery_inputs=$session/codex-inputs
+		recovery_updates=$session/codex-updates
+		cp "$state/inputs" "$recovery_inputs" ||
+			die "could not freeze pinned recovery inputs"
+		cp "$tmp_dir/updates" "$recovery_updates" ||
+			die "could not freeze pinned recovery updates"
+		printf '%s\n' "$candidate" >"$session/codex-candidate" ||
+			die "could not freeze pinned recovery candidate"
+		create_bundle "$session/codex.bundle" "$state" "$candidate"
+		for name in codex.bundle codex-candidate codex-inputs \
+			codex-updates
+		do
+			chmod 600 "$session/$name" ||
+				die "could not protect pinned recovery file '$name'"
+		done
+		say "Pinned recovery session: $session"
+		say "No refs were updated. Stage the verified candidate with:"
+		say "  $(shell_quote "$script_path") stage \\"
+		say "    --remote $(shell_quote "$remote") --staging codex-staging \\"
+		say "    --inputs $(shell_quote "$recovery_inputs") \\"
+		say "    --updates $(shell_quote "$recovery_updates")${require_automation:+ --require-automation}"
+		unstable_candidate=$(awk -F '\t' \
+			'$1 == "refs/heads/codex-unstable" { print $3 }' \
+			"$tmp_dir/updates")
+		if test -n "$unstable_candidate" &&
+			! is_null_oid "$unstable_candidate"
+		then
+			say "  $(shell_quote "$script_path") stage \\"
+			say "    --remote $(shell_quote "$remote") \\"
+			say "    --staging codex-unstable-staging \\"
+			say "    --inputs $(shell_quote "$recovery_inputs") \\"
+			say "    --updates $(shell_quote "$recovery_updates")${require_automation:+ --require-automation}"
+		fi
+		say "After fresh staging CI passes, promote the same session with:"
+		say "  $(shell_quote "$script_path") promote \\"
+		say "    --remote $(shell_quote "$remote") --staging codex-staging \\"
+		say "    --inputs $(shell_quote "$recovery_inputs") \\"
+		say "    --updates $(shell_quote "$recovery_updates")${require_automation:+ --require-automation}"
+		return
+	fi
 
 	(
 		cd "$worktree" || exit 1

--- a/.github/workflows/codex-branch.sh
+++ b/.github/workflows/codex-branch.sh
@@ -8164,15 +8164,15 @@ verify_control_paths () {
 		automation_count=0
 		while IFS="$tab" read -r name source_tip prerequisites
 		do
+			source_base=$(plan_source_base \
+				"$graph/desired-source-bases" "$name")
+			test -n "$source_base" ||
+				die "pinned plan has no source boundary for '$name'"
 			case "$name" in
 			??/codex/automation)
 				automation_count=$((automation_count + 1))
 				test "$prerequisites" = master ||
 					die "automation topic '$name' must be based directly on master"
-				source_base=$(plan_source_base \
-					"$graph/desired-source-bases" "$name")
-				test -n "$source_base" ||
-					die "pinned plan has no source boundary for automation topic '$name'"
 				make_tmp_dir
 				git diff --name-only "$source_base" "$source_tip" \
 					>"$tmp_dir/automation-paths" ||
@@ -8193,21 +8193,8 @@ verify_control_paths () {
 				continue
 				;;
 			esac
-			for prerequisite in $prerequisites
-			do
-				if test "$prerequisite" = "$base_name"
-				then
-					dependency_source=$base_oid
-				else
-					dependency_source=$(plan_tip \
-						"$graph/desired-prerequisites" "$prerequisite")
-					test -n "$dependency_source" ||
-						die "pinned plan has no source for prerequisite '$prerequisite'"
-				fi
-				topic_control_paths_unchanged "$dependency_source" \
-					"$source_tip" ||
-					die "topic '$name' changes a protected controller or CI file"
-			done
+			topic_control_paths_unchanged "$source_base" "$source_tip" ||
+				die "topic '$name' changes a protected controller or CI file"
 		done <"$graph/desired-prerequisites"
 		test "$automation_count" = 1 ||
 			die "exactly one active ??/codex/automation topic is required"

--- a/t/t9905-codex-branch.sh
+++ b/t/t9905-codex-branch.sh
@@ -9206,8 +9206,10 @@ test_expect_success 'a pinned root keeps its reviewed boundary after base and so
 		(
 			cd ../pinned-root-boundary-source &&
 			git switch master &&
+			mkdir -p .github/workflows &&
+			write upstream .github/workflows/main.yml &&
 			write advanced advanced-base &&
-			git add advanced-base &&
+			git add .github/workflows/main.yml advanced-base &&
 			git commit -m "advance base after review" &&
 			git push origin master
 		) &&

--- a/t/t9905-codex-branch.sh
+++ b/t/t9905-codex-branch.sh
@@ -9243,6 +9243,83 @@ test_expect_success 'a pinned root keeps its reviewed boundary after base and so
 	)
 '
 
+test_expect_success 'pinned conflict recovery freezes output artifacts' '
+	git init --bare pinned-conflict.git &&
+	test_create_repo pinned-conflict-source &&
+	(
+		cd pinned-conflict-source &&
+		git remote add origin ../pinned-conflict.git &&
+		write base shared &&
+		git add shared &&
+		install_rerere_train &&
+		git commit -m "pinned conflict base" &&
+		install_reviewed_automation_topic &&
+		git switch -c bb/codex/conflict "$automation_tip" &&
+		write topic shared &&
+		git add shared &&
+		git commit -m "pinned conflicting topic" &&
+		conflict=$(git rev-parse HEAD) &&
+		conflict_tree=$(git merge-tree --write-tree \
+			"$automation_codex_tip" "$conflict") &&
+		codex_tip=$(make_test_integration bb/codex/conflict \
+			"$conflict" "$automation_codex_tip" "$conflict_tree") &&
+		git branch codex "$codex_tip" &&
+		create_unstable_sentinel codex &&
+		git branch meta master &&
+		install_pinned_meta_state meta master codex codex-unstable &&
+		git switch master &&
+		write upstream shared &&
+		git add shared &&
+		git commit -m "move pinned conflict base" &&
+		git push origin --all
+	) &&
+	git clone pinned-conflict.git pinned-conflict-runner &&
+	(
+		cd pinned-conflict-runner &&
+		fetch_all &&
+		snapshot_refs ../pinned-conflict.git >before &&
+		test_expect_code 1 sh "$codex_branch" rewrite \
+			--remote origin --base master --codex codex \
+			--result result --updates updates --inputs inputs \
+			--failure failure --require-automation &&
+		digest=$(git hash-object inputs) &&
+		sh "$codex_branch" resolve --remote origin \
+			--base master --codex codex --inputs-oid "$digest" \
+			--worktree resolution --require-automation &&
+		write resolved resolution/shared &&
+		git -C resolution add shared &&
+		sh "$codex_branch" continue --worktree resolution &&
+		sh "$codex_branch" publish-topics --worktree resolution \
+			>publish.out &&
+		session=$(sed -n \
+			"s/^Pinned recovery session: //p" publish.out) &&
+		test -n "$session" &&
+		printf "%s\n" "$session" >session &&
+		test_line_count = 1 session &&
+		for name in codex.bundle codex-candidate codex-inputs \
+			codex-updates
+		do
+			test_path_is_file "$session/$name" || return 1
+		done &&
+		test_cmp inputs "$session/codex-inputs" &&
+		sh "$codex_branch" verify-output \
+			--inputs "$session/codex-inputs" \
+			--updates "$session/codex-updates" \
+			--result "$session/codex-candidate" \
+			--require-automation &&
+		candidate=$(cat "$session/codex-candidate") &&
+		test resolved = "$(git show "$candidate:shared")" &&
+		git bundle verify "$session/codex.bundle" &&
+		cut -f1 "$session/codex-updates" >actual-updates &&
+		printf "%s\n" refs/heads/codex refs/heads/codex-unstable \
+			refs/heads/meta >expected-updates &&
+		test_cmp expected-updates actual-updates &&
+		snapshot_refs ../pinned-conflict.git >after &&
+		test_cmp before after &&
+		git worktree remove --force resolution
+	)
+'
+
 test_expect_success 'pre-v3 bootstrap records authorization and can pin each explicit override' '
 	git init --bare pinned-bootstrap-command.git &&
 	test_create_repo pinned-bootstrap-command-source &&


### PR DESCRIPTION
## Summary

- check pinned topic control paths from their reviewed source boundaries, so an upstream-only protected-path change does not block a rebuild
- freeze verified candidate artifacts after a pinned conflict recovery instead of trying to push immutable source refs
- preserve the existing pre-pinned source-ref publication path

## Testing

- `git diff --check`
- `sh -n .github/workflows/codex-branch.sh`
- `t/t9905-codex-branch.sh -v -i --run=121-122`

<!-- codex-thread: 01a02073-da32-73b1-a783-c629c35fb432 -->