### PR TITLE
[PATCH] fetch-pack: defer .gitattributes checks for packfile URIs

### DIFF
--- a/.github/workflows/codex-pgo-training.sh
+++ b/.github/workflows/codex-pgo-training.sh
@@ -1,0 +1,60 @@
+#!/bin/sh
+
+# Keep this workload short and biased toward the local Git operations Codex
+# invokes frequently. The full Git test suite is too slow for each release
+# target and would weight test-harness paths more heavily than status, diff,
+# clone, fetch, and repository maintenance.
+
+set -eu
+
+git_bin="$PWD/bin-wrappers/git"
+training_dir=$(mktemp -d "${TMPDIR:-/tmp}/codex-git-pgo.XXXXXX")
+repo="$training_dir/repo"
+clone="$training_dir/clone"
+
+cleanup () {
+	rm -rf "$training_dir"
+}
+trap cleanup EXIT HUP INT TERM
+
+mkdir -p "$training_dir/home"
+export HOME="$training_dir/home"
+export GIT_CONFIG_NOSYSTEM=1
+export GIT_TERMINAL_PROMPT=0
+
+"$git_bin" clone --quiet --no-local "$PWD" "$repo"
+"$git_bin" -C "$repo" config user.name "Codex Git PGO"
+"$git_bin" -C "$repo" config user.email "codex-git-pgo@openai.com"
+
+i=0
+while test "$i" -lt 256
+do
+	dir="$repo/training/$((i % 16))"
+	mkdir -p "$dir"
+	printf '%s\n' "$i" >"$dir/file-$i"
+	i=$((i + 1))
+done
+
+"$git_bin" -C "$repo" status --porcelain=v2 --branch >/dev/null
+"$git_bin" -C "$repo" status --porcelain=v2 --branch --untracked-files=all >/dev/null
+"$git_bin" -C "$repo" ls-files --others --exclude-standard >/dev/null
+"$git_bin" -C "$repo" add training
+"$git_bin" -C "$repo" diff --cached --stat >/dev/null
+"$git_bin" -C "$repo" commit --quiet -m "add training files"
+
+printf 'changed\n' >>"$repo/training/0/file-0"
+rm "$repo/training/1/file-1"
+mkdir -p "$repo/untracked"
+printf 'new\n' >"$repo/untracked/file"
+
+"$git_bin" -C "$repo" status --porcelain=v2 --branch >/dev/null
+"$git_bin" -C "$repo" diff --stat >/dev/null
+"$git_bin" -C "$repo" diff --name-status >/dev/null
+"$git_bin" -C "$repo" ls-files --stage >/dev/null
+"$git_bin" -C "$repo" log --oneline --decorate -20 >/dev/null
+"$git_bin" -C "$repo" rev-list --objects --all >/dev/null
+"$git_bin" -C "$repo" for-each-ref --format='%(refname) %(objectname)' >/dev/null
+"$git_bin" -C "$repo" repack -ad
+"$git_bin" clone --quiet --no-local "$repo" "$clone"
+"$git_bin" -C "$clone" status --porcelain=v2 --branch >/dev/null
+"$git_bin" -C "$clone" fetch --quiet "$repo"

--- a/.github/workflows/codex-release.yml
+++ b/.github/workflows/codex-release.yml
@@ -94,7 +94,7 @@ jobs:
             file_pattern: ELF 64-bit.*x86-64
             has_gcm: true
           - name: Windows arm64
-            os: windows-2025
+            os: windows-11-arm
             target_platform: win32
             asset_platform: windows
             arch: arm64
@@ -314,8 +314,8 @@ jobs:
           grep -E "$FILE_PATTERN" /tmp/git-file-type
           strings "$GIT_BINARY" | grep -F "$GITHUB_SHA"
 
-      - name: Smoke-test the native x64 distribution
-        if: matrix.arch == 'x64'
+      - name: Smoke-test the native distribution
+        if: matrix.arch == 'x64' || matrix.target_platform == 'win32'
         shell: bash
         env:
           TARGET_PLATFORM: ${{ matrix.target_platform }}

--- a/.github/workflows/codex-release.yml
+++ b/.github/workflows/codex-release.yml
@@ -278,7 +278,7 @@ jobs:
             NO_INSTALL_HARDLINKS=YesPlease
             NO_CROSS_DIRECTORY_HARDLINKS=YesPlease
           )
-          jobs="$(nproc)"
+          jobs="${NUMBER_OF_PROCESSORS:-2}"
           make -j"$jobs" "${make_args[@]}" all
           make "${make_args[@]}" DESTDIR=/tmp/build/git strip install
 

--- a/.github/workflows/codex-release.yml
+++ b/.github/workflows/codex-release.yml
@@ -184,8 +184,8 @@ jobs:
       - name: Check out Dugite Native
         uses: actions/checkout@v6
         with:
-          repository: desktop/dugite-native
-          ref: f97e50add48cdcff053a69d95aa343a4a4a258c2
+          repository: dreynaud-oai/dugite-native
+          ref: b6f4473557acb85433fdf9deffe0854a34fd9cc5
           path: dugite-native
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/codex-release.yml
+++ b/.github/workflows/codex-release.yml
@@ -68,7 +68,8 @@ jobs:
             arch: arm64
             binary: /tmp/build/git/bin/git
             file_pattern: Mach-O 64-bit executable arm64
-            has_gcm: true
+            has_gcm: false
+            max_tar_bytes: 33554432
           - name: macOS x64
             os: macos-15-intel
             target_platform: macOS
@@ -76,7 +77,8 @@ jobs:
             arch: x64
             binary: /tmp/build/git/bin/git
             file_pattern: Mach-O 64-bit executable x86_64
-            has_gcm: true
+            has_gcm: false
+            max_tar_bytes: 33554432
           - name: Linux arm64
             os: ubuntu-22.04
             target_platform: ubuntu
@@ -85,6 +87,7 @@ jobs:
             binary: /tmp/build/git/bin/git
             file_pattern: ELF 64-bit.*ARM aarch64
             has_gcm: false
+            max_tar_bytes: 41943040
           - name: Linux x64
             os: ubuntu-22.04
             target_platform: ubuntu
@@ -92,7 +95,8 @@ jobs:
             arch: x64
             binary: /tmp/build/git/bin/git
             file_pattern: ELF 64-bit.*x86-64
-            has_gcm: true
+            has_gcm: false
+            max_tar_bytes: 41943040
           - name: Windows arm64
             os: windows-11-arm
             target_platform: win32
@@ -101,6 +105,7 @@ jobs:
             binary: /tmp/build/git/clangarm64/bin/git.exe
             file_pattern: PE32\+.*ARM64
             has_gcm: true
+            max_tar_bytes: 83886080
             sdk_arch: aarch64
             sdk_flavor: full
             mingw_dir: clangarm64
@@ -116,6 +121,7 @@ jobs:
             binary: /tmp/build/git/mingw64/bin/git.exe
             file_pattern: PE32\+.*x86-64
             has_gcm: true
+            max_tar_bytes: 83886080
             sdk_arch: x86_64
             sdk_flavor: full
             mingw_dir: mingw64
@@ -235,6 +241,20 @@ jobs:
             dependencies.json >"$updated"
           mv "$updated" dependencies.json
 
+      # Codex does not configure or invoke GCM on macOS or Linux. The
+      # self-contained .NET payload accounts for most of those bundles, while
+      # Windows MinGit configures credential.helper=manager and must retain it.
+      - name: Omit unused GCM from POSIX bundles
+        if: matrix.target_platform != 'win32'
+        shell: bash
+        working-directory: dugite-native
+        run: |
+          set -euo pipefail
+          updated="$(mktemp)"
+          jq '."git-credential-manager".files = []' \
+            dependencies.json >"$updated"
+          mv "$updated" dependencies.json
+
       # Dugite cross-compiles several targets. Keep Git's optional Rust
       # library disabled until its Makefile can direct Cargo at those targets.
       - name: Build the Dugite Native distribution
@@ -259,6 +279,8 @@ jobs:
       # Dugite Native compiles its Git submodule on macOS and Linux. On
       # Windows it starts from MinGit, so replace MinGit's Git programs with
       # the build from this repository while retaining the portable runtime.
+      # MinGit omits dashed builtin aliases; installing them as copies would
+      # add hundreds of redundant MiB to the archive.
       - name: Install this Git build into the Windows distribution
         if: matrix.target_platform == 'win32'
         shell: bash
@@ -276,6 +298,7 @@ jobs:
             NO_GETTEXT=YesPlease
             NO_INSTALL_HARDLINKS=YesPlease
             NO_CROSS_DIRECTORY_HARDLINKS=YesPlease
+            SKIP_DASHED_BUILT_INS=YesPlease
           )
           jobs="${NUMBER_OF_PROCESSORS:-2}"
           make -j"$jobs" "${make_args[@]}" all
@@ -296,6 +319,7 @@ jobs:
             test -f /tmp/build/git/cmd/git.exe
             test -f "/tmp/build/git/$MINGW_DIR/libexec/git-core/git-lfs.exe"
             test -d "/tmp/build/git/$MINGW_DIR/share/git-core/templates"
+            test ! -e "/tmp/build/git/$MINGW_DIR/libexec/git-core/git-add.exe"
             if test "$HAS_GCM" = true
             then
               test -f "/tmp/build/git/$MINGW_DIR/bin/git-credential-manager.exe"
@@ -306,6 +330,8 @@ jobs:
             if test "$HAS_GCM" = true
             then
               test -x /tmp/build/git/libexec/git-core/git-credential-manager
+            else
+              test ! -e /tmp/build/git/libexec/git-core/git-credential-manager
             fi
           fi
           test -f /tmp/build/git/etc/gitconfig
@@ -320,6 +346,7 @@ jobs:
         env:
           TARGET_PLATFORM: ${{ matrix.target_platform }}
           MINGW_DIR: ${{ matrix.mingw_dir }}
+          HAS_GCM: ${{ matrix.has_gcm }}
         run: |
           set -euo pipefail
           smoke=/tmp/codex-git-smoke
@@ -352,7 +379,10 @@ jobs:
           printf '%s\n' "$build_options"
           grep -F "built from commit: $GITHUB_SHA" <<<"$build_options"
           env "${git_env[@]}" "$git_binary" lfs version
-          env "${git_env[@]}" "$git_binary" credential-manager --version
+          if test "$HAS_GCM" = true
+          then
+            env "${git_env[@]}" "$git_binary" credential-manager --version
+          fi
 
           env "${git_env[@]}" "$git_binary" init --quiet "$smoke/repo"
           echo test >"$smoke/repo/file"
@@ -371,6 +401,7 @@ jobs:
           TARGET_PLATFORM: ${{ matrix.target_platform }}
           TARGET_ARCH: ${{ matrix.arch }}
           VERSION: ${{ needs.version.outputs.version }}
+          MAX_TAR_BYTES: ${{ matrix.max_tar_bytes }}
         run: |
           set -euo pipefail
           script/package.sh
@@ -400,6 +431,11 @@ jobs:
             fi
             test "$actual" = "$expected"
           done
+
+          tarball="output/git-$VERSION-$ASSET_PLATFORM-$TARGET_ARCH.tar.gz"
+          tar_bytes="$(wc -c <"$tarball")"
+          printf '%s bytes: %s\n' "$tar_bytes" "$tarball"
+          test "$tar_bytes" -le "$MAX_TAR_BYTES"
 
       - name: Upload release assets
         uses: actions/upload-artifact@v7

--- a/.github/workflows/codex-release.yml
+++ b/.github/workflows/codex-release.yml
@@ -117,6 +117,7 @@ jobs:
             binary: /tmp/build/git/bin/git
             file_pattern: Mach-O 64-bit executable arm64
             has_gcm: false
+            lto: thin
             max_tar_bytes: 67108864
           - name: macOS x64
             os: macos-15-intel
@@ -126,6 +127,7 @@ jobs:
             binary: /tmp/build/git/bin/git
             file_pattern: Mach-O 64-bit executable x86_64
             has_gcm: false
+            lto: thin
             max_tar_bytes: 67108864
           # Keep arm64 builds native so release smoke tests can execute them.
           - name: Linux arm64
@@ -136,6 +138,7 @@ jobs:
             binary: /tmp/build/git/bin/git
             file_pattern: ELF 64-bit.*ARM aarch64
             has_gcm: false
+            lto: auto
             max_tar_bytes: 67108864
           - name: Linux x64
             os: ubuntu-22.04
@@ -145,6 +148,7 @@ jobs:
             binary: /tmp/build/git/bin/git
             file_pattern: ELF 64-bit.*x86-64
             has_gcm: false
+            lto: auto
             max_tar_bytes: 67108864
           - name: Windows arm64
             os: windows-11-arm
@@ -154,6 +158,7 @@ jobs:
             binary: /tmp/build/git/clangarm64/bin/git.exe
             file_pattern: PE32\+.*ARM64
             has_gcm: true
+            lto: thin
             max_tar_bytes: 134217728
             sdk_arch: aarch64
             sdk_flavor: full
@@ -170,6 +175,7 @@ jobs:
             binary: /tmp/build/git/mingw64/bin/git.exe
             file_pattern: PE32\+.*x86-64
             has_gcm: true
+            lto: auto
             max_tar_bytes: 134217728
             sdk_arch: x86_64
             sdk_flavor: full
@@ -209,6 +215,11 @@ jobs:
             -c 'user.name=github-actions[bot]' \
             -c 'user.email=41898282+github-actions[bot]@users.noreply.github.com' \
             tag -a "$VERSION" -m "$VERSION"
+
+      - name: Install OpenAI build configuration
+        shell: bash
+        working-directory: dugite-native/git
+        run: cp config.mak.openai config.mak
 
       # Match Dugite Native's compatibility choice for its macOS x64 build.
       - name: Select Xcode 16.4
@@ -305,6 +316,7 @@ jobs:
         working-directory: dugite-native
         env:
           NO_RUST: 1
+          OPENAI_LTO: ${{ matrix.lto }}
           TARGET_PLATFORM: ${{ matrix.target_platform }}
           TARGET_ARCH: ${{ matrix.arch }}
         run: |
@@ -330,6 +342,7 @@ jobs:
         working-directory: dugite-native/git
         env:
           MINGW_DIR: ${{ matrix.mingw_dir }}
+          OPENAI_LTO: ${{ matrix.lto }}
         run: |
           set -euo pipefail
 
@@ -355,6 +368,7 @@ jobs:
           GIT_BINARY: ${{ matrix.binary }}
           FILE_PATTERN: ${{ matrix.file_pattern }}
           HAS_GCM: ${{ matrix.has_gcm }}
+          LTO: ${{ matrix.lto }}
         run: |
           set -euo pipefail
           if test "$TARGET_PLATFORM" = win32
@@ -382,6 +396,7 @@ jobs:
           file "$GIT_BINARY" | tee /tmp/git-file-type
           grep -E "$FILE_PATTERN" /tmp/git-file-type
           strings "$GIT_BINARY" | grep -F "$GITHUB_SHA"
+          grep -F -- "-flto=$LTO" dugite-native/git/GIT-CFLAGS
 
       - name: Smoke-test the native distribution
         shell: bash

--- a/.github/workflows/codex-release.yml
+++ b/.github/workflows/codex-release.yml
@@ -69,7 +69,7 @@ jobs:
             binary: /tmp/build/git/bin/git
             file_pattern: Mach-O 64-bit executable arm64
             has_gcm: false
-            max_tar_bytes: 33554432
+            max_tar_bytes: 67108864
           - name: macOS x64
             os: macos-15-intel
             target_platform: macOS
@@ -78,7 +78,7 @@ jobs:
             binary: /tmp/build/git/bin/git
             file_pattern: Mach-O 64-bit executable x86_64
             has_gcm: false
-            max_tar_bytes: 33554432
+            max_tar_bytes: 67108864
           - name: Linux arm64
             os: ubuntu-22.04
             target_platform: ubuntu
@@ -87,7 +87,7 @@ jobs:
             binary: /tmp/build/git/bin/git
             file_pattern: ELF 64-bit.*ARM aarch64
             has_gcm: false
-            max_tar_bytes: 41943040
+            max_tar_bytes: 67108864
           - name: Linux x64
             os: ubuntu-22.04
             target_platform: ubuntu
@@ -96,7 +96,7 @@ jobs:
             binary: /tmp/build/git/bin/git
             file_pattern: ELF 64-bit.*x86-64
             has_gcm: false
-            max_tar_bytes: 41943040
+            max_tar_bytes: 67108864
           - name: Windows arm64
             os: windows-11-arm
             target_platform: win32
@@ -105,7 +105,7 @@ jobs:
             binary: /tmp/build/git/clangarm64/bin/git.exe
             file_pattern: PE32\+.*ARM64
             has_gcm: true
-            max_tar_bytes: 83886080
+            max_tar_bytes: 134217728
             sdk_arch: aarch64
             sdk_flavor: full
             mingw_dir: clangarm64
@@ -121,7 +121,7 @@ jobs:
             binary: /tmp/build/git/mingw64/bin/git.exe
             file_pattern: PE32\+.*x86-64
             has_gcm: true
-            max_tar_bytes: 83886080
+            max_tar_bytes: 134217728
             sdk_arch: x86_64
             sdk_flavor: full
             mingw_dir: mingw64

--- a/.github/workflows/codex-release.yml
+++ b/.github/workflows/codex-release.yml
@@ -127,8 +127,9 @@ jobs:
             file_pattern: Mach-O 64-bit executable x86_64
             has_gcm: false
             max_tar_bytes: 67108864
+          # Keep arm64 builds native so release smoke tests can execute them.
           - name: Linux arm64
-            os: ubuntu-22.04
+            os: ubuntu-22.04-arm
             target_platform: ubuntu
             asset_platform: ubuntu
             arch: arm64
@@ -243,19 +244,13 @@ jobs:
       - name: Install Linux arm64 build dependencies
         if: matrix.target_platform == 'ubuntu' && matrix.arch == 'arm64'
         run: |
