### PR TITLE
codex: verify frozen overlapping merge recoveries

### DIFF
--- a/.github/workflows/codex-branch.sh
+++ b/.github/workflows/codex-branch.sh
@@ -4672,6 +4672,10 @@ verify_merge_topology () (
 	if test -f "$state/pinned-merge-root"
 	then
 		prepare_pinned_merge_overlay "$state" "$root" "$base"
+		# A disjoint replay has one mechanically expected tree per commit.
+		# An overlapping replay may contain conflict resolutions, so its
+		# durable proof is the one-to-one commit and parent mapping below,
+		# not producer-local recovery state.
 		if test -f "$state/pinned-merge-disjoint-base"
 		then
 			LC_ALL=C sort -u "$source" \
@@ -4695,9 +4699,6 @@ verify_merge_topology () (
 					die "pinned merge replay changes its reviewed tree outside the moved base"
 			done <"$state/verified-tree-commits"
 			exec 3<&-
-		else
-			test -f "$state/pinned-merge-overlap-rebase" ||
-				die "overlapping pinned merge graph was not rebased by the controller"
 		fi
 	fi
 

--- a/t/t9905-codex-branch.sh
+++ b/t/t9905-codex-branch.sh
@@ -9268,6 +9268,13 @@ test_expect_success 'pinned merge chain preserves recoverable overlap state' '
 			>publish.out 2>publish.err &&
 		test_grep "Pinned recovery session" publish.out &&
 		test_grep "No refs were updated" publish.out &&
+		session=$(sed -n \
+			"s/^Pinned recovery session: //p" publish.out) &&
+		test -n "$session" &&
+		sh "$codex_branch" verify-output \
+			--inputs "$session/codex-inputs" \
+			--updates "$session/codex-updates" \
+			--result "$session/codex-candidate" &&
 		snapshot_refs "$fixture_remote" >after-publish &&
 		test_cmp before after-publish
 	)


### PR DESCRIPTION
## Summary

- verify frozen overlapping merge recoveries from their durable commit and parent mapping instead of transient producer state
- preserve mechanical tree verification for disjoint pinned graphs
- cover fresh-process verification of frozen recovery artifacts

## Testing

- `t/t9905-codex-branch.sh --run=112,118,120`
- `verify-output` against the repaired 426-commit release candidate

<!-- codex-thread: 01a03532-28b4-7c42-b388-766d9adeb285 -->