-          sudo sed -i "s/^deb/deb [arch=amd64,i386]/g" /etc/apt/sources.list
-          release="$(lsb_release -s -c)"
-          echo "deb [arch=arm64,armhf] http://azure.ports.ubuntu.com/ ${release} main universe multiverse restricted" | sudo tee -a /etc/apt/sources.list
-          echo "deb [arch=arm64,armhf] http://azure.ports.ubuntu.com/ ${release}-updates main universe multiverse restricted" | sudo tee -a /etc/apt/sources.list
-          sudo dpkg --add-architecture arm64
-          sudo apt-get update
           sudo apt-get install -y \
             binutils-aarch64-linux-gnu \
             gcc-aarch64-linux-gnu \
-            libcurl4-gnutls-dev:arm64 \
-            libexpat1-dev:arm64 \
-            libssl-dev:arm64 \
-            zlib1g-dev:arm64
+            libcurl4-gnutls-dev \
+            libexpat1-dev \
+            libssl-dev \
+            zlib1g-dev
 
       # Dugite Native currently pins MinGit 2.53. Keep its build script and
       # dependency schema, but match the runtime to the Git series we compile.
@@ -389,7 +384,6 @@ jobs:
           strings "$GIT_BINARY" | grep -F "$GITHUB_SHA"
 
       - name: Smoke-test the native distribution
-        if: matrix.arch == 'x64' || matrix.target_platform == 'win32'
         shell: bash
         env:
           TARGET_PLATFORM: ${{ matrix.target_platform }}

--- a/.github/workflows/codex-release.yml
+++ b/.github/workflows/codex-release.yml
@@ -13,8 +13,42 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  publication:
+    name: Verify controller publication
+    runs-on: ubuntu-24.04
+    outputs:
+      published: ${{ steps.verify.outputs.published }}
+    steps:
+      - name: Check the published controller output
+        id: verify
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          meta=$(gh api \
+            "repos/$GITHUB_REPOSITORY/git/ref/heads/meta" \
+            --jq '.object.sha')
+          recorded=$(gh api \
+            "repos/$GITHUB_REPOSITORY/contents/codex.config?ref=$meta" \
+            -H 'Accept: application/vnd.github.raw+json' |
+            git config --no-includes --file /dev/stdin \
+              --get codex.output-tip)
+
+          if test "$GITHUB_SHA" = "$recorded"
+          then
+            printf 'published=true\n' >>"$GITHUB_OUTPUT"
+            printf 'Releasing controller-published commit %s.\n' "$GITHUB_SHA"
+          else
+            printf 'published=false\n' >>"$GITHUB_OUTPUT"
+            printf 'Skipping non-controller publication %s.\n' "$GITHUB_SHA"
+          fi
+
   version:
     name: Determine version
+    needs: publication
+    if: needs.publication.outputs.published == 'true'
     runs-on: ubuntu-24.04
     outputs:
       describe: ${{ steps.version.outputs.describe }}

--- a/.github/workflows/codex-release.yml
+++ b/.github/workflows/codex-release.yml
@@ -235,14 +235,6 @@ jobs:
             dependencies.json >"$updated"
           mv "$updated" dependencies.json
 
-      - name: Set up Git for Windows SDK
-        if: matrix.target_platform == 'win32'
-        uses: git-for-windows/setup-git-for-windows-sdk@v2
-        with:
-          architecture: ${{ matrix.sdk_arch }}
-          flavor: ${{ matrix.sdk_flavor }}
-          cache: false
-
       # Dugite cross-compiles several targets. Keep Git's optional Rust
       # library disabled until its Makefile can direct Cargo at those targets.
       - name: Build the Dugite Native distribution
@@ -254,11 +246,15 @@ jobs:
           TARGET_ARCH: ${{ matrix.arch }}
         run: |
           set -euo pipefail
-          if test "$TARGET_PLATFORM" = win32
-          then
-            . /etc/profile
-          fi
           script/build.sh
+
+      - name: Set up Git for Windows SDK
+        if: matrix.target_platform == 'win32'
+        uses: git-for-windows/setup-git-for-windows-sdk@v2
+        with:
+          architecture: ${{ matrix.sdk_arch }}
+          flavor: ${{ matrix.sdk_flavor }}
+          cache: false
 
       # Dugite Native compiles its Git submodule on macOS and Linux. On
       # Windows it starts from MinGit, so replace MinGit's Git programs with

--- a/.github/workflows/codex-release.yml
+++ b/.github/workflows/codex-release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - codex
+      - codex-unstable
 
 permissions:
   contents: read
@@ -16,6 +17,7 @@ jobs:
   publication:
     name: Verify controller publication
     runs-on: ubuntu-24.04
+    if: github.event.deleted == false
     outputs:
       published: ${{ steps.verify.outputs.published }}
     steps:
@@ -26,6 +28,18 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
+          case "$GITHUB_REF" in
+          refs/heads/codex)
+            output_key=codex.output-tip
+            ;;
+          refs/heads/codex-unstable)
+            output_key=codex-unstable.output-tip
+            ;;
+          *)
+            printf 'unexpected release ref: %s\n' "$GITHUB_REF" >&2
+            exit 1
+            ;;
+          esac
 
           meta=$(gh api \
             "repos/$GITHUB_REPOSITORY/git/ref/heads/meta" \
@@ -34,7 +48,7 @@ jobs:
             "repos/$GITHUB_REPOSITORY/contents/codex.config?ref=$meta" \
             -H 'Accept: application/vnd.github.raw+json' |
             git config --no-includes --file /dev/stdin \
-              --get codex.output-tip)
+              --get "$output_key")
 
           if test "$GITHUB_SHA" = "$recorded"
           then

--- a/.github/workflows/codex-release.yml
+++ b/.github/workflows/codex-release.yml
@@ -117,7 +117,7 @@ jobs:
             file_pattern: PE32\+.*x86-64
             has_gcm: true
             sdk_arch: x86_64
-            sdk_flavor: minimal
+            sdk_flavor: full
             mingw_dir: mingw64
             mingit_arch: amd64
             mingit_filename: MinGit-2.55.0.2-64-bit.zip
@@ -267,7 +267,6 @@ jobs:
           MINGW_DIR: ${{ matrix.mingw_dir }}
         run: |
           set -euo pipefail
-          . /etc/profile
 
           make_args=(
             "prefix=/$MINGW_DIR"
@@ -294,7 +293,6 @@ jobs:
           set -euo pipefail
           if test "$TARGET_PLATFORM" = win32
           then
-            . /etc/profile
             test -f /tmp/build/git/cmd/git.exe
             test -f "/tmp/build/git/$MINGW_DIR/libexec/git-core/git-lfs.exe"
             test -d "/tmp/build/git/$MINGW_DIR/share/git-core/templates"
@@ -329,7 +327,6 @@ jobs:
 
           if test "$TARGET_PLATFORM" = win32
           then
-            . /etc/profile
             git_binary=/tmp/build/git/cmd/git.exe
             git_env=(
               "PATH=/tmp/build/git/cmd:/tmp/build/git/$MINGW_DIR/bin:/tmp/build/git/usr/bin:$PATH"
@@ -376,10 +373,6 @@ jobs:
           VERSION: ${{ needs.version.outputs.version }}
         run: |
           set -euo pipefail
-          if test "$TARGET_PLATFORM" = win32
-          then
-            . /etc/profile
-          fi
           script/package.sh
 
           for extension in tar.gz lzma
@@ -415,6 +408,15 @@ jobs:
           path: dugite-native/output/git-*
           if-no-files-found: error
           retention-days: 7
+
+      # The arm64 SDK puts its target Git first on PATH, but action cleanup
+      # runs on the x64 host and therefore needs the runner's native Git.
+      - name: Restore native Git for action cleanup
+        if: always() && matrix.target_platform == 'win32'
+        shell: pwsh
+        run: |
+          "C:\Program Files\Git\cmd" |
+            Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
   release:
     name: Publish GitHub prerelease

--- a/.github/workflows/codex-release.yml
+++ b/.github/workflows/codex-release.yml
@@ -99,7 +99,7 @@ jobs:
             asset_platform: windows
             arch: arm64
             binary: /tmp/build/git/clangarm64/bin/git.exe
-            file_pattern: PE32\+.*Aarch64
+            file_pattern: PE32\+.*ARM64
             has_gcm: true
             sdk_arch: aarch64
             sdk_flavor: full

--- a/.github/workflows/codex-release.yml
+++ b/.github/workflows/codex-release.yml
@@ -1,0 +1,461 @@
+name: Codex Git release
+
+on:
+  push:
+    branches:
+      - codex
+
+permissions:
+  contents: read
+
+concurrency:
+  group: codex-git-release-${{ github.sha }}
+  cancel-in-progress: false
+
+jobs:
+  version:
+    name: Determine version
+    runs-on: ubuntu-24.04
+    outputs:
+      describe: ${{ steps.version.outputs.describe }}
+      upstream_tag: ${{ steps.version.outputs.upstream_tag }}
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Derive OpenAI version from git describe
+        id: version
+        shell: bash
+        run: |
+          set -euo pipefail
+          describe="$(git describe \
+            --match 'v[0-9]*' \
+            --exclude 'v*-openai.*' \
+            --long \
+            --always \
+            --abbrev=12 \
+            "$GITHUB_SHA")"
+
+          if [[ "$describe" =~ ^(.+)-([0-9]+)-g([0-9a-f]+)$ ]]
+          then
+            upstream_tag="${BASH_REMATCH[1]}"
+            version="$upstream_tag-openai.${BASH_REMATCH[2]}.g${BASH_REMATCH[3]}"
+          else
+            upstream_tag=
+            version="openai-$describe"
+          fi
+          git check-ref-format "refs/tags/$version"
+          printf 'describe=%s\n' "$describe" | tee -a "$GITHUB_OUTPUT"
+          printf 'upstream_tag=%s\n' "$upstream_tag" | tee -a "$GITHUB_OUTPUT"
+          printf 'version=%s\n' "$version" | tee -a "$GITHUB_OUTPUT"
+
+  build:
+    name: ${{ matrix.name }}
+    needs: version
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: macOS arm64
+            os: macos-15
+            target_platform: macOS
+            asset_platform: macOS
+            arch: arm64
+            binary: /tmp/build/git/bin/git
+            file_pattern: Mach-O 64-bit executable arm64
+            has_gcm: true
+          - name: macOS x64
+            os: macos-15-intel
+            target_platform: macOS
+            asset_platform: macOS
+            arch: x64
+            binary: /tmp/build/git/bin/git
+            file_pattern: Mach-O 64-bit executable x86_64
+            has_gcm: true
+          - name: Linux arm64
+            os: ubuntu-22.04
+            target_platform: ubuntu
+            asset_platform: ubuntu
+            arch: arm64
+            binary: /tmp/build/git/bin/git
+            file_pattern: ELF 64-bit.*ARM aarch64
+            has_gcm: false
+          - name: Linux x64
+            os: ubuntu-22.04
+            target_platform: ubuntu
+            asset_platform: ubuntu
+            arch: x64
+            binary: /tmp/build/git/bin/git
+            file_pattern: ELF 64-bit.*x86-64
+            has_gcm: true
+          - name: Windows arm64
+            os: windows-2025
+            target_platform: win32
+            asset_platform: windows
+            arch: arm64
+            binary: /tmp/build/git/clangarm64/bin/git.exe
+            file_pattern: PE32\+.*Aarch64
+            has_gcm: true
+            sdk_arch: aarch64
+            sdk_flavor: full
+            mingw_dir: clangarm64
+            mingit_arch: arm64
+            mingit_filename: MinGit-2.55.0.2-arm64.zip
+            mingit_url: https://github.com/git-for-windows/git/releases/download/v2.55.0.windows.2/MinGit-2.55.0.2-arm64.zip
+            mingit_sha256: 0b2b81fdce284efd174cbb51b886ccea2fd271679c4b5c21f07d9e03bae51413
+          - name: Windows x64
+            os: windows-2025
+            target_platform: win32
+            asset_platform: windows
+            arch: x64
+            binary: /tmp/build/git/mingw64/bin/git.exe
+            file_pattern: PE32\+.*x86-64
+            has_gcm: true
+            sdk_arch: x86_64
+            sdk_flavor: minimal
+            mingw_dir: mingw64
+            mingit_arch: amd64
+            mingit_filename: MinGit-2.55.0.2-64-bit.zip
+            mingit_url: https://github.com/git-for-windows/git/releases/download/v2.55.0.windows.2/MinGit-2.55.0.2-64-bit.zip
+            mingit_sha256: e3ea2944cea4b3fabcd69c7c1669ef69b1b66c05ac7806d81224d0abad2dec31
+
+    steps:
+      # Keep the packaging contract, dependency pins, and platform build logic
+      # aligned with the artifacts already consumed by Codex and GitHub Desktop.
+      - name: Check out Dugite Native
+        uses: actions/checkout@v6
+        with:
+          repository: desktop/dugite-native
+          ref: f97e50add48cdcff053a69d95aa343a4a4a258c2
+          path: dugite-native
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Check out this Git revision
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.sha }}
+          path: dugite-native/git
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Give the source an immutable package version
+        shell: bash
+        working-directory: dugite-native/git
+        env:
+          VERSION: ${{ needs.version.outputs.version }}
+        run: |
+          git \
+            -c 'user.name=github-actions[bot]' \
+            -c 'user.email=41898282+github-actions[bot]@users.noreply.github.com' \
+            tag -a "$VERSION" -m "$VERSION"
+
+      # Match Dugite Native's compatibility choice for its macOS x64 build.
+      - name: Select Xcode 16.4
+        if: matrix.target_platform == 'macOS' && matrix.arch == 'x64'
+        run: |
+          sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer/
+          sudo rm -rf /Library/Developer/CommandLineTools
+
+      - name: Install Linux build dependencies
+        if: matrix.target_platform == 'ubuntu'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            autoconf \
+            automake \
+            build-essential \
+            ca-certificates \
+            curl \
+            gettext \
+            jq \
+            lsb-release \
+            pkg-config
+
+      - name: Install Linux x64 build dependencies
+        if: matrix.target_platform == 'ubuntu' && matrix.arch == 'x64'
+        run: |
+          sudo apt-get install -y \
+            libcurl4-gnutls-dev \
+            libexpat1-dev \
+            libssl-dev \
+            zlib1g-dev
+
+      - name: Install Linux arm64 build dependencies
+        if: matrix.target_platform == 'ubuntu' && matrix.arch == 'arm64'
+        run: |
+          sudo sed -i "s/^deb/deb [arch=amd64,i386]/g" /etc/apt/sources.list
+          release="$(lsb_release -s -c)"
+          echo "deb [arch=arm64,armhf] http://azure.ports.ubuntu.com/ ${release} main universe multiverse restricted" | sudo tee -a /etc/apt/sources.list
+          echo "deb [arch=arm64,armhf] http://azure.ports.ubuntu.com/ ${release}-updates main universe multiverse restricted" | sudo tee -a /etc/apt/sources.list
+          sudo dpkg --add-architecture arm64
+          sudo apt-get update
+          sudo apt-get install -y \
+            binutils-aarch64-linux-gnu \
+            gcc-aarch64-linux-gnu \
+            libcurl4-gnutls-dev:arm64 \
+            libexpat1-dev:arm64 \
+            libssl-dev:arm64 \
+            zlib1g-dev:arm64
+
+      # Dugite Native currently pins MinGit 2.53. Keep its build script and
+      # dependency schema, but match the runtime to the Git series we compile.
+      - name: Select the matching MinGit runtime
+        if: matrix.target_platform == 'win32'
+        shell: bash
+        working-directory: dugite-native
+        env:
+          MINGIT_ARCH: ${{ matrix.mingit_arch }}
+          MINGIT_FILENAME: ${{ matrix.mingit_filename }}
+          MINGIT_SHA256: ${{ matrix.mingit_sha256 }}
+          MINGIT_URL: ${{ matrix.mingit_url }}
+          MINGIT_VERSION: v2.55.0
+          SOURCE_UPSTREAM_TAG: ${{ needs.version.outputs.upstream_tag }}
+        run: |
+          set -euo pipefail
+          test "$SOURCE_UPSTREAM_TAG" = "$MINGIT_VERSION"
+          updated="$(mktemp)"
+          jq \
+            --arg arch "$MINGIT_ARCH" \
+            --arg checksum "$MINGIT_SHA256" \
+            --arg filename "$MINGIT_FILENAME" \
+            --arg url "$MINGIT_URL" \
+            --arg version "$MINGIT_VERSION" \
+            '.git.version = $version |
+             (.git.files[] |
+                select(.platform == "windows" and .arch == $arch)) |=
+               (.filename = $filename |
+                .url = $url |
+                .checksum = $checksum)' \
+            dependencies.json >"$updated"
+          mv "$updated" dependencies.json
+
+      - name: Set up Git for Windows SDK
+        if: matrix.target_platform == 'win32'
+        uses: git-for-windows/setup-git-for-windows-sdk@v2
+        with:
+          architecture: ${{ matrix.sdk_arch }}
+          flavor: ${{ matrix.sdk_flavor }}
+          cache: false
+
+      # Dugite cross-compiles several targets. Keep Git's optional Rust
+      # library disabled until its Makefile can direct Cargo at those targets.
+      - name: Build the Dugite Native distribution
+        shell: bash
+        working-directory: dugite-native
+        env:
+          NO_RUST: 1
+          TARGET_PLATFORM: ${{ matrix.target_platform }}
+          TARGET_ARCH: ${{ matrix.arch }}
+        run: |
+          set -euo pipefail
+          if test "$TARGET_PLATFORM" = win32
+          then
+            . /etc/profile
+          fi
+          script/build.sh
+
+      # Dugite Native compiles its Git submodule on macOS and Linux. On
+      # Windows it starts from MinGit, so replace MinGit's Git programs with
+      # the build from this repository while retaining the portable runtime.
+      - name: Install this Git build into the Windows distribution
+        if: matrix.target_platform == 'win32'
+        shell: bash
+        working-directory: dugite-native/git
+        env:
+          MINGW_DIR: ${{ matrix.mingw_dir }}
+        run: |
+          set -euo pipefail
+          . /etc/profile
+
+          make_args=(
+            "prefix=/$MINGW_DIR"
+            NO_PERL=YesPlease
+            NO_RUST=YesPlease
+            NO_TCLTK=YesPlease
+            NO_GETTEXT=YesPlease
+            NO_INSTALL_HARDLINKS=YesPlease
+            NO_CROSS_DIRECTORY_HARDLINKS=YesPlease
+          )
+          jobs="$(nproc)"
+          make -j"$jobs" "${make_args[@]}" all
+          make "${make_args[@]}" DESTDIR=/tmp/build/git strip install
+
+      - name: Verify distribution layout and provenance
+        shell: bash
+        env:
+          TARGET_PLATFORM: ${{ matrix.target_platform }}
+          MINGW_DIR: ${{ matrix.mingw_dir }}
+          GIT_BINARY: ${{ matrix.binary }}
+          FILE_PATTERN: ${{ matrix.file_pattern }}
+          HAS_GCM: ${{ matrix.has_gcm }}
+        run: |
+          set -euo pipefail
+          if test "$TARGET_PLATFORM" = win32
+          then
+            . /etc/profile
+            test -f /tmp/build/git/cmd/git.exe
+            test -f "/tmp/build/git/$MINGW_DIR/libexec/git-core/git-lfs.exe"
+            test -d "/tmp/build/git/$MINGW_DIR/share/git-core/templates"
+            if test "$HAS_GCM" = true
+            then
+              test -f "/tmp/build/git/$MINGW_DIR/bin/git-credential-manager.exe"
+            fi
+          else
+            test -x /tmp/build/git/libexec/git-core/git-lfs
+            test -d /tmp/build/git/share/git-core/templates
+            if test "$HAS_GCM" = true
+            then
+              test -x /tmp/build/git/libexec/git-core/git-credential-manager
+            fi
+          fi
+          test -f /tmp/build/git/etc/gitconfig
+
+          file "$GIT_BINARY" | tee /tmp/git-file-type
+          grep -E "$FILE_PATTERN" /tmp/git-file-type
+          strings "$GIT_BINARY" | grep -F "$GITHUB_SHA"
+
+      - name: Smoke-test the native x64 distribution
+        if: matrix.arch == 'x64'
+        shell: bash
+        env:
+          TARGET_PLATFORM: ${{ matrix.target_platform }}
+          MINGW_DIR: ${{ matrix.mingw_dir }}
+        run: |
+          set -euo pipefail
+          smoke=/tmp/codex-git-smoke
+          mkdir -p "$smoke/home"
+
+          if test "$TARGET_PLATFORM" = win32
+          then
+            . /etc/profile
+            git_binary=/tmp/build/git/cmd/git.exe
+            git_env=(
+              "PATH=/tmp/build/git/cmd:/tmp/build/git/$MINGW_DIR/bin:/tmp/build/git/usr/bin:$PATH"
+            )
+          else
+            git_binary=/tmp/build/git/bin/git
+            git_env=(
+              GIT_CONFIG_SYSTEM=/tmp/build/git/etc/gitconfig
+              GIT_EXEC_PATH=/tmp/build/git/libexec/git-core
+              GIT_TEMPLATE_DIR=/tmp/build/git/share/git-core/templates
+            )
+            if test "$TARGET_PLATFORM" = ubuntu
+            then
+              git_env+=(
+                GIT_SSL_CAINFO=/tmp/build/git/ssl/cacert.pem
+                PREFIX=/tmp/build/git
+              )
+            fi
+          fi
+          git_env+=("HOME=$smoke/home" GIT_TERMINAL_PROMPT=0)
+
+          build_options="$(env "${git_env[@]}" "$git_binary" --version --build-options)"
+          printf '%s\n' "$build_options"
+          grep -F "built from commit: $GITHUB_SHA" <<<"$build_options"
+          env "${git_env[@]}" "$git_binary" lfs version
+          env "${git_env[@]}" "$git_binary" credential-manager --version
+
+          env "${git_env[@]}" "$git_binary" init --quiet "$smoke/repo"
+          echo test >"$smoke/repo/file"
+          env "${git_env[@]}" "$git_binary" -C "$smoke/repo" add file
+          env "${git_env[@]}" "$git_binary" -C "$smoke/repo" \
+            -c user.name='Codex Git CI' \
+            -c user.email='codex-git-ci@openai.com' \
+            commit --quiet -m initial
+          test -z "$(env "${git_env[@]}" "$git_binary" -C "$smoke/repo" status --porcelain)"
+
+      - name: Package with Dugite Native
+        shell: bash
+        working-directory: dugite-native
+        env:
+          ASSET_PLATFORM: ${{ matrix.asset_platform }}
+          TARGET_PLATFORM: ${{ matrix.target_platform }}
+          TARGET_ARCH: ${{ matrix.arch }}
+          VERSION: ${{ needs.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          if test "$TARGET_PLATFORM" = win32
+          then
+            . /etc/profile
+          fi
+          script/package.sh
+
+          for extension in tar.gz lzma
+          do
+            matches=(
+              output/dugite-native-"$VERSION"-*-"$ASSET_PLATFORM"-"$TARGET_ARCH.$extension"
+            )
+            test "${#matches[@]}" -eq 1
+            test -f "${matches[0]}"
+
+            destination="output/git-$VERSION-$ASSET_PLATFORM-$TARGET_ARCH.$extension"
+            mv "${matches[0]}" "$destination"
+            mv "${matches[0]}.sha256" "$destination.sha256"
+          done
+
+          for checksum in output/*.sha256
+          do
+            archive="${checksum%.sha256}"
+            expected="$(tr -d '\r\n' <"$checksum")"
+            if command -v sha256sum >/dev/null 2>&1
+            then
+              actual="$(sha256sum "$archive" | awk '{print $1}')"
+            else
+              actual="$(shasum -a 256 "$archive" | awk '{print $1}')"
+            fi
+            test "$actual" = "$expected"
+          done
+
+      - name: Upload release assets
+        uses: actions/upload-artifact@v7
+        with:
+          name: git-${{ matrix.asset_platform }}-${{ matrix.arch }}
+          path: dugite-native/output/git-*
+          if-no-files-found: error
+          retention-days: 7
+
+  release:
+    name: Publish GitHub prerelease
+    needs:
+      - version
+      - build
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    steps:
+      - name: Download release assets
+        uses: actions/download-artifact@v8
+        with:
+          pattern: git-*
+          path: artifacts
+          merge-multiple: true
+
+      - name: Publish immutable prerelease
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SOURCE_DESCRIPTION: ${{ needs.version.outputs.describe }}
+          VERSION: ${{ needs.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          assets=(artifacts/git-*)
+
+          if gh release view "$VERSION" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1
+          then
+            gh release upload "$VERSION" "${assets[@]}" \
+              --repo "$GITHUB_REPOSITORY" \
+              --clobber
+          else
+            gh release create "$VERSION" "${assets[@]}" \
+              --repo "$GITHUB_REPOSITORY" \
+              --target "$GITHUB_SHA" \
+              --title "$VERSION" \
+              --notes "OpenAI Git release artifacts for $SOURCE_DESCRIPTION, built from $GITHUB_SHA for Codex." \
+              --prerelease
+          fi

--- a/.github/workflows/codex-release.yml
+++ b/.github/workflows/codex-release.yml
@@ -104,7 +104,7 @@ jobs:
     name: ${{ matrix.name }}
     needs: version
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 30
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -118,6 +118,8 @@ jobs:
             file_pattern: Mach-O 64-bit executable arm64
             has_gcm: false
             lto: thin
+            profile_format: LLVM
+            llvm_profdata: xcrun llvm-profdata
             max_tar_bytes: 67108864
           - name: macOS x64
             os: macos-15-intel
@@ -128,6 +130,8 @@ jobs:
             file_pattern: Mach-O 64-bit executable x86_64
             has_gcm: false
             lto: thin
+            profile_format: LLVM
+            llvm_profdata: xcrun llvm-profdata
             max_tar_bytes: 67108864
           # Keep arm64 builds native so release smoke tests can execute them.
           - name: Linux arm64
@@ -139,6 +143,7 @@ jobs:
             file_pattern: ELF 64-bit.*ARM aarch64
             has_gcm: false
             lto: auto
+            profile_format: GCC
             max_tar_bytes: 67108864
           - name: Linux x64
             os: ubuntu-22.04
@@ -149,6 +154,7 @@ jobs:
             file_pattern: ELF 64-bit.*x86-64
             has_gcm: false
             lto: auto
+            profile_format: GCC
             max_tar_bytes: 67108864
           - name: Windows arm64
             os: windows-11-arm
@@ -159,6 +165,8 @@ jobs:
             file_pattern: PE32\+.*ARM64
             has_gcm: true
             lto: thin
+            profile_format: LLVM
+            llvm_profdata: llvm-profdata
             max_tar_bytes: 134217728
             sdk_arch: aarch64
             sdk_flavor: full
@@ -176,6 +184,7 @@ jobs:
             file_pattern: PE32\+.*x86-64
             has_gcm: true
             lto: auto
+            profile_format: GCC
             max_tar_bytes: 134217728
             sdk_arch: x86_64
             sdk_flavor: full
@@ -309,14 +318,18 @@ jobs:
             dependencies.json >"$updated"
           mv "$updated" dependencies.json
 
-      # Dugite cross-compiles several targets. Keep Git's optional Rust
-      # library disabled until its Makefile can direct Cargo at those targets.
+      # Build an instrumented Git, run a representative local workload, then
+      # rebuild with its profile. Keep Git's optional Rust library disabled
+      # until its Makefile can direct Cargo at these targets.
       - name: Build the Dugite Native distribution
         shell: bash
         working-directory: dugite-native
         env:
           NO_RUST: 1
+          OPENAI_LLVM_PROFDATA: ${{ matrix.llvm_profdata }}
           OPENAI_LTO: ${{ matrix.lto }}
+          OPENAI_PROFILE: BUILD
+          OPENAI_PROFILE_FORMAT: ${{ matrix.profile_format }}
           TARGET_PLATFORM: ${{ matrix.target_platform }}
           TARGET_ARCH: ${{ matrix.arch }}
         run: |
@@ -342,7 +355,9 @@ jobs:
         working-directory: dugite-native/git
         env:
           MINGW_DIR: ${{ matrix.mingw_dir }}
+          OPENAI_LLVM_PROFDATA: ${{ matrix.llvm_profdata }}
           OPENAI_LTO: ${{ matrix.lto }}
+          OPENAI_PROFILE_FORMAT: ${{ matrix.profile_format }}
         run: |
           set -euo pipefail
 
@@ -357,8 +372,8 @@ jobs:
             SKIP_DASHED_BUILT_INS=YesPlease
           )
           jobs="${NUMBER_OF_PROCESSORS:-2}"
-          make -j"$jobs" "${make_args[@]}" all
-          make "${make_args[@]}" DESTDIR=/tmp/build/git strip install
+          make -j"$jobs" "${make_args[@]}" OPENAI_PROFILE=BUILD all
+          make "${make_args[@]}" OPENAI_PROFILE=USE DESTDIR=/tmp/build/git strip install
 
       - name: Verify distribution layout and provenance
         shell: bash
@@ -369,6 +384,7 @@ jobs:
           FILE_PATTERN: ${{ matrix.file_pattern }}
           HAS_GCM: ${{ matrix.has_gcm }}
           LTO: ${{ matrix.lto }}
+          PROFILE_FORMAT: ${{ matrix.profile_format }}
         run: |
           set -euo pipefail
           if test "$TARGET_PLATFORM" = win32
@@ -397,6 +413,12 @@ jobs:
           grep -E "$FILE_PATTERN" /tmp/git-file-type
           strings "$GIT_BINARY" | grep -F "$GITHUB_SHA"
           grep -F -- "-flto=$LTO" dugite-native/git/GIT-CFLAGS
+          if test "$PROFILE_FORMAT" = LLVM
+          then
+            grep -F -- "-fprofile-instr-use=" dugite-native/git/GIT-CFLAGS
+          else
+            grep -F -- "-fprofile-use=" dugite-native/git/GIT-CFLAGS
+          fi
 
       - name: Smoke-test the native distribution
         shell: bash

--- a/.github/workflows/codex-release.yml
+++ b/.github/workflows/codex-release.yml
@@ -523,10 +523,18 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           SOURCE_DESCRIPTION: ${{ needs.version.outputs.describe }}
+          SOURCE_REF: ${{ github.ref }}
           VERSION: ${{ needs.version.outputs.version }}
         run: |
           set -euo pipefail
           assets=(artifacts/git-*)
+          release_notes=$(
+            printf '%s\n' \
+              "source_ref=$SOURCE_REF" \
+              "source_sha=$GITHUB_SHA" \
+              "" \
+              "OpenAI Git release artifacts for $SOURCE_DESCRIPTION, built from $GITHUB_SHA for Codex."
+          )
 
           if gh release view "$VERSION" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1
           then
@@ -538,6 +546,6 @@ jobs:
               --repo "$GITHUB_REPOSITORY" \
               --target "$GITHUB_SHA" \
               --title "$VERSION" \
-              --notes "OpenAI Git release artifacts for $SOURCE_DESCRIPTION, built from $GITHUB_SHA for Codex." \
+              --notes "$release_notes" \
               --prerelease
           fi

--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -1,0 +1,243 @@
+name: Refresh codex
+
+on:
+  schedule:
+    - cron: '*/5 * * * *'
+  workflow_dispatch:
+    inputs:
+      operation:
+        description: Refresh, scan, remove, or reorder a pinned topic
+        type: choice
+        options:
+          - refresh
+          - scan
+          - remove
+          - reorder
+        default: refresh
+      lane:
+        description: codex or codex-unstable for a plan operation
+        required: false
+        type: string
+      topic:
+        description: Exact topic branch for a plan operation
+        required: false
+        type: string
+      after:
+        description: Existing topic or root for reorder
+        required: false
+        type: string
+      plan_branch:
+        description: Optional codex-plan/* branch name
+        required: false
+        type: string
+  pull_request_target:
+    branches:
+      - meta
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+
+permissions:
+  actions: read
+  contents: read
+  pull-requests: read
+
+jobs:
+  refresh:
+    if: >-
+      github.event_name == 'workflow_dispatch' &&
+      github.ref == 'refs/heads/codex' &&
+      inputs.operation == 'refresh'
+    uses: openai/git/.github/workflows/codex.yml@meta
+  topic_plan_scan:
+    name: Find one approved topic plan
+    if: >-
+      github.event_name == 'schedule' ||
+      (github.event_name == 'workflow_dispatch' &&
+       github.ref == 'refs/heads/codex' &&
+       inputs.operation == 'scan')
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      pull-requests: read
+    concurrency:
+      group: codex-topic-plan-scan
+      cancel-in-progress: false
+    outputs:
+      lane: ${{ steps.reviewed.outputs.lane }}
+      topic: ${{ steps.reviewed.outputs.topic }}
+      source_tip: ${{ steps.reviewed.outputs.source_tip }}
+      review_pr: ${{ steps.reviewed.outputs.review_pr }}
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Pin trusted meta
+        id: meta
+        run: |
+          set -euo pipefail
+          test "$GITHUB_REPOSITORY" = openai/git
+          test "$GITHUB_REF" = refs/heads/codex
+          sha=$(gh api "repos/$GITHUB_REPOSITORY/git/ref/heads/meta" \
+            --jq .object.sha)
+          case "$sha" in
+          ''|*[!0-9a-f]*) exit 1 ;;
+          esac
+          test "${#sha}" = 40
+          printf 'sha=%s\n' "$sha" >>"$GITHUB_OUTPUT"
+
+      - name: Check out trusted meta
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          repository: ${{ github.repository }}
+          ref: ${{ steps.meta.outputs.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Find one exact approved topic PR
+        id: reviewed
+        env:
+          META_SHA: ${{ steps.meta.outputs.sha }}
+        run: |
+          set -euo pipefail
+
+          die () {
+            printf '%s\n' "$*" >&2
+            exit 1
+          }
+
+          test "$GITHUB_REPOSITORY" = openai/git
+          test "$GITHUB_REF" = refs/heads/codex ||
+            die "topic scan must run from the trusted default branch"
+          test "$(git rev-parse HEAD)" = "$META_SHA" ||
+            die "trusted checkout does not match pinned meta"
+          gh auth setup-git
+          mkdir -p "$RUNNER_TEMP/codex-plan-scan"
+          for lane in codex codex-unstable
+          do
+            case "$lane" in
+            codex) plan=codex.plan ;;
+            codex-unstable) plan=codex-unstable.plan ;;
+            esac
+            test -f "$plan" ||
+              die "trusted meta has no $plan"
+            gh pr list --repo "$GITHUB_REPOSITORY" --state open \
+              --base "$lane" --limit 1000 \
+              --json number,isDraft,headRefName,headRefOid,headRepository,reviewDecision |
+              jq -r --arg lane "$lane" '
+                .[] |
+                select(.isDraft | not) |
+                select(.reviewDecision == "APPROVED") |
+                select(.headRepository.nameWithOwner == "openai/git") |
+                [$lane, .headRefName, .headRefOid,
+                 (.number | tostring)] | @tsv
+              '
+          done | sort -k4,4n >"$RUNNER_TEMP/codex-plan-scan/candidates"
+
+          while IFS=$'\t' read -r lane topic source_tip review_pr
+          do
+            test -n "$review_pr" || continue
+            case "$review_pr" in
+            *[!0-9]*) die "approved topic PR has invalid number '$review_pr'" ;;
+            esac
+            case "$source_tip" in
+            *[!0-9a-f]*|'') die "approved topic PR has invalid source SHA" ;;
+            esac
+            test "${#source_tip}" = 40 ||
+              die "approved topic PR has invalid source SHA"
+            git check-ref-format "refs/heads/$topic" >/dev/null 2>&1 ||
+              die "approved topic PR has invalid branch '$topic'"
+            case "$topic" in
+            ??/codex/*) ;;
+            *) continue ;;
+            esac
+            suffix=${topic#??/codex/}
+            case "$suffix" in
+            ''|*/*|*-wip|*-stale) continue ;;
+            esac
+            case "$lane" in
+            codex)
+              case "$topic" in
+              *-unstable) continue ;;
+              esac
+              plan=codex.plan
+              ;;
+            codex-unstable)
+              case "$topic" in
+              *-unstable) ;;
+              *) continue ;;
+              esac
+              plan=codex-unstable.plan
+              ;;
+            *) die "approved topic PR has invalid lane '$lane'" ;;
+            esac
+            pinned=$(git config --no-includes \
+              --file "$plan" \
+              --get "branch.$topic.source-tip" || :)
+            test "$pinned" = "$source_tip" && continue
+            short=$(printf '%.12s' "$source_tip")
+            slug=${topic##*/}
+            plan_branch=codex-plan/$lane-$slug-$short
+            pending=$(gh pr list --repo "$GITHUB_REPOSITORY" \
+              --state open --base meta --head "$plan_branch" \
+              --json number --jq '.[0].number // empty') ||
+              die "could not inspect pending Codex plan PR"
+            test -n "$pending" && continue
+            if ! sh .github/workflows/codex-branch.sh propose-plan \
+              --remote origin --lane "$lane" --topic "$topic" \
+              --action auto --source-tip "$source_tip" \
+              --review-pr "$review_pr" --expected-meta "$META_SHA" \
+              --no-push >/dev/null
+            then
+              printf 'skipping approved topic PR #%s: preflight failed\n' \
+                "$review_pr" >&2
+              continue
+            fi
+            {
+              printf 'lane=%s\n' "$lane"
+              printf 'topic=%s\n' "$topic"
+              printf 'source_tip=%s\n' "$source_tip"
+              printf 'review_pr=%s\n' "$review_pr"
+            } >>"$GITHUB_OUTPUT"
+            exit 0
+          done <"$RUNNER_TEMP/codex-plan-scan/candidates"
+  topic_plan_propose:
+    name: Propose reviewed topic plan
+    needs: topic_plan_scan
+    if: needs.topic_plan_scan.outputs.review_pr != ''
+    permissions:
+      contents: read
+      pull-requests: read
+    uses: openai/git/.github/workflows/codex-plan-propose.yml@meta
+    with:
+      lane: ${{ needs.topic_plan_scan.outputs.lane }}
+      topic: ${{ needs.topic_plan_scan.outputs.topic }}
+      action: auto
+      source_tip: ${{ needs.topic_plan_scan.outputs.source_tip }}
+      review_pr: ${{ needs.topic_plan_scan.outputs.review_pr }}
+  policy_plan_propose:
+    name: Propose explicit plan policy
+    if: >-
+      github.event_name == 'workflow_dispatch' &&
+      github.ref == 'refs/heads/codex' &&
+      (inputs.operation == 'remove' || inputs.operation == 'reorder')
+    permissions:
+      contents: read
+      pull-requests: read
+    uses: openai/git/.github/workflows/codex-plan-propose.yml@meta
+    with:
+      lane: ${{ inputs.lane }}
+      topic: ${{ inputs.topic }}
+      action: ${{ inputs.operation }}
+      after: ${{ inputs.after }}
+      plan_branch: ${{ inputs.plan_branch }}
+  plan_admission:
+    name: Codex plan admission
+    if: >-
+      github.event_name == 'pull_request_target' &&
+      github.event.pull_request.base.ref == 'meta'
+    permissions:
+      contents: read
+      pull-requests: write
+    uses: openai/git/.github/workflows/codex-plan-admission.yml@meta

--- a/Documentation/config/fetch.adoc
+++ b/Documentation/config/fetch.adoc
@@ -94,6 +94,16 @@ A value of 0 will give some reasonable default. If unset, it defaults to 1.
 For submodules, this setting can be overridden using the `submodule.fetchJobs`
 config setting.
 
+`fetch.packfileUriJobs`::
+	Specifies the maximum number of packfile URI downloads and indexers
+	to run at once. The default is 1, which preserves advertised URI
+	order.
++
+Values greater than 1 are used only when the server advertises and the
+client requests the `no-ref-delta` promise. Each URI pack is then checked
+with `index-pack --no-ref-delta` before it is accepted.
+Responses with one URI retain the serial path.
+
 `fetch.writeCommitGraph`::
 	Set to true to write a commit-graph after every `git fetch` command
 	that downloads a pack-file from a remote. Using the `--split` option,

--- a/Documentation/config/uploadpack.adoc
+++ b/Documentation/config/uploadpack.adoc
@@ -86,3 +86,14 @@ uploadpack.allowRefInWant::
 	is intended for the benefit of load-balanced servers which may
 	not have the same view of what OIDs their refs point to due to
 	replication delay.
+
+uploadpack.allowNoRefDelta::
+	If this option is set, `upload-pack` may advertise the
+	`no-ref-delta` feature of the protocol version 2 `fetch`
+	command. When a client requests the feature, `upload-pack` passes
+	`--no-ref-delta` to `pack-objects` for the inline pack and promises
+	that every pack named in a `packfile-uris` response section also
+	contains no `REF_DELTA` entries. `upload-pack` does not inspect
+	configured URI packs, so the server administrator must create each
+	pack with `pack-objects --no-ref-delta` or otherwise verify this
+	property. The default is `false`.

--- a/Documentation/git-index-pack.adoc
+++ b/Documentation/git-index-pack.adoc
@@ -9,8 +9,10 @@ git-index-pack - Build pack index file for an existing packed archive
 SYNOPSIS
 --------
 [verse]
-'git index-pack' [-v] [-o <index-file>] [--[no-]rev-index] <pack-file>
-'git index-pack' --stdin [--fix-thin] [--keep] [-v] [-o <index-file>]
+'git index-pack' [-v] [-o <index-file>] [--no-ref-delta]
+		[--[no-]rev-index] <pack-file>
+'git index-pack' --stdin [--fix-thin] [--keep] [--no-ref-delta]
+		[-v] [-o <index-file>]
 		  [--[no-]rev-index] [<pack-file>]
 
 
@@ -59,6 +61,11 @@ OPTIONS
 	linkgit:git-pack-objects[1] for details) by adding the
 	excluded objects the deltified objects are based on to the
 	pack. This option only makes sense in conjunction with --stdin.
+
+--no-ref-delta::
+	Reject a pack containing a `REF_DELTA` entry. `OFS_DELTA` entries
+	are accepted. This option can be used to verify a protocol promise
+	that a pack contains no `REF_DELTA` entries.
 
 --keep::
 	Before moving the index into its final destination

--- a/Documentation/git-index-pack.adoc
+++ b/Documentation/git-index-pack.adoc
@@ -107,9 +107,11 @@ default and "Indexing objects" when `--stdin` is specified.
 --fsck-objects[=<msg-id>=<severity>...]::
 	Die if the pack contains broken objects, but unlike `--strict`, don't
 	choke on broken links. If the pack contains a tree pointing to a
-	.gitmodules blob that does not exist, prints the hash of that blob
-	(for the caller to check) after the hash that goes into the name of the
-	pack/idx file (see "Notes").
+	.gitmodules or .gitattributes blob that does not exist, prints a record
+	for that blob (for the caller to check) after the hash that goes into
+	the name of the pack/idx file (see "Notes"). The record for a
+	.gitmodules blob is its hash. The record for a .gitattributes blob is
+	`gitattributes` followed by a space and its hash.
 +
 An optional comma-separated list of `<msg-id>=<severity>` can be passed to
 change the severity of some possible issues, e.g.,

--- a/Documentation/git-pack-objects.adoc
+++ b/Documentation/git-pack-objects.adoc
@@ -10,7 +10,8 @@ SYNOPSIS
 --------
 [verse]
 'git pack-objects' [-q | --progress | --all-progress] [--all-progress-implied]
-		   [--no-reuse-delta] [--delta-base-offset] [--non-empty]
+		   [--no-reuse-delta] [--delta-base-offset] [--no-ref-delta]
+		   [--non-empty]
 		   [--local] [--incremental] [--window=<n>] [--depth=<n>]
 		   [--revs [--unpacked | --all]] [--keep-pack=<pack-name>]
 		   [--cruft] [--cruft-expiration=<time>]
@@ -296,6 +297,11 @@ Note: Porcelain commands such as `git gc` (see linkgit:git-gc[1]),
 `git repack` (see linkgit:git-repack[1]) pass this option by default
 in modern Git when they put objects in your repository into pack files.
 So does `git bundle` (see linkgit:git-bundle[1]) when it creates a bundle.
+
+--no-ref-delta::
+	Do not emit deltas which represent their base by their literal
+	object ID. This is independent of `--delta-base-offset`;
+	without that option, no deltas are emitted.
 
 --threads=<n>::
 	Specifies the number of threads to spawn when searching for best

--- a/Documentation/gitprotocol-capabilities.adoc
+++ b/Documentation/gitprotocol-capabilities.adoc
@@ -34,9 +34,9 @@ were sent.  Server MUST NOT ignore capabilities that client requested
 and server advertised.  As a consequence of these rules, server MUST
 NOT advertise capabilities it does not understand.
 
-The 'atomic', 'report-status', 'report-status-v2', 'delete-refs', 'quiet',
-and 'push-cert' capabilities are sent and recognized by the receive-pack
-(push to server) process.
+The 'atomic', 'report-status', 'report-status-v2', 'delete-refs',
+'no-ref-delta', 'quiet', and 'push-cert' capabilities are sent and
+recognized by the receive-pack (push to server) process.
 
 The 'ofs-delta' and 'side-band-64k' capabilities are sent and recognized
 by both upload-pack and receive-pack protocols.  The 'agent' and 'session-id'
@@ -173,6 +173,17 @@ ofs-delta
 The server can send, and the client can understand, PACKv2 with delta referring to
 its base by position in pack rather than by an obj-id.  That is, they can
 send/read OBJ_OFS_DELTA (aka type 6) in a packfile.
+
+no-ref-delta
+------------
+
+The receive-pack server can request, and the client can send, PACKv2
+without deltas referring to their bases by an obj-id. That is, the
+client MUST NOT send OBJ_REF_DELTA (aka type 7) in a packfile when the
+server advertises this capability.
+
+This does not imply that the server understands OBJ_OFS_DELTA entries;
+that is negotiated separately with the 'ofs-delta' capability.
 
 agent
 -----

--- a/Documentation/gitprotocol-capabilities.adoc
+++ b/Documentation/gitprotocol-capabilities.adoc
@@ -185,6 +185,10 @@ server advertises this capability.
 This does not imply that the server understands OBJ_OFS_DELTA entries;
 that is negotiated separately with the 'ofs-delta' capability.
 
+Protocol v2 `fetch` uses the same name for the corresponding
+upload-pack request. There, the promise covers both the inline pack and
+any packs named by a `packfile-uris` section.
+
 agent
 -----
 

--- a/Documentation/gitprotocol-v2.adoc
+++ b/Documentation/gitprotocol-v2.adoc
@@ -376,6 +376,18 @@ to the server.
 	client should download from all given URIs. Currently, the
 	protocols supported are "http" and "https".
 
+If the 'no-ref-delta' feature is advertised, the following argument can
+be included in the client's request:
+
+    no-ref-delta
+	Indicates that the server MUST NOT include a `REF_DELTA` entry in
+	the inline `packfile` section or any pack named by a
+	`packfile-uris` section.
++
+`no-ref-delta` does not imply `ofs-delta`. The server may use `OFS_DELTA`
+only when the client also requests `ofs-delta`. By definition, an
+`OFS_DELTA` refers to an earlier entry in the same pack.
+
 If the 'wait-for-done' feature is advertised, the following argument
 can be included in the client's request.
 

--- a/Documentation/technical/packfile-uri.adoc
+++ b/Documentation/technical/packfile-uri.adoc
@@ -25,6 +25,13 @@ Clients should then download and index all the given URIs (in addition to
 downloading and indexing the packfile given in the `packfile` section of the
 response) before performing the connectivity check.
 
+URI packs are normally indexed in advertised order, since a later pack may
+contain a `REF_DELTA` whose base is installed by an earlier response pack.
+If the server advertises `no-ref-delta` and the client requests it, the
+promise covers the inline pack and every URI pack. A client may then index
+URI packs concurrently, while rejecting any pack that contains a
+`REF_DELTA`.
+
 Server design
 -------------
 

--- a/builtin/index-pack.c
+++ b/builtin/index-pack.c
@@ -33,7 +33,7 @@
 #include "strvec.h"
 
 static const char index_pack_usage[] =
-"git index-pack [-v] [-o <index-file>] [--keep | --keep=<msg>] [--[no-]rev-index] [--verify] [--strict[=<msg-id>=<severity>...]] [--fsck-objects[=<msg-id>=<severity>...]] (<pack-file> | --stdin [--fix-thin] [<pack-file>])";
+"git index-pack [-v] [-o <index-file>] [--keep | --keep=<msg>] [--[no-]rev-index] [--verify] [--strict[=<msg-id>=<severity>...]] [--fsck-objects[=<msg-id>=<severity>...]] [--no-ref-delta] (<pack-file> | --stdin [--fix-thin] [<pack-file>])";
 
 struct object_entry {
 	struct pack_idx_entry idx;
@@ -138,6 +138,7 @@ static int strict;
 static int do_fsck_object;
 static struct fsck_options fsck_options;
 static int verbose;
+static int no_ref_delta;
 static const char *progress_title;
 static int show_resolving_progress;
 static int show_stat;
@@ -550,6 +551,9 @@ static void *unpack_raw_entry(struct object_entry *obj,
 
 	switch (obj->type) {
 	case OBJ_REF_DELTA:
+		if (no_ref_delta)
+			bad_object(obj->idx.offset,
+				   _("REF_DELTA not allowed by --no-ref-delta"));
 		oidread(ref_oid, fill(the_hash_algo->rawsz),
 			the_repository->hash_algo);
 		use(the_hash_algo->rawsz);
@@ -1937,6 +1941,8 @@ int cmd_index_pack(int argc,
 				from_stdin = 1;
 			} else if (!strcmp(arg, "--fix-thin")) {
 				fix_thin_pack = 1;
+			} else if (!strcmp(arg, "--no-ref-delta")) {
+				no_ref_delta = 1;
 			} else if (skip_to_optional_arg(arg, "--strict", &arg)) {
 				strict = 1;
 				do_fsck_object = 1;

--- a/builtin/index-pack.c
+++ b/builtin/index-pack.c
@@ -1919,7 +1919,8 @@ int cmd_index_pack(int argc,
 
 	disable_replace_refs();
 
-	fsck_options_init(&fsck_options, the_repository, FSCK_OPTIONS_MISSING_GITMODULES);
+	fsck_options_init(&fsck_options, the_repository,
+			  FSCK_OPTIONS_MISSING_GITMODULES_AND_GITATTRIBUTES);
 	fsck_options.walk = mark_link;
 
 	reset_pack_idx_option(&opts);

--- a/builtin/pack-objects.c
+++ b/builtin/pack-objects.c
@@ -2208,6 +2208,13 @@ static int can_reuse_delta(const struct object_id *base_oid,
 	 */
 	base = packlist_find(&to_pack, base_oid);
 	if (base) {
+		/*
+		 * A preferred base is omitted from the resulting pack, so it
+		 * can only be referenced by object ID.
+		 */
+		if (base->preferred_base && !allow_ref_delta)
+			return 0;
+
 		if (!in_same_island(&delta->idx.oid, &base->idx.oid))
 			return 0;
 		*base_out = base;
@@ -2219,7 +2226,8 @@ static int can_reuse_delta(const struct object_id *base_oid,
 	 * even if it was buried too deep in history to make it into the
 	 * packing list.
 	 */
-	if (thin && bitmap_has_oid_in_uninteresting(bitmap_git, base_oid)) {
+	if (allow_ref_delta && thin &&
+	    bitmap_has_oid_in_uninteresting(bitmap_git, base_oid)) {
 		if (use_delta_islands) {
 			if (!in_same_island(&delta->idx.oid, base_oid))
 				return 0;
@@ -4716,7 +4724,7 @@ static int pack_options_allow_reuse(void)
 	       !ignore_packed_keep_on_disk &&
 	       !ignore_packed_keep_in_core &&
 	       (!local || !have_non_local_packs) &&
-	       !incremental && allow_ref_delta;
+	       !incremental && (allow_ref_delta || allow_ofs_delta);
 }
 
 static int get_object_list_from_bitmap(struct rev_info *revs)
@@ -4738,7 +4746,8 @@ static int get_object_list_from_bitmap(struct rev_info *revs)
 						   &reuse_packfiles,
 						   &reuse_packfiles_nr,
 						   &reuse_packfile_bitmap,
-						   allow_pack_reuse == MULTI_PACK_REUSE);
+						   allow_pack_reuse == MULTI_PACK_REUSE,
+						   allow_ref_delta);
 
 	if (reuse_packfiles) {
 		reuse_packfile_objects = bitmap_popcount(reuse_packfile_bitmap);
@@ -5369,7 +5378,7 @@ int cmd_pack_objects(int argc,
 	if (unpack_unreachable || keep_unreachable || pack_loose_unreachable)
 		use_internal_rev_list = 1;
 
-	if (!reuse_object || !allow_ref_delta)
+	if (!reuse_object || (!allow_ref_delta && !allow_ofs_delta))
 		reuse_delta = 0;
 	if (cfg->pack_compression_level == -1)
 		cfg->pack_compression_level = Z_DEFAULT_COMPRESSION;

--- a/builtin/pack-objects.c
+++ b/builtin/pack-objects.c
@@ -1338,6 +1338,7 @@ static void write_pack_file(void)
 	uint32_t nr_remaining = nr_result;
 	time_t last_mtime = 0;
 	struct object_entry **write_order;
+	off_t bytes_written = 0;
 
 	if (progress > pack_to_stdout)
 		progress_state = start_progress(the_repository,
@@ -1391,6 +1392,8 @@ static void write_pack_file(void)
 		}
 
 		if (pack_to_stdout) {
+			bytes_written += hashfile_total(f) +
+				the_repository->hash_algo->rawsz;
 			/*
 			 * We never fsync when writing to stdout since we may
 			 * not be writing to an actual pack file. For instance,
@@ -1511,6 +1514,9 @@ static void write_pack_file(void)
 		    written, nr_result);
 	trace2_data_intmax("pack-objects", the_repository,
 			   "write_pack_file/wrote", nr_result);
+	if (pack_to_stdout)
+		trace2_data_intmax("pack-objects", the_repository,
+				   "written/bytes", bytes_written);
 }
 
 static int no_try_delta(const char *path)

--- a/builtin/pack-objects.c
+++ b/builtin/pack-objects.c
@@ -1391,9 +1391,10 @@ static void write_pack_file(void)
 			display_progress(progress_state, written);
 		}
 
+		/* Every finalization path appends the pack checksum. */
+		bytes_written += hashfile_total(f) +
+			the_repository->hash_algo->rawsz;
 		if (pack_to_stdout) {
-			bytes_written += hashfile_total(f) +
-				the_repository->hash_algo->rawsz;
 			/*
 			 * We never fsync when writing to stdout since we may
 			 * not be writing to an actual pack file. For instance,
@@ -1514,9 +1515,8 @@ static void write_pack_file(void)
 		    written, nr_result);
 	trace2_data_intmax("pack-objects", the_repository,
 			   "write_pack_file/wrote", nr_result);
-	if (pack_to_stdout)
-		trace2_data_intmax("pack-objects", the_repository,
-				   "written/bytes", bytes_written);
+	trace2_data_intmax("pack-objects", the_repository,
+			   "write_pack_file/wrote_bytes", bytes_written);
 }
 
 static int no_try_delta(const char *path)

--- a/builtin/pack-objects.c
+++ b/builtin/pack-objects.c
@@ -1349,6 +1349,7 @@ static void write_pack_file(void)
 	do {
 		unsigned char hash[GIT_MAX_RAWSZ];
 		char *pack_tmp_name = NULL;
+		off_t pack_bytes;
 
 		if (pack_to_stdout) {
 			/*
@@ -1391,8 +1392,7 @@ static void write_pack_file(void)
 			display_progress(progress_state, written);
 		}
 
-		/* Every finalization path appends the pack checksum. */
-		bytes_written += hashfile_total(f) +
+		pack_bytes = hashfile_total(f) +
 			the_repository->hash_algo->rawsz;
 		if (pack_to_stdout) {
 			/*
@@ -1424,6 +1424,7 @@ static void write_pack_file(void)
 				write_bitmap_index = 0;
 			}
 		}
+		bytes_written += pack_bytes;
 
 		if (!pack_to_stdout) {
 			struct stat st;

--- a/builtin/pack-objects.c
+++ b/builtin/pack-objects.c
@@ -191,7 +191,8 @@ static inline void oe_set_delta_size(struct packing_data *pack,
 
 static const char *const pack_usage[] = {
 	N_("git pack-objects [-q | --progress | --all-progress] [--all-progress-implied]\n"
-	   "                 [--no-reuse-delta] [--delta-base-offset] [--non-empty]\n"
+	   "                 [--no-reuse-delta] [--delta-base-offset] [--no-ref-delta]\n"
+	   "                 [--non-empty]\n"
 	   "                 [--local] [--incremental] [--window=<n>] [--depth=<n>]\n"
 	   "                 [--revs [--unpacked | --all]] [--keep-pack=<pack-name>]\n"
 	   "                 [--cruft] [--cruft-expiration=<time>]\n"
@@ -222,6 +223,7 @@ static int ignore_packed_keep_in_core;
 static int ignore_packed_keep_in_core_open;
 static int ignore_packed_keep_in_core_has_cruft;
 static int allow_ofs_delta;
+static int allow_ref_delta = 1;
 static struct pack_idx_option pack_idx_opts;
 static const char *base_name;
 static int progress = 1;
@@ -3405,6 +3407,9 @@ static int should_attempt_deltas(struct object_entry *entry)
 	if (entry->no_try_delta)
 		return 0;
 
+	if (entry->preferred_base && !allow_ref_delta)
+		return 0;
+
 	if (!entry->preferred_base) {
 		if (oe_type(entry) < 0)
 			die(_("unable to get type of object %s"),
@@ -3647,7 +3652,8 @@ static void prepare_pack(int window, int depth)
 	if (!pack_to_stdout)
 		do_check_packed_object_crc = 1;
 
-	if (!to_pack.nr_objects || !window || !depth)
+	if (!to_pack.nr_objects || !window || !depth ||
+	    (!allow_ref_delta && !allow_ofs_delta))
 		return;
 
 	if (path_walk)
@@ -4710,7 +4716,7 @@ static int pack_options_allow_reuse(void)
 	       !ignore_packed_keep_on_disk &&
 	       !ignore_packed_keep_in_core &&
 	       (!local || !have_non_local_packs) &&
-	       !incremental;
+	       !incremental && allow_ref_delta;
 }
 
 static int get_object_list_from_bitmap(struct rev_info *revs)
@@ -5163,6 +5169,8 @@ int cmd_pack_objects(int argc,
 			 N_("reuse existing objects")),
 		OPT_BOOL(0, "delta-base-offset", &allow_ofs_delta,
 			 N_("use OFS_DELTA objects")),
+		OPT_BOOL(0, "ref-delta", &allow_ref_delta,
+			 N_("use REF_DELTA objects")),
 		OPT_INTEGER(0, "threads", &delta_search_threads,
 			    N_("use threads when searching for best delta matches")),
 		OPT_BOOL(0, "non-empty", &non_empty,
@@ -5361,7 +5369,7 @@ int cmd_pack_objects(int argc,
 	if (unpack_unreachable || keep_unreachable || pack_loose_unreachable)
 		use_internal_rev_list = 1;
 
-	if (!reuse_object)
+	if (!reuse_object || !allow_ref_delta)
 		reuse_delta = 0;
 	if (cfg->pack_compression_level == -1)
 		cfg->pack_compression_level = Z_DEFAULT_COMPRESSION;

--- a/builtin/receive-pack.c
+++ b/builtin/receive-pack.c
@@ -65,6 +65,7 @@ static struct strbuf fsck_msg_types = STRBUF_INIT;
 static int receive_unpack_limit = -1;
 static int transfer_unpack_limit = -1;
 static int advertise_atomic_push = 1;
+static int advertise_no_ref_delta;
 static int advertise_push_options;
 static int advertise_sid;
 static int unpack_limit = 100;
@@ -287,6 +288,8 @@ static void show_ref(const char *path, const struct object_id *oid)
 			strbuf_addstr(&cap, " atomic");
 		if (prefer_ofs_delta)
 			strbuf_addstr(&cap, " ofs-delta");
+		if (advertise_no_ref_delta)
+			strbuf_addstr(&cap, " no-ref-delta");
 		if (push_cert_nonce)
 			strbuf_addf(&cap, " push-cert=%s", push_cert_nonce);
 		if (advertise_push_options)
@@ -2629,6 +2632,8 @@ int cmd_receive_pack(int argc,
 		OPT_HIDDEN_BOOL(0, "http-backend-info-refs", &advertise_refs, NULL),
 		OPT_ALIAS(0, "advertise-refs", "http-backend-info-refs"),
 		OPT_HIDDEN_BOOL(0, "reject-thin-pack-for-testing", &reject_thin, NULL),
+		OPT_HIDDEN_BOOL(0, "advertise-no-ref-delta-for-testing",
+				&advertise_no_ref_delta, NULL),
 		OPT_END()
 	};
 

--- a/config.mak.openai
+++ b/config.mak.openai
@@ -1,0 +1,10 @@
+# OpenAI release build settings.
+#
+# The Codex release workflow copies this file to config.mak before
+# building. Keep release-only optimizations here instead of in the
+# upstream Makefile.
+
+ifdef OPENAI_LTO
+CFLAGS_APPEND += -flto=$(OPENAI_LTO)
+LDFLAGS_APPEND += -flto=$(OPENAI_LTO)
+endif

--- a/config.mak.openai
+++ b/config.mak.openai
@@ -4,7 +4,71 @@
 # building. Keep release-only optimizations here instead of in the
 # upstream Makefile.
 
+OPENAI_PROFILE_DIR := $(CURDIR)
+OPENAI_PROFILE_RAW := $(OPENAI_PROFILE_DIR)/default_%m_%p.profraw
+OPENAI_PROFILE_DATA := $(OPENAI_PROFILE_DIR)/default.profdata
+OPENAI_PROFILE_TRAINING ?= .github/workflows/codex-pgo-training.sh
+OPENAI_LLVM_PROFDATA ?= llvm-profdata
+
 ifdef OPENAI_LTO
 CFLAGS_APPEND += -flto=$(OPENAI_LTO)
 LDFLAGS_APPEND += -flto=$(OPENAI_LTO)
 endif
+
+ifeq ("$(OPENAI_PROFILE_FORMAT)","LLVM")
+ifeq ("$(OPENAI_PROFILE)","GEN")
+	BASIC_CFLAGS += -fprofile-instr-generate=$(OPENAI_PROFILE_RAW)
+	BASIC_CFLAGS += -DNO_NORETURN=1
+	export CCACHE_DISABLE = t
+	V = 1
+else
+ifneq ("$(OPENAI_PROFILE)","")
+	BASIC_CFLAGS += -fprofile-instr-use=$(OPENAI_PROFILE_DATA)
+	BASIC_CFLAGS += -Wno-profile-instr-unprofiled -DNO_NORETURN=1
+	export CCACHE_DISABLE = t
+	V = 1
+endif
+endif
+else
+ifeq ("$(OPENAI_PROFILE)","GEN")
+	BASIC_CFLAGS += -fprofile-generate=$(OPENAI_PROFILE_DIR)
+	BASIC_CFLAGS += -DNO_NORETURN=1
+	EXTLIBS += -lgcov
+	export CCACHE_DISABLE = t
+	V = 1
+else
+ifneq ("$(OPENAI_PROFILE)","")
+	BASIC_CFLAGS += -fprofile-use=$(OPENAI_PROFILE_DIR)
+	BASIC_CFLAGS += -fprofile-correction -DNO_NORETURN=1
+	export CCACHE_DISABLE = t
+	V = 1
+endif
+endif
+endif
+
+# Every C object already waits for Git's forced GIT-CFLAGS target. Gate that
+# target so "make strip install" finishes PGO before its normal prerequisites
+# can start compiling with profile-use flags.
+ifeq "$(OPENAI_PROFILE)" "BUILD"
+GIT-CFLAGS: openai-profile
+endif
+
+openai-profile: profile-clean openai-profile-clean
+	$(MAKE) OPENAI_PROFILE=GEN all
+	$(SHELL_PATH) $(OPENAI_PROFILE_TRAINING)
+	$(MAKE) OPENAI_PROFILE= openai-profile-merge
+	$(MAKE) OPENAI_PROFILE=USE all
+
+openai-profile-merge:
+ifeq ("$(OPENAI_PROFILE_FORMAT)","LLVM")
+	$(OPENAI_LLVM_PROFDATA) merge \
+		-output=$(OPENAI_PROFILE_DATA) \
+		$(OPENAI_PROFILE_DIR)/*.profraw
+endif
+
+clean: openai-profile-clean
+
+openai-profile-clean:
+	$(RM) $(OPENAI_PROFILE_DIR)/*.profraw $(OPENAI_PROFILE_DATA)
+
+.PHONY: openai-profile openai-profile-merge openai-profile-clean

--- a/fetch-pack.c
+++ b/fetch-pack.c
@@ -923,24 +923,29 @@ static void create_promisor_file(const char *keep_name,
 	strbuf_release(&promisor_name);
 }
 
-static void parse_gitmodules_oids(int fd, struct oidset *gitmodules_oids)
+static void parse_deferred_fsck_oids(int fd, struct fsck_options *options)
 {
-	int len = the_hash_algo->hexsz + 1; /* hash + NL */
+	struct strbuf line = STRBUF_INIT;
 
-	do {
-		char hex_hash[GIT_MAX_HEXSZ + 1];
-		int read_len = read_in_full(fd, hex_hash, len);
+	while (1) {
 		struct object_id oid;
-		const char *end;
+		const char *end, *hex;
+		struct oidset *found = &options->gitmodules_found;
+		int ret = strbuf_getwholeline_fd(&line, fd, '\n');
 
-		if (!read_len)
-			return;
-		if (read_len != len)
-			die("invalid length read %d", read_len);
-		if (parse_oid_hex(hex_hash, &oid, &end) || *end != '\n')
+		if (ret == EOF) {
+			if (!line.len)
+				break;
+			die("invalid fsck object ID");
+		}
+		hex = line.buf;
+		if (skip_prefix(hex, "gitattributes ", &hex))
+			found = &options->gitattributes_found;
+		if (parse_oid_hex(hex, &oid, &end) || *end != '\n')
 			die("invalid hash");
-		oidset_insert(gitmodules_oids, &oid);
-	} while (1);
+		oidset_insert(found, &oid);
+	}
+	strbuf_release(&line);
 }
 
 static void add_index_pack_keep_option(struct strvec *args)
@@ -963,7 +968,7 @@ static int get_pack(struct fetch_pack_args *args,
 		    struct strvec *index_pack_args,
 		    int no_ref_delta,
 		    struct ref **sought, int nr_sought,
-		    struct oidset *gitmodules_oids)
+		    struct fsck_options *fsck_options)
 {
 	struct async demux;
 	int do_keep = args->keep_pack;
@@ -1091,7 +1096,7 @@ static int get_pack(struct fetch_pack_args *args,
 			string_list_append_nodup(pack_lockfiles, pack_lockfile);
 		else
 			free(pack_lockfile);
-		parse_gitmodules_oids(cmd.out, gitmodules_oids);
+		parse_deferred_fsck_oids(cmd.out, fsck_options);
 		close(cmd.out);
 	}
 
@@ -1269,9 +1274,10 @@ static struct ref *do_fetch_pack(struct fetch_pack_args *args,
 	} else
 		alternate_shallow_file = NULL;
 
-	fsck_options_init(&fsck_options, the_repository, FSCK_OPTIONS_MISSING_GITMODULES);
+	fsck_options_init(&fsck_options, the_repository,
+			  FSCK_OPTIONS_MISSING_GITMODULES_AND_GITATTRIBUTES);
 	if (get_pack(args, fd, pack_lockfiles, NULL, 0, sought, nr_sought,
-		     &fsck_options.gitmodules_found))
+		     &fsck_options))
 		die(_("git fetch-pack: fetch failed."));
 	if (fsck_finish(&fsck_options))
 		die("fsck failed");
@@ -1743,7 +1749,7 @@ static void start_packfile_uri_task(
 }
 
 static void finish_packfile_uri_task(struct packfile_uri_task *task,
-				     struct oidset *gitmodules_oids)
+				     struct fsck_options *fsck_options)
 {
 	char packhash[GIT_MAX_HEXSZ + 1];
 	struct object_id oid;
@@ -1759,7 +1765,7 @@ static void finish_packfile_uri_task(struct packfile_uri_task *task,
 	if (get_oid_hex(packhash, &oid))
 		die("fetch-pack: expected hash then LF in http-fetch output");
 
-	parse_gitmodules_oids(task->cmd.out, gitmodules_oids);
+	parse_deferred_fsck_oids(task->cmd.out, fsck_options);
 	close(task->cmd.out);
 	task->cmd.out = -1;
 
@@ -1772,7 +1778,7 @@ static void finish_packfile_uri_task(struct packfile_uri_task *task,
 
 static void fetch_packfile_uris_parallel(
 	struct string_list *uris, struct strvec *index_pack_args,
-	struct string_list *pack_lockfiles, struct oidset *gitmodules_oids)
+	struct string_list *pack_lockfiles, struct fsck_options *fsck_options)
 {
 	size_t task_nr = uris->nr;
 	struct packfile_uri_task *tasks;
@@ -1813,7 +1819,7 @@ static void fetch_packfile_uris_parallel(
 		if (ready == task_nr)
 			BUG("poll returned without a ready http-fetch");
 
-		finish_packfile_uri_task(&tasks[ready], gitmodules_oids);
+		finish_packfile_uri_task(&tasks[ready], fsck_options);
 		if (next < uris->nr) {
 			start_packfile_uri_task(&tasks[ready],
 						uris->items[next].string,
@@ -1872,7 +1878,8 @@ static struct ref *do_fetch_pack_v2(struct fetch_pack_args *args,
 	struct strvec index_pack_args = STRVEC_INIT;
 	const char *promisor_remote_config;
 
-	fsck_options_init(&fsck_options, the_repository, FSCK_OPTIONS_MISSING_GITMODULES);
+	fsck_options_init(&fsck_options, the_repository,
+			  FSCK_OPTIONS_MISSING_GITMODULES_AND_GITATTRIBUTES);
 
 	if (server_feature_v2("promisor-remote", &promisor_remote_config))
 		promisor_remote_reply(promisor_remote_config, NULL);
@@ -2020,7 +2027,7 @@ static struct ref *do_fetch_pack_v2(struct fetch_pack_args *args,
 			if (get_pack(args, fd, pack_lockfiles,
 				     packfile_uris.nr ? &index_pack_args : NULL,
 				     no_ref_delta,
-				     sought, nr_sought, &fsck_options.gitmodules_found))
+				     sought, nr_sought, &fsck_options))
 				die(_("git fetch-pack: fetch failed."));
 			do_check_stateless_delimiter(args->stateless_rpc, &reader);
 
@@ -2044,7 +2051,7 @@ static struct ref *do_fetch_pack_v2(struct fetch_pack_args *args,
 		strvec_push(&index_pack_args, "--threads=1");
 		fetch_packfile_uris_parallel(&packfile_uris, &index_pack_args,
 					    pack_lockfiles,
-					    &fsck_options.gitmodules_found);
+					    &fsck_options);
 		goto packfile_uris_done;
 	}
 
@@ -2081,7 +2088,7 @@ static struct ref *do_fetch_pack_v2(struct fetch_pack_args *args,
 			die("fetch-pack: expected hash then LF in http-fetch output");
 		packhash[the_hash_algo->hexsz] = '\0';
 
-		parse_gitmodules_oids(cmd.out, &fsck_options.gitmodules_found);
+		parse_deferred_fsck_oids(cmd.out, &fsck_options);
 
 		close(cmd.out);
 

--- a/fetch-pack.c
+++ b/fetch-pack.c
@@ -49,6 +49,7 @@ static int fetch_fsck_objects = -1;
 static int transfer_fsck_objects = -1;
 static int agent_supported;
 static int server_supports_filtering;
+static int fetch_packfile_uri_jobs = 1;
 static struct shallow_lock shallow_lock;
 static const char *alternate_shallow_file;
 static struct strbuf fsck_msg_types = STRBUF_INIT;
@@ -960,6 +961,7 @@ static void add_index_pack_keep_option(struct strvec *args)
 static int get_pack(struct fetch_pack_args *args,
 		    int xd[2], struct string_list *pack_lockfiles,
 		    struct strvec *index_pack_args,
+		    int no_ref_delta,
 		    struct ref **sought, int nr_sought,
 		    struct oidset *gitmodules_oids)
 {
@@ -988,7 +990,8 @@ static int get_pack(struct fetch_pack_args *args,
 	else
 		demux.out = xd[0];
 
-	if (!args->keep_pack && unpack_limit && !index_pack_args) {
+	if (!args->keep_pack && unpack_limit && !index_pack_args &&
+	    !no_ref_delta) {
 
 		if (read_pack_header(demux.out, &header))
 			die(_("protocol error: bad pack header"));
@@ -1006,12 +1009,15 @@ static int get_pack(struct fetch_pack_args *args,
 
 	fsck_objects = fetch_pack_fsck_objects();
 
-	if (do_keep || args->from_promisor || index_pack_args || fsck_objects) {
+	if (do_keep || args->from_promisor || index_pack_args ||
+	    no_ref_delta || fsck_objects) {
 		if (pack_lockfiles || fsck_objects)
 			cmd.out = -1;
 		cmd_name = "index-pack";
 		strvec_push(&cmd.args, cmd_name);
 		strvec_push(&cmd.args, "--stdin");
+		if (no_ref_delta)
+			strvec_push(&cmd.args, "--no-ref-delta");
 		if (!args->quiet && !args->no_progress)
 			strvec_push(&cmd.args, "-v");
 		if (args->use_thin_pack)
@@ -1264,7 +1270,7 @@ static struct ref *do_fetch_pack(struct fetch_pack_args *args,
 		alternate_shallow_file = NULL;
 
 	fsck_options_init(&fsck_options, the_repository, FSCK_OPTIONS_MISSING_GITMODULES);
-	if (get_pack(args, fd, pack_lockfiles, NULL, sought, nr_sought,
+	if (get_pack(args, fd, pack_lockfiles, NULL, 0, sought, nr_sought,
 		     &fsck_options.gitmodules_found))
 		die(_("git fetch-pack: fetch failed."));
 	if (fsck_finish(&fsck_options))
@@ -1380,7 +1386,8 @@ static int send_fetch_request(struct fetch_negotiator *negotiator, int fd_out,
 			      const struct ref *wants, struct oidset *common,
 			      int *haves_to_send, int *in_vain,
 			      int sideband_all, int seen_ack,
-			      struct oidset *negotiation_include_oids)
+			      struct oidset *negotiation_include_oids,
+			      int *no_ref_delta)
 {
 	int haves_added;
 	int done_sent = 0;
@@ -1425,6 +1432,12 @@ static int send_fetch_request(struct fetch_negotiator *negotiator, int fd_out,
 		if (to_send.len) {
 			packet_buf_write(&req_buf, "packfile-uris %s",
 					 to_send.buf);
+			if (fetch_packfile_uri_jobs > 1 &&
+			    server_supports_feature(
+				    "fetch", "no-ref-delta", 0)) {
+				packet_buf_write(&req_buf, "no-ref-delta");
+				*no_ref_delta = 1;
+			}
 			strbuf_release(&to_send);
 		}
 	}
@@ -1643,14 +1656,176 @@ static void receive_packfile_uris(struct packet_reader *reader,
 {
 	process_section_header(reader, "packfile-uris", 0);
 	while (packet_reader_read(reader) == PACKET_READ_NORMAL) {
-		if (reader->pktlen < the_hash_algo->hexsz ||
-		    reader->line[the_hash_algo->hexsz] != ' ')
+		struct object_id oid;
+		const char *end;
+
+		if (parse_oid_hex(reader->line, &oid, &end) || *end != ' ')
 			die("expected '<hash> <uri>', got: %s", reader->line);
 
 		string_list_append(uris, reader->line);
 	}
 	if (reader->status != PACKET_READ_DELIM)
 		die("expected DELIM");
+}
+
+static int index_pack_arg_is_keep(const char *arg)
+{
+	const char *suffix;
+
+	return skip_prefix(arg, "--keep", &suffix) &&
+		(!*suffix || *suffix == '=');
+}
+
+static int index_pack_args_have_keep(struct strvec *index_pack_args)
+{
+	for (size_t i = 0; i < index_pack_args->nr; i++)
+		if (index_pack_arg_is_keep(index_pack_args->v[i]))
+			return 1;
+
+	return 0;
+}
+
+static void precreate_packfile_uri_keep(const struct object_id *oid,
+					struct string_list *pack_lockfiles)
+{
+	struct strbuf keep = STRBUF_INIT;
+	int keep_fd;
+
+	odb_pack_name(the_repository, &keep, oid->hash, "keep");
+	keep_fd = safe_create_file_with_leading_directories(the_repository,
+							    keep.buf);
+	if (keep_fd < 0) {
+		if (errno != EEXIST)
+			die_errno("fetch-pack: unable to create URI keep");
+		strbuf_release(&keep);
+		return;
+	}
+	string_list_append_nodup(pack_lockfiles,
+				 strbuf_detach(&keep, NULL));
+	if (close(keep_fd))
+		die_errno("fetch-pack: unable to close URI keep");
+}
+
+struct packfile_uri_task {
+	struct child_process cmd;
+	struct object_id oid;
+	const char *uri;
+};
+
+static void start_packfile_uri_task(
+	struct packfile_uri_task *task, const char *entry,
+	struct strvec *index_pack_args, struct string_list *pack_lockfiles,
+	int precreate_keeps)
+{
+	if (parse_oid_hex(entry, &task->oid, &task->uri) ||
+	    *task->uri++ != ' ')
+		BUG("invalid packfile URI entry");
+	if (precreate_keeps)
+		precreate_packfile_uri_keep(&task->oid, pack_lockfiles);
+
+	child_process_init(&task->cmd);
+	strvec_push(&task->cmd.args, "http-fetch");
+	strvec_pushf(&task->cmd.args, "--packfile=%s",
+		     oid_to_hex(&task->oid));
+	for (size_t i = 0; i < index_pack_args->nr; i++) {
+		if (index_pack_arg_is_keep(index_pack_args->v[i]))
+			continue;
+		strvec_pushf(&task->cmd.args, "--index-pack-arg=%s",
+			     index_pack_args->v[i]);
+	}
+	strvec_push(&task->cmd.args, task->uri);
+	task->cmd.git_cmd = 1;
+	task->cmd.no_stdin = 1;
+	task->cmd.clean_on_exit = 1;
+	task->cmd.out = -1;
+	if (start_command(&task->cmd))
+		die("fetch-pack: unable to spawn http-fetch");
+}
+
+static void finish_packfile_uri_task(struct packfile_uri_task *task,
+				     struct oidset *gitmodules_oids)
+{
+	char packhash[GIT_MAX_HEXSZ + 1];
+	struct object_id oid;
+
+	if (read_in_full(task->cmd.out, packhash, 5) != 5 ||
+	    memcmp(packhash, "pack\t", 5))
+		die("fetch-pack: expected pack then TAB at start of http-fetch output");
+	if (read_in_full(task->cmd.out, packhash,
+			 the_hash_algo->hexsz + 1) != the_hash_algo->hexsz + 1 ||
+	    packhash[the_hash_algo->hexsz] != '\n')
+		die("fetch-pack: expected hash then LF in http-fetch output");
+	packhash[the_hash_algo->hexsz] = '\0';
+	if (get_oid_hex(packhash, &oid))
+		die("fetch-pack: expected hash then LF in http-fetch output");
+
+	parse_gitmodules_oids(task->cmd.out, gitmodules_oids);
+	close(task->cmd.out);
+	task->cmd.out = -1;
+
+	if (finish_command(&task->cmd))
+		die("fetch-pack: unable to finish http-fetch");
+	if (!oideq(&task->oid, &oid))
+		die("fetch-pack: pack downloaded from %s does not match expected hash %s",
+		    task->uri, oid_to_hex(&task->oid));
+}
+
+static void fetch_packfile_uris_parallel(
+	struct string_list *uris, struct strvec *index_pack_args,
+	struct string_list *pack_lockfiles, struct oidset *gitmodules_oids)
+{
+	size_t task_nr = uris->nr;
+	struct packfile_uri_task *tasks;
+	struct pollfd *pollfds;
+	int precreate_keeps = index_pack_args_have_keep(index_pack_args);
+	size_t next = 0, running = 0;
+
+	if (task_nr > (size_t)fetch_packfile_uri_jobs)
+		task_nr = fetch_packfile_uri_jobs;
+	CALLOC_ARRAY(tasks, task_nr);
+	CALLOC_ARRAY(pollfds, task_nr);
+
+	for (; next < task_nr; next++)
+		start_packfile_uri_task(&tasks[next],
+					uris->items[next].string, index_pack_args,
+					pack_lockfiles, precreate_keeps);
+	running = next;
+
+	while (running) {
+		size_t ready = task_nr;
+		int ret;
+
+		for (size_t i = 0; i < task_nr; i++) {
+			pollfds[i].fd = tasks[i].cmd.out;
+			pollfds[i].events = POLLIN | POLLHUP;
+		}
+		do
+			ret = poll(pollfds, task_nr, -1);
+		while (ret < 0 && errno == EINTR);
+		if (ret < 0)
+			die_errno("fetch-pack: unable to poll http-fetch");
+		for (size_t i = 0; i < task_nr; i++) {
+			if (pollfds[i].revents) {
+				ready = i;
+				break;
+			}
+		}
+		if (ready == task_nr)
+			BUG("poll returned without a ready http-fetch");
+
+		finish_packfile_uri_task(&tasks[ready], gitmodules_oids);
+		if (next < uris->nr) {
+			start_packfile_uri_task(&tasks[ready],
+						uris->items[next].string,
+						index_pack_args, pack_lockfiles,
+						precreate_keeps);
+			next++;
+		} else
+			running--;
+	}
+
+	free(pollfds);
+	free(tasks);
 }
 
 enum fetch_state {
@@ -1691,8 +1866,9 @@ static struct ref *do_fetch_pack_v2(struct fetch_pack_args *args,
 	int seen_ack = 0;
 	struct object_id common_oid;
 	int received_ready = 0;
+	int no_ref_delta = 0;
 	struct string_list packfile_uris = STRING_LIST_INIT_DUP;
-	int i;
+	int parallel_uri_indexing;
 	struct strvec index_pack_args = STRVEC_INIT;
 	const char *promisor_remote_config;
 
@@ -1777,7 +1953,8 @@ static struct ref *do_fetch_pack_v2(struct fetch_pack_args *args,
 					       &haves_to_send, &in_vain,
 					       reader.use_sideband,
 					       seen_ack,
-					       &negotiation_include_oids)) {
+					       &negotiation_include_oids,
+					       &no_ref_delta)) {
 				trace2_region_leave_printf("negotiation_v2", "round",
 							   the_repository, "%d",
 							   negotiation_round);
@@ -1842,6 +2019,7 @@ static struct ref *do_fetch_pack_v2(struct fetch_pack_args *args,
 
 			if (get_pack(args, fd, pack_lockfiles,
 				     packfile_uris.nr ? &index_pack_args : NULL,
+				     no_ref_delta,
 				     sought, nr_sought, &fsck_options.gitmodules_found))
 				die(_("git fetch-pack: fetch failed."));
 			do_check_stateless_delimiter(args->stateless_rpc, &reader);
@@ -1853,9 +2031,25 @@ static struct ref *do_fetch_pack_v2(struct fetch_pack_args *args,
 		}
 	}
 
-	for (i = 0; i < packfile_uris.nr; i++) {
+	parallel_uri_indexing = no_ref_delta &&
+		pack_lockfiles &&
+		fetch_packfile_uri_jobs > 1 &&
+		packfile_uris.nr > 1;
+	if (parallel_uri_indexing) {
+		/*
+		 * Bound total indexer threads by the number of URI jobs. The
+		 * URI packs are independent, so each indexer can stay single
+		 * threaded while several indexers run at once.
+		 */
+		strvec_push(&index_pack_args, "--threads=1");
+		fetch_packfile_uris_parallel(&packfile_uris, &index_pack_args,
+					    pack_lockfiles,
+					    &fsck_options.gitmodules_found);
+		goto packfile_uris_done;
+	}
+
+	for (size_t i = 0; i < packfile_uris.nr; i++) {
 		bool created_keep;
-		int j;
 		struct child_process cmd = CHILD_PROCESS_INIT;
 		char packhash[GIT_MAX_HEXSZ + 1];
 		const char *uri = packfile_uris.items[i].string +
@@ -1865,7 +2059,7 @@ static struct ref *do_fetch_pack_v2(struct fetch_pack_args *args,
 		strvec_pushf(&cmd.args, "--packfile=%.*s",
 			     (int) the_hash_algo->hexsz,
 			     packfile_uris.items[i].string);
-		for (j = 0; j < index_pack_args.nr; j++)
+		for (size_t j = 0; j < index_pack_args.nr; j++)
 			strvec_pushf(&cmd.args, "--index-pack-arg=%s",
 				     index_pack_args.v[j]);
 		strvec_push(&cmd.args, uri);
@@ -1906,6 +2100,8 @@ static struct ref *do_fetch_pack_v2(struct fetch_pack_args *args,
 							 repo_get_object_directory(the_repository),
 							 packhash));
 	}
+
+packfile_uris_done:
 	string_list_clear(&packfile_uris, 0);
 	strvec_clear(&index_pack_args);
 
@@ -1956,6 +2152,12 @@ static int fetch_pack_config_cb(const char *var, const char *value,
 				const struct config_context *ctx, void *cb)
 {
 	int ret = fetch_pack_fsck_config(var, value, &fsck_msg_types);
+
+	if (!strcmp(var, "fetch.packfileurijobs")) {
+		fetch_packfile_uri_jobs = git_config_int(var, value, ctx->kvi);
+		return 0;
+	}
+
 	if (ret > 0)
 		return git_default_config(var, value, ctx, cb);
 

--- a/fsck.c
+++ b/fsck.c
@@ -1399,13 +1399,14 @@ void fsck_options_init(struct fsck_options *options,
 			.gitattributes_done = OIDSET_INIT,
 			.error_func = fsck_objects_error_function,
 		},
-		[FSCK_OPTIONS_MISSING_GITMODULES] = {
+		[FSCK_OPTIONS_MISSING_GITMODULES_AND_GITATTRIBUTES] = {
 			.strict = 1,
 			.gitmodules_found = OIDSET_INIT,
 			.gitmodules_done = OIDSET_INIT,
 			.gitattributes_found = OIDSET_INIT,
 			.gitattributes_done = OIDSET_INIT,
-			.error_func = fsck_objects_error_cb_print_missing_gitmodules,
+			.error_func =
+				fsck_objects_error_cb_print_missing_gitmodules_and_gitattributes,
 		},
 		[FSCK_OPTIONS_REFS] = {
 			.error_func = fsck_refs_error_function,
@@ -1415,7 +1416,7 @@ void fsck_options_init(struct fsck_options *options,
 	switch (type) {
 	case FSCK_OPTIONS_DEFAULT:
 	case FSCK_OPTIONS_STRICT:
-	case FSCK_OPTIONS_MISSING_GITMODULES:
+	case FSCK_OPTIONS_MISSING_GITMODULES_AND_GITATTRIBUTES:
 	case FSCK_OPTIONS_REFS:
 		memcpy(options, &defaults[type], sizeof(*options));
 		break;
@@ -1472,15 +1473,19 @@ int git_fsck_config(const char *var, const char *value,
  * Custom error callbacks that are used in more than one place.
  */
 
-int fsck_objects_error_cb_print_missing_gitmodules(struct fsck_options *o,
-						   void *fsck_report,
-						   enum fsck_msg_type msg_type,
-						   enum fsck_msg_id msg_id,
-						   const char *message)
+int fsck_objects_error_cb_print_missing_gitmodules_and_gitattributes(
+	struct fsck_options *o, void *fsck_report,
+	enum fsck_msg_type msg_type, enum fsck_msg_id msg_id,
+	const char *message)
 {
+	struct fsck_object_report *report = fsck_report;
+
 	if (msg_id == FSCK_MSG_GITMODULES_MISSING) {
-		struct fsck_object_report *report = fsck_report;
 		puts(oid_to_hex(report->oid));
+		return 0;
+	}
+	if (msg_id == FSCK_MSG_GITATTRIBUTES_MISSING) {
+		printf("gitattributes %s\n", oid_to_hex(report->oid));
 		return 0;
 	}
 	return fsck_objects_error_function(o, fsck_report,

--- a/fsck.h
+++ b/fsck.h
@@ -145,11 +145,10 @@ int fsck_objects_error_function(struct fsck_options *o,
 				void *fsck_report,
 				enum fsck_msg_type msg_type, enum fsck_msg_id msg_id,
 				const char *message);
-int fsck_objects_error_cb_print_missing_gitmodules(struct fsck_options *o,
-						   void *fsck_report,
-						   enum fsck_msg_type msg_type,
-						   enum fsck_msg_id msg_id,
-						   const char *message);
+int fsck_objects_error_cb_print_missing_gitmodules_and_gitattributes(
+	struct fsck_options *o, void *fsck_report,
+	enum fsck_msg_type msg_type, enum fsck_msg_id msg_id,
+	const char *message);
 
 int fsck_refs_error_function(struct fsck_options *options,
 			     void *fsck_report,
@@ -233,7 +232,7 @@ bool fsck_has_queued_checks(struct fsck_options *options);
 enum fsck_options_type {
 	FSCK_OPTIONS_DEFAULT,
 	FSCK_OPTIONS_STRICT,
-	FSCK_OPTIONS_MISSING_GITMODULES,
+	FSCK_OPTIONS_MISSING_GITMODULES_AND_GITATTRIBUTES,
 	FSCK_OPTIONS_REFS,
 };
 

--- a/http.c
+++ b/http.c
@@ -2700,6 +2700,7 @@ int finish_http_pack_request(struct http_pack_request *preq)
 
 	ip.git_cmd = 1;
 	ip.in = tmpfile_fd;
+	ip.clean_on_exit = 1;
 	strvec_pushv(&ip.args, preq->index_pack_args ?
 		     preq->index_pack_args :
 		     default_index_pack_args);

--- a/odb/source-files.c
+++ b/odb/source-files.c
@@ -693,7 +693,8 @@ int odb_source_files_optimize(struct odb_source *source,
 		pack_geometry_init(&geometry, &existing_packs, &po_args);
 		pack_geometry_split(&geometry);
 
-		if (geometry.split < geometry.pack_nr) {
+		if (geometry.split < geometry.pack_nr ||
+		    geometry.promisor_split < geometry.promisor_pack_nr) {
 			strvec_pushf(&repack_cmd.args, "--geometric=%d",
 				     geometry.split_factor);
 		} else {

--- a/odb/source-files.c
+++ b/odb/source-files.c
@@ -559,7 +559,7 @@ bool odb_source_files_optimize_required(struct odb_source *source,
 		 * When we'd merge at least two packs with one another we always
 		 * perform the repack.
 		 */
-		if (geometry.split) {
+		if (geometry.split || geometry.promisor_split) {
 			ret = true;
 			goto out;
 		}

--- a/pack-bitmap.c
+++ b/pack-bitmap.c
@@ -2286,7 +2286,8 @@ static int try_partial_reuse(struct bitmap_index *bitmap_git,
 			     uint32_t pack_pos,
 			     off_t offset,
 			     struct bitmap *reuse,
-			     struct pack_window **w_curs)
+			     struct pack_window **w_curs,
+			     int allow_ref_delta)
 {
 	off_t delta_obj_offset;
 	enum object_type type;
@@ -2304,6 +2305,9 @@ static int try_partial_reuse(struct bitmap_index *bitmap_git,
 		off_t base_offset;
 		uint32_t base_pos;
 		uint32_t base_bitmap_pos;
+
+		if (type == OBJ_REF_DELTA && !allow_ref_delta)
+			return 0;
 
 		/*
 		 * Find the position of the base object so we can look it up
@@ -2377,20 +2381,19 @@ static int try_partial_reuse(struct bitmap_index *bitmap_git,
 
 static void reuse_partial_packfile_from_bitmap_1(struct bitmap_index *bitmap_git,
 						 struct bitmapped_pack *pack,
-						 struct bitmap *reuse)
+						 struct bitmap *reuse,
+						 int allow_ref_delta)
 {
 	struct bitmap *result = bitmap_git->result;
 	struct pack_window *w_curs = NULL;
 	size_t pos = pack->bitmap_pos / BITS_IN_EWORD;
 
-	if (!pack->bitmap_pos) {
+	if (allow_ref_delta && !pack->bitmap_pos) {
 		/*
 		 * If we're processing the first (in the case of a MIDX, the
 		 * preferred pack) or the only (in the case of single-pack
-		 * bitmaps) pack, then we can reuse whole words at a time.
-		 *
-		 * This is because we know that any deltas in this range *must*
-		 * have their bases chosen from the same pack, since:
+		 * bitmaps) pack, then any delta in this range must have its
+		 * base chosen from the same pack:
 		 *
 		 * - In the single pack case, there is no other pack to choose
 		 *   them from.
@@ -2399,6 +2402,10 @@ static void reuse_partial_packfile_from_bitmap_1(struct bitmap_index *bitmap_git
 		 *   all ties are broken in favor of that pack (i.e. the one
 		 *   we're currently processing). So any duplicate bases will be
 		 *   resolved in favor of the pack we're processing.
+		 *
+		 * When REF_DELTAs are allowed, we can therefore reuse whole
+		 * words at a time without inspecting object headers. Otherwise,
+		 * inspect each object below to avoid reusing a REF_DELTA entry.
 		 */
 		while (pos < result->word_alloc &&
 		       pos < pack->bitmap_nr / BITS_IN_EWORD &&
@@ -2448,7 +2455,8 @@ static void reuse_partial_packfile_from_bitmap_1(struct bitmap_index *bitmap_git
 			}
 
 			if (try_partial_reuse(bitmap_git, pack, bit_pos,
-					      pack_pos, ofs, reuse, &w_curs) < 0) {
+					      pack_pos, ofs, reuse, &w_curs,
+					      allow_ref_delta) < 0) {
 				/*
 				 * try_partial_reuse indicated we couldn't reuse
 				 * any bits, so there is no point in trying more
@@ -2483,7 +2491,8 @@ void reuse_partial_packfile_from_bitmap(struct bitmap_index *bitmap_git,
 					struct bitmapped_pack **packs_out,
 					size_t *packs_nr_out,
 					struct bitmap **reuse_out,
-					int multi_pack_reuse)
+					int multi_pack_reuse,
+					int allow_ref_delta)
 {
 	struct repository *r = bitmap_repo(bitmap_git);
 	struct bitmapped_pack *packs = NULL;
@@ -2578,7 +2587,8 @@ void reuse_partial_packfile_from_bitmap(struct bitmap_index *bitmap_git,
 	reuse = bitmap_word_alloc(word_alloc);
 
 	for (i = 0; i < packs_nr; i++)
-		reuse_partial_packfile_from_bitmap_1(bitmap_git, &packs[i], reuse);
+		reuse_partial_packfile_from_bitmap_1(bitmap_git, &packs[i], reuse,
+						     allow_ref_delta);
 
 	if (bitmap_is_empty(reuse)) {
 		free(packs);

--- a/pack-bitmap.h
+++ b/pack-bitmap.h
@@ -122,7 +122,8 @@ void reuse_partial_packfile_from_bitmap(struct bitmap_index *bitmap_git,
 					struct bitmapped_pack **packs_out,
 					size_t *packs_nr_out,
 					struct bitmap **reuse_out,
-					int multi_pack_reuse);
+					int multi_pack_reuse,
+					int allow_ref_delta);
 int rebuild_existing_bitmaps(struct bitmap_index *, struct packing_data *mapping,
 			     kh_oid_map_t *reused_bitmaps, int show_progress);
 void free_bitmap_index(struct bitmap_index *);

--- a/send-pack.c
+++ b/send-pack.c
@@ -80,6 +80,8 @@ static int pack_objects(struct repository *r,
 		strvec_push(&po.args, "--thin");
 	if (args->use_ofs_delta)
 		strvec_push(&po.args, "--delta-base-offset");
+	if (args->no_ref_delta)
+		strvec_push(&po.args, "--no-ref-delta");
 	if (args->quiet || !args->progress)
 		strvec_push(&po.args, "-q");
 	if (args->progress)
@@ -570,6 +572,8 @@ int send_pack(struct repository *r,
 		allow_deleting_refs = 1;
 	if (server_supports("ofs-delta"))
 		args->use_ofs_delta = 1;
+	if (server_supports("no-ref-delta"))
+		args->no_ref_delta = 1;
 	if (server_supports("side-band-64k"))
 		use_sideband = 1;
 	if (server_supports("quiet"))

--- a/send-pack.h
+++ b/send-pack.h
@@ -28,6 +28,7 @@ struct send_pack_args {
 		force_update:1,
 		use_thin_pack:1,
 		use_ofs_delta:1,
+		no_ref_delta:1,
 		dry_run:1,
 		/* One of the SEND_PACK_PUSH_CERT_* constants. */
 		push_cert:2,

--- a/t/helper/test-pack-deltas.c
+++ b/t/helper/test-pack-deltas.c
@@ -7,6 +7,7 @@
 #include "hash.h"
 #include "hex.h"
 #include "pack.h"
+#include "packfile.h"
 #include "pack-objects.h"
 #include "parse-options.h"
 #include "setup.h"
@@ -15,6 +16,7 @@
 
 static const char *usage_str[] = {
 	"test-tool pack-deltas --num-objects <num-objects>",
+	"test-tool pack-deltas --list-deltas <pack>.idx",
 	NULL
 };
 
@@ -81,18 +83,85 @@ static void write_ref_delta(struct hashfile *f,
 	free(delta_buf);
 }
 
+static int list_delta(const struct object_id *oid,
+		      struct packed_git *p,
+		      uint32_t pos,
+		      void *_w_curs)
+{
+	struct pack_window **w_curs = _w_curs;
+	off_t obj_offset = nth_packed_object_offset(p, pos);
+	off_t cur = obj_offset;
+	size_t size;
+	enum object_type type = unpack_object_header(p, w_curs, &cur,
+						      &size);
+
+	if (type < 0)
+		die("unable to parse object at position %"PRIu32, pos);
+	if (type != OBJ_REF_DELTA && type != OBJ_OFS_DELTA)
+		return 0;
+
+	if (type == OBJ_REF_DELTA) {
+		struct object_id base_oid;
+		const unsigned char *base = use_pack(p, w_curs, cur,
+						     NULL);
+
+		oidread(&base_oid, base, p->repo->hash_algo);
+		printf("%s REF_DELTA %s\n", oid_to_hex(oid),
+		       oid_to_hex(&base_oid));
+	} else {
+		off_t base_offset = get_delta_base(p, w_curs, &cur,
+						   type, obj_offset);
+
+		if (!base_offset)
+			die("unable to read base of object %s", oid_to_hex(oid));
+		printf("%s OFS_DELTA %"PRIuMAX"\n", oid_to_hex(oid),
+		       (uintmax_t)base_offset);
+	}
+
+	return 0;
+}
+
+static void list_deltas(const char *idx_name)
+{
+	struct packed_git *p;
+	struct pack_window *w_curs = NULL;
+
+	p = add_packed_git(the_repository, idx_name, strlen(idx_name), 1);
+	if (!p || open_pack_index(p))
+		die("unable to open pack index %s", idx_name);
+
+	if (for_each_object_in_pack(p, list_delta, &w_curs,
+				    ODB_FOR_EACH_OBJECT_PACK_ORDER))
+		die("unable to iterate over objects in %s", idx_name);
+
+	unuse_pack(&w_curs);
+	close_pack(p);
+	free(p);
+}
+
 int cmd__pack_deltas(int argc, const char **argv)
 {
 	int num_objects = -1;
+	int list_deltas_mode = 0;
 	struct hashfile *f;
 	struct strbuf line = STRBUF_INIT;
 	struct option options[] = {
 		OPT_INTEGER('n', "num-objects", &num_objects, N_("the number of objects to write")),
+		OPT_BOOL(0, "list-deltas", &list_deltas_mode,
+			 N_("list REF_DELTA and OFS_DELTA entries")),
 		OPT_END()
 	};
 
 	argc = parse_options(argc, argv, NULL,
 			     options, usage_str, 0);
+
+	if (list_deltas_mode) {
+		if (argc != 1 || num_objects >= 0)
+			usage_with_options(usage_str, options);
+		setup_git_directory(the_repository);
+		list_deltas(argv[0]);
+		return 0;
+	}
 
 	if (argc || num_objects < 0)
 		usage_with_options(usage_str, options);

--- a/t/t5300-pack-object.sh
+++ b/t/t5300-pack-object.sh
@@ -211,6 +211,58 @@ test_expect_success 'pack with OFS_DELTA' '
 	test_grep " OFS_DELTA " deltas
 '
 
+test_expect_success 'pack without REF_DELTA' '
+	git pack-objects --no-ref-delta --stdout <obj-list >no-ref.pack &&
+	git index-pack -o no-ref.idx no-ref.pack &&
+
+	test-tool pack-deltas --list-deltas no-ref.idx >deltas &&
+	test_must_be_empty deltas
+'
+
+test_expect_success 'pack without REF_DELTA with OFS_DELTA' '
+	git pack-objects --delta-base-offset --no-ref-delta --stdout \
+		<obj-list >no-ref-ofs.pack &&
+	git index-pack -o no-ref-ofs.idx no-ref-ofs.pack &&
+
+	test-tool pack-deltas --list-deltas no-ref-ofs.idx >deltas &&
+	test_grep " OFS_DELTA " deltas &&
+	test_grep ! " REF_DELTA " deltas
+'
+
+test_expect_success 'pack without REF_DELTA skips excluded delta bases' '
+	test_when_finished "git read-tree $tree" &&
+
+	echo bar >>d &&
+	git update-index --add d &&
+	thin_tree=$(git write-tree) &&
+	thin_commit=$(git commit-tree $thin_tree -p $commit </dev/null) &&
+
+	{
+		echo $thin_commit &&
+		echo ^$commit
+	} >thin-revs &&
+
+	# Each type appears only once in the output, so any delta must
+	# use an excluded base and therefore be a REF_DELTA.
+	git pack-objects --thin --stdout --revs \
+		<thin-revs >thin.pack &&
+	git index-pack --fix-thin --stdin thin-fixed.pack \
+		<thin.pack >/dev/null &&
+
+	test-tool pack-deltas --list-deltas thin-fixed.idx >deltas &&
+	test_grep ! " OFS_DELTA " deltas &&
+	test_grep " REF_DELTA " deltas &&
+
+	git pack-objects --thin --stdout --revs \
+		--delta-base-offset --no-ref-delta \
+		<thin-revs >no-ref-thin.pack &&
+	git index-pack --fix-thin --stdin no-ref-thin-fixed.pack \
+		<no-ref-thin.pack >/dev/null &&
+
+	test-tool pack-deltas --list-deltas no-ref-thin-fixed.idx >deltas &&
+	test_must_be_empty deltas
+'
+
 test_expect_success 'unpack with OFS_DELTA' '
 	check_unpack test-3-${packname_3} obj-list
 '

--- a/t/t5300-pack-object.sh
+++ b/t/t5300-pack-object.sh
@@ -190,7 +190,9 @@ test_expect_success 'unpack without delta (core.fsyncmethod=batch)' '
 
 test_expect_success 'pack with REF_DELTA' '
 	packname_2=$(git pack-objects --progress test-2 <obj-list 2>stderr) &&
-	check_deltas stderr -gt 0
+	check_deltas stderr -gt 0 &&
+	test-tool pack-deltas --list-deltas test-2-$packname_2.idx >deltas &&
+	test_grep " REF_DELTA " deltas
 '
 
 test_expect_success 'unpack with REF_DELTA' '
@@ -204,7 +206,9 @@ test_expect_success 'unpack with REF_DELTA (core.fsyncmethod=batch)' '
 test_expect_success 'pack with OFS_DELTA' '
 	packname_3=$(git pack-objects --progress --delta-base-offset test-3 \
 			<obj-list 2>stderr) &&
-	check_deltas stderr -gt 0
+	check_deltas stderr -gt 0 &&
+	test-tool pack-deltas --list-deltas test-3-$packname_3.idx >deltas &&
+	test_grep " OFS_DELTA " deltas
 '
 
 test_expect_success 'unpack with OFS_DELTA' '

--- a/t/t5300-pack-object.sh
+++ b/t/t5300-pack-object.sh
@@ -229,6 +229,20 @@ test_expect_success 'pack without REF_DELTA with OFS_DELTA' '
 	test_grep ! " REF_DELTA " deltas
 '
 
+test_expect_success 'pack without REF_DELTA reuses deltas as OFS_DELTA' '
+	# Install the REF_DELTA pack above and disable delta search, so any
+	# output delta must be a reused REF_DELTA rewritten as OFS_DELTA.
+	test_when_finished "rm -f .git/objects/pack/pack-$packname_2.*" &&
+	git index-pack --stdin <test-2-${packname_2}.pack >/dev/null &&
+
+	git pack-objects --window=0 --delta-base-offset \
+		--no-ref-delta --stdout <obj-list >reused.pack &&
+	git index-pack -o reused.idx reused.pack &&
+	test-tool pack-deltas --list-deltas reused.idx >deltas &&
+	test_grep " OFS_DELTA " deltas &&
+	test_grep ! " REF_DELTA " deltas
+'
+
 test_expect_success 'pack without REF_DELTA skips excluded delta bases' '
 	test_when_finished "git read-tree $tree" &&
 
@@ -253,7 +267,12 @@ test_expect_success 'pack without REF_DELTA skips excluded delta bases' '
 	test_grep ! " OFS_DELTA " deltas &&
 	test_grep " REF_DELTA " deltas &&
 
-	git pack-objects --thin --stdout --revs \
+	# Store the REF_DELTA entries above and disable delta search below,
+	# so any output delta would have to reuse an excluded-base
+	# REF_DELTA.
+	git index-pack --stdin <thin-fixed.pack >/dev/null &&
+
+	git pack-objects --thin --window=0 --stdout --revs \
 		--delta-base-offset --no-ref-delta \
 		<thin-revs >no-ref-thin.pack &&
 	git index-pack --fix-thin --stdin no-ref-thin-fixed.pack \

--- a/t/t5300-pack-object.sh
+++ b/t/t5300-pack-object.sh
@@ -195,6 +195,19 @@ test_expect_success 'pack with REF_DELTA' '
 	test_grep " REF_DELTA " deltas
 '
 
+test_expect_success 'index-pack rejects REF_DELTA when requested' '
+	test_must_fail git index-pack --no-ref-delta \
+		-o rejected-ref-delta.idx test-2-$packname_2.pack 2>err &&
+	test_grep "REF_DELTA not allowed by --no-ref-delta" err &&
+	test_path_is_missing rejected-ref-delta.idx
+'
+
+test_expect_success 'index-pack --stdin rejects REF_DELTA when requested' '
+	test_must_fail git index-pack --stdin --no-ref-delta \
+		<test-2-$packname_2.pack 2>err &&
+	test_grep "REF_DELTA not allowed by --no-ref-delta" err
+'
+
 test_expect_success 'unpack with REF_DELTA' '
 	check_unpack test-2-${packname_2} obj-list
 '
@@ -227,6 +240,12 @@ test_expect_success 'pack without REF_DELTA with OFS_DELTA' '
 	test-tool pack-deltas --list-deltas no-ref-ofs.idx >deltas &&
 	test_grep " OFS_DELTA " deltas &&
 	test_grep ! " REF_DELTA " deltas
+'
+
+test_expect_success 'index-pack accepts OFS_DELTA when REF_DELTA is forbidden' '
+	git index-pack --no-ref-delta -o accepted-ofs-delta.idx \
+		no-ref-ofs.pack &&
+	test_path_is_file accepted-ofs-delta.idx
 '
 
 test_expect_success 'pack without REF_DELTA reuses deltas as OFS_DELTA' '

--- a/t/t5300-pack-object.sh
+++ b/t/t5300-pack-object.sh
@@ -40,7 +40,21 @@ test_expect_success 'pack-object traces bytes written to stdout' '
 	$commit
 	EOF
 	bytes=$(test_file_size pack.pack) &&
-	test_grep "\"key\":\"written/bytes\",\"value\":\"$bytes\"" pack.trace
+	test_grep "\"key\":\"write_pack_file/wrote_bytes\",\"value\":\"$bytes\"" pack.trace
+'
+
+test_expect_success 'pack-object traces bytes written to split pack files' '
+	test_when_finished "rm -f split.trace traced-pack-*" &&
+	GIT_TRACE2_EVENT="$PWD/split.trace" \
+		git -c pack.packSizeLimit=3m pack-objects --quiet traced-pack <obj-list &&
+	test 2 = $(ls traced-pack-*.pack | wc -l) &&
+	bytes=0 &&
+	for pack in traced-pack-*.pack
+	do
+		pack_size=$(test_file_size "$pack") &&
+		bytes=$((bytes + pack_size)) || return 1
+	done &&
+	test_grep "\"key\":\"write_pack_file/wrote_bytes\",\"value\":\"$bytes\"" split.trace
 '
 
 test_expect_success 'setup pack-object <stdin' '

--- a/t/t5300-pack-object.sh
+++ b/t/t5300-pack-object.sh
@@ -33,6 +33,16 @@ test_expect_success 'setup' '
 	} >expect
 '
 
+test_expect_success 'pack-object traces bytes written to stdout' '
+	test_when_finished "rm -f pack.trace pack.pack" &&
+	GIT_TRACE2_EVENT="$PWD/pack.trace" \
+		git pack-objects --quiet --revs --stdout >pack.pack <<-EOF &&
+	$commit
+	EOF
+	bytes=$(test_file_size pack.pack) &&
+	test_grep "\"key\":\"written/bytes\",\"value\":\"$bytes\"" pack.trace
+'
+
 test_expect_success 'setup pack-object <stdin' '
 	git init pack-object-stdin &&
 	test_commit -C pack-object-stdin one &&

--- a/t/t5331-pack-objects-stdin.sh
+++ b/t/t5331-pack-objects-stdin.sh
@@ -368,7 +368,8 @@ test_expect_success '--stdin-packs does not perform backfill fetch' '
 	git -C remote config set --local uploadpack.allowfilter 1 &&
 	git -C remote config set --local uploadpack.allowanysha1inwant 1 &&
 
-	git clone --filter=tree:0 "file://$(pwd)/remote" client &&
+	git -c maintenance.auto=false clone --filter=tree:0 \
+		"file://$(pwd)/remote" client &&
 	(
 		cd client &&
 		ls .git/objects/pack/*.promisor | sed "s|.*/||; s/\.promisor$/.pack/" >packs &&

--- a/t/t5332-multi-pack-reuse.sh
+++ b/t/t5332-multi-pack-reuse.sh
@@ -111,6 +111,22 @@ test_expect_success 'reuse all objects from all packs' '
 	test_pack_objects_reused_all 9 3
 '
 
+test_expect_success '--no-ref-delta reuses REF_DELTA-free bitmapped packs' '
+	# Whole-word reuse is unavailable under --no-ref-delta, so reusing
+	# every object below exercises the per-object bitmap path.
+	: >trace2.txt &&
+	GIT_TRACE2_EVENT="$PWD/trace2.txt" \
+		git pack-objects --stdout --revs --all --delta-base-offset \
+		--no-ref-delta >got.pack &&
+
+	test_pack_reused 9 <trace2.txt &&
+	test_packs_reused 3 <trace2.txt &&
+
+	git index-pack --strict -o got.idx got.pack &&
+	test-tool pack-deltas --list-deltas got.idx >deltas &&
+	test_grep ! " REF_DELTA " deltas
+'
+
 test_expect_success 'reuse objects from first pack with middle gap' '
 	for i in D E F
 	do

--- a/t/t5516-fetch-push.sh
+++ b/t/t5516-fetch-push.sh
@@ -1548,6 +1548,20 @@ EOF
 	git push --no-thin --receive-pack="$rcvpck" no-thin/.git refs/heads/main:refs/heads/foo
 '
 
+test_expect_success 'push honors no-ref-delta capability' '
+	test_commit no-ref-delta &&
+
+	rcvpck="git receive-pack --advertise-no-ref-delta-for-testing" &&
+
+	GIT_TRACE2_EVENT="$PWD/no-ref-delta" \
+	git push --receive-pack="$rcvpck" no-thin/.git \
+		refs/heads/main:refs/heads/bar &&
+
+	test_subcommand git pack-objects --all-progress-implied --revs \
+		--stdout --thin --delta-base-offset --no-ref-delta -q \
+		<no-ref-delta
+'
+
 test_expect_success 'pushing a tag pushes the tagged object' '
 	blob=$(echo unreferenced | git hash-object -w --stdin) &&
 	git tag -m foo tag-of-blob $blob &&

--- a/t/t5702-protocol-v2.sh
+++ b/t/t5702-protocol-v2.sh
@@ -1517,6 +1517,51 @@ test_expect_success 'packfile-uri with transfer.fsckobjects fails when .gitmodul
 	test_grep "disallowed submodule name" err
 '
 
+test_expect_success 'parallel packfile URIs defer valid .gitattributes fsck' '
+	P="$HTTPD_DOCUMENT_ROOT_PATH/http_parent" &&
+	rm -rf "$P" http_child &&
+
+	git init "$P" &&
+	git -C "$P" config uploadpack.allowsidebandall true &&
+	git -C "$P" config uploadpack.allowNoRefDelta true &&
+
+	echo "*.txt text" >"$P/.gitattributes" &&
+	echo other >"$P/other" &&
+	git -C "$P" add .gitattributes other &&
+	git -C "$P" commit -m x &&
+	configure_exclusion "$P" .gitattributes >/dev/null &&
+	configure_exclusion "$P" other >/dev/null &&
+
+	sane_unset GIT_TEST_SIDEBAND_ALL &&
+	git -c protocol.version=2 -c transfer.fsckobjects=1 \
+		-c fetch.uriprotocols=http,https \
+		-c fetch.packfileUriJobs=2 \
+		clone "$HTTPD_URL/smart/http_parent" http_child
+'
+
+test_expect_success 'parallel packfile URIs reject invalid .gitattributes' '
+	P="$HTTPD_DOCUMENT_ROOT_PATH/http_parent" &&
+	rm -rf "$P" http_child err &&
+
+	git init "$P" &&
+	git -C "$P" config uploadpack.allowsidebandall true &&
+	git -C "$P" config uploadpack.allowNoRefDelta true &&
+
+	printf "pattern %02048d" 1 >"$P/.gitattributes" &&
+	echo other >"$P/other" &&
+	git -C "$P" add .gitattributes other &&
+	git -C "$P" commit -m x &&
+	configure_exclusion "$P" .gitattributes >/dev/null &&
+	configure_exclusion "$P" other >/dev/null &&
+
+	sane_unset GIT_TEST_SIDEBAND_ALL &&
+	test_must_fail git -c protocol.version=2 -c transfer.fsckobjects=1 \
+		-c fetch.uriprotocols=http,https \
+		-c fetch.packfileUriJobs=2 \
+		clone "$HTTPD_URL/smart/http_parent" http_child 2>err &&
+	test_grep "gitattributes has too long lines" err
+'
+
 test_expect_success 'packfile-uri path redacted in trace' '
 	P="$HTTPD_DOCUMENT_ROOT_PATH/http_parent" &&
 	rm -rf "$P" http_child log &&

--- a/t/t5702-protocol-v2.sh
+++ b/t/t5702-protocol-v2.sh
@@ -1300,6 +1300,38 @@ test_expect_success 'part of packfile response provided as URI' '
 	test_line_count = 6 filelist
 '
 
+test_expect_success 'no-ref-delta URI packs are indexed concurrently' '
+	P="$HTTPD_DOCUMENT_ROOT_PATH/http_parent" &&
+	rm -rf "$P" http_child-no-ref no-ref-* &&
+	git init "$P" &&
+	git -C "$P" config uploadpack.allowsidebandall true &&
+	git -C "$P" config uploadpack.allowNoRefDelta true &&
+	echo one >"$P/one" &&
+	echo two >"$P/two" &&
+	echo three >"$P/three" &&
+	git -C "$P" add one two three &&
+	git -C "$P" commit -m objects &&
+	# A one-object pack cannot contain a delta.
+	configure_exclusion "$P" one >/dev/null &&
+	configure_exclusion "$P" two >/dev/null &&
+	configure_exclusion "$P" three >/dev/null &&
+
+	GIT_TRACE2_EVENT="$TRASH_DIRECTORY/no-ref-index.trace" \
+	GIT_TRACE_PACKET="$TRASH_DIRECTORY/no-ref-packet.trace" \
+	GIT_TEST_SIDEBAND_ALL=1 \
+	git -c protocol.version=2 -c fetch.uriprotocols=http \
+		-c fetch.packfileUriJobs=2 \
+		clone "$HTTPD_URL/smart/http_parent" http_child-no-ref &&
+
+	test_grep "> no-ref-delta" no-ref-packet.trace &&
+	grep "\"event\":\"child_start\".*\"index-pack\".*--no-ref-delta" \
+		no-ref-index.trace >no-ref-indexers &&
+	test_line_count = 4 no-ref-indexers &&
+	grep "\"event\":\"child_start\".*\"index-pack\".*--no-ref-delta.*--threads=1" \
+		no-ref-index.trace >no-ref-uri-indexers &&
+	test_line_count = 3 no-ref-uri-indexers
+'
+
 test_expect_success 'packfile URIs with fetch instead of clone' '
 	P="$HTTPD_DOCUMENT_ROOT_PATH/http_parent" &&
 	rm -rf "$P" http_child log &&

--- a/t/t5702-protocol-v2.sh
+++ b/t/t5702-protocol-v2.sh
@@ -972,6 +972,36 @@ test_expect_success 'reject client packfile-uris if not advertised' '
 		upload-pack client <input
 '
 
+test_expect_success 'fetch no-ref-delta requires advertisement' '
+	rm -rf no-ref-advertisement &&
+	git init no-ref-advertisement &&
+	test_commit -C no-ref-advertisement one &&
+	env GIT_CONFIG_COUNT=1 \
+		GIT_CONFIG_KEY_0=uploadpack.allowNoRefDelta \
+		GIT_CONFIG_VALUE_0=true \
+		test-tool -C no-ref-advertisement serve-v2 \
+		--advertise-capabilities \
+		>advertisement &&
+	test_grep "fetch=.*no-ref-delta" advertisement &&
+	{
+		packetize command=fetch &&
+		packetize object-format=$(test_oid algo) &&
+		printf 0001 &&
+		packetize no-ref-delta &&
+		packetize "want $(git -C no-ref-advertisement rev-parse HEAD)" &&
+		packetize done &&
+		printf 0000
+	} >input &&
+	test_must_fail env GIT_PROTOCOL=version=2 \
+		git upload-pack no-ref-advertisement <input &&
+	GIT_TRACE2_EVENT="$PWD/no-ref-upload.trace" \
+	GIT_PROTOCOL=version=2 \
+		git -c uploadpack.allowNoRefDelta=true \
+		upload-pack no-ref-advertisement <input >out &&
+	test_grep "\"event\":\"child_start\".*\"pack-objects\".*--no-ref-delta" \
+		no-ref-upload.trace
+'
+
 # Test protocol v2 with 'http://' transport
 #
 . "$TEST_DIRECTORY"/lib-httpd.sh

--- a/t/t7900-maintenance.sh
+++ b/t/t7900-maintenance.sh
@@ -617,6 +617,13 @@ run_and_verify_geometric_pack () {
 	test_must_be_empty orphaned-idx
 }
 
+pack_promisor () {
+	packdir=.git/objects/pack &&
+	pack="$(echo "$@" | git pack-objects --revs "$packdir/pack")" &&
+	touch "$packdir/pack-$pack.promisor" &&
+	echo "$pack"
+}
+
 test_expect_success 'geometric repacking task' '
 	test_when_finished "rm -rf repo" &&
 	git init repo &&
@@ -690,6 +697,41 @@ test_expect_success 'geometric repacking task' '
 		test_line_count = 2 packs &&
 		ls .git/objects/pack/*.mtimes >cruft &&
 		test_line_count = 1 cruft
+	)
+'
+
+test_expect_success 'geometric repacking task handles promisor packs' '
+	test_when_finished "rm -rf repo" &&
+	git init repo &&
+	(
+		cd repo &&
+		git config set maintenance.auto false &&
+		git remote add promisor garbage &&
+		git config set remote.promisor.promisor true &&
+
+		for n in $(test_seq 6)
+		do
+			test_commit $n || return 1
+		done &&
+
+		A="$(pack_promisor 1)" &&
+		B="$(pack_promisor 1..2)" &&
+		pack_promisor 2..6 >/dev/null &&
+		git prune-packed &&
+
+		ls .git/objects/pack/*.promisor | sort >promisors.before &&
+		GIT_TRACE2_EVENT="$(pwd)/trace2.txt" \
+			git maintenance run --quiet --task=geometric-repack &&
+		ls .git/objects/pack/*.promisor | sort >promisors.after &&
+
+		test_subcommand git repack -d -l -q --geometric=2 \
+			--write-midx <trace2.txt &&
+		test_line_count = 2 promisors.after &&
+
+		printf ".git/objects/pack/pack-%s.promisor\n" "$A" "$B" |
+			sort >expect &&
+		comm -23 promisors.before promisors.after >actual &&
+		test_cmp expect actual
 	)
 '
 

--- a/t/t7900-maintenance.sh
+++ b/t/t7900-maintenance.sh
@@ -790,6 +790,29 @@ test_expect_success 'geometric repacking with --auto' '
 	)
 '
 
+test_expect_success 'geometric repacking with --auto handles promisor packs' '
+	test_when_finished "rm -rf repo" &&
+	git init repo &&
+	(
+		cd repo &&
+		git config set maintenance.auto false &&
+		git remote add promisor garbage &&
+		git config set remote.promisor.promisor true &&
+
+		for n in $(test_seq 6)
+		do
+			test_commit $n || return 1
+		done &&
+
+		pack_promisor 1 >/dev/null &&
+		pack_promisor 1..2 >/dev/null &&
+		pack_promisor 2..6 >/dev/null &&
+		git prune-packed &&
+
+		test_geometric_repack_needed true auto=9000
+	)
+'
+
 test_expect_success 'geometric repacking honors configured split factor' '
 	test_when_finished "rm -rf repo" &&
 	git init repo &&

--- a/upload-pack.c
+++ b/upload-pack.c
@@ -120,6 +120,8 @@ struct upload_pack_data {
 	unsigned allow_sideband_all : 1;			/* v2 only */
 	unsigned seen_haves : 1;				/* v2 only */
 	unsigned allow_packfile_uris : 1;			/* v2 only */
+	unsigned allow_no_ref_delta : 1;			/* v2 only */
+	unsigned use_no_ref_delta : 1;			/* v2 only */
 	unsigned advertise_sid : 1;
 	unsigned sent_capabilities : 1;
 };
@@ -333,6 +335,8 @@ static void create_pack_file(struct upload_pack_data *pack_data,
 		strvec_push(&pack_objects.args, "--progress");
 	if (pack_data->use_ofs_delta)
 		strvec_push(&pack_objects.args, "--delta-base-offset");
+	if (pack_data->use_no_ref_delta)
+		strvec_push(&pack_objects.args, "--no-ref-delta");
 	if (pack_data->use_include_tag)
 		strvec_push(&pack_objects.args, "--include-tag");
 	if (repo_has_accepted_promisor_remote(the_repository))
@@ -1363,6 +1367,8 @@ static int upload_pack_config(const char *var, const char *value,
 		data->allow_ref_in_want = git_config_bool(var, value);
 	} else if (!strcmp("uploadpack.allowsidebandall", var)) {
 		data->allow_sideband_all = git_config_bool(var, value);
+	} else if (!strcmp("uploadpack.allownorefdelta", var)) {
+		data->allow_no_ref_delta = git_config_bool(var, value);
 	} else if (!strcmp("uploadpack.blobpackfileuri", var)) {
 		if (value)
 			data->allow_packfile_uris = 1;
@@ -1668,6 +1674,11 @@ static void process_args(struct packet_reader *request,
 			string_list_split(&data->uri_protocols, p, ",", -1);
 			continue;
 		}
+		if (data->allow_no_ref_delta &&
+		    !strcmp(arg, "no-ref-delta")) {
+			data->use_no_ref_delta = 1;
+			continue;
+		}
 
 		/* ignore unknown lines maybe? */
 		die("unexpected line: '%s'", arg);
@@ -1854,6 +1865,9 @@ int upload_pack_advertise(struct repository *r,
 
 		if (data.allow_packfile_uris)
 			strbuf_addstr(value, " packfile-uris");
+
+		if (data.allow_no_ref_delta)
+			strbuf_addstr(value, " no-ref-delta");
 	}
 
 	upload_pack_data_clear(&data);


### PR DESCRIPTION
With fetch.fsckObjects or transfer.fsckObjects enabled, index-pack checks
each pack as soon as it has been installed. Some checks need objects from
another pack, though. A tree in the inline pack can name a .gitattributes
blob that arrives in a packfile URI response. index-pack then reports the
missing blob before fetch-pack has downloaded the URI pack.

The same split already works for .gitmodules. index-pack writes any
unresolved .gitmodules object IDs after its pack result. fetch-pack
collects those IDs and runs fsck_finish() after all packs have been
installed.

Extend that handoff to .gitattributes. Prefix .gitattributes records so
fetch-pack can distinguish them while leaving the existing .gitmodules
output unchanged. The existing fsck_finish() call then checks both sets
after every packfile URI has been indexed.

Test that two concurrently indexed URI packs accept a valid split
.gitattributes file and reject an overlong one.

Signed-off-by: Friel <friel@openai.com>

---
 Documentation/git-index-pack.adoc |  8 +++---
 builtin/index-pack.c              |  3 ++-
 fetch-pack.c                      | 57 ++++++++++++++++++++++-----------------
 fsck.c                            | 23 +++++++++-------
 fsck.h                            | 11 ++++----
 t/t5702-protocol-v2.sh            | 45 +++++++++++++++++++++++++++++++
 6 files changed, 103 insertions(+), 44 deletions(-)
