### PR TITLE
ci: allow reviewed action pins in Codex topics

### DIFF
--- a/.github/CODEX.md
+++ b/.github/CODEX.md
@@ -117,6 +117,12 @@ controller or workflow paths. A prerequisite change is deliberately not an
 alter: retire and re-add the topic under a newly reviewed ancestry, or extend
 the policy explicitly.
 
+The three inherited CI workflows may take the exact full-SHA replacements
+listed in `ci_workflow_pins_are_reviewed()`. Those entries allow the reviewed
+action pins without admitting other workflow edits or mode changes. A stable
+topic carries the replacements into both output lanes; changes to the
+approved workflow contents require another controller review.
+
 ## Day-to-day commands
 
 Start a production topic from `master`, or from its intended production

--- a/.github/workflows/codex-branch.sh
+++ b/.github/workflows/codex-branch.sh
@@ -369,6 +369,27 @@ legacy_control_paths_unchanged () (
 		t/t9905-codex-branch.sh
 )
 
+ci_workflow_pins_are_reviewed () (
+	base_oid=$1
+	head_oid=$2
+
+	# Permit only the reviewed full-SHA replacements of the inherited CI
+	# workflows. Comparing tree entries also rejects mode changes, symlinks,
+	# and deletions. New upstream workflow contents need a new review.
+	while read -r path old_blob new_blob
+	do
+		old=$(git ls-tree "$base_oid" -- "$path") || return 1
+		new=$(git ls-tree "$head_oid" -- "$path") || return 1
+		test "$old" = "$new" && continue
+		test "$old" = "100644 blob $old_blob$tab$path" &&
+		test "$new" = "100644 blob $new_blob$tab$path" || return 1
+	done <<-\EOF
+	.github/workflows/check-style.yml 108a2de903310cfd0f6327353ee700d99d54edc3 b265fe35cbfc51db4cd53729e602de5d36b6632e
+	.github/workflows/check-whitespace.yml ea6f49f742108e27812decc666e6839ab84080f1 3379f89a814abd439ac13efaa572264be5b75080
+	.github/workflows/main.yml 205325eb33b06444f24a11271a9e669841e29cb9 485e3be66581518bca55b62d97ebd2217be194b1
+	EOF
+)
+
 meta_control_paths_unchanged () (
 	base_oid=$1
 	head_oid=$2
@@ -388,7 +409,6 @@ meta_control_paths_unchanged () (
 		.github/workflows/codex-pr-state.yml \
 		.github/workflows/codex-topic.yml \
 		.github/workflows/codex-branch.sh \
-		.github/workflows/main.yml \
 		codex \
 		publish \
 		rebuild \
@@ -400,8 +420,12 @@ meta_control_paths_unchanged () (
 	git diff --quiet "$base_oid" "$head_oid" -- \
 		':(glob).github/workflows/*.yml' \
 		':(glob).github/workflows/*.yaml' \
+		':(exclude).github/workflows/check-style.yml' \
+		':(exclude).github/workflows/check-whitespace.yml' \
+		':(exclude).github/workflows/main.yml' \
 		':(exclude).github/workflows/codex.yml' \
-		':(exclude).github/workflows/codex-release.yml'
+		':(exclude).github/workflows/codex-release.yml' &&
+	ci_workflow_pins_are_reviewed "$base_oid" "$head_oid"
 )
 
 write_automation_workflow () {
@@ -8204,7 +8228,6 @@ topic_control_paths_unchanged () (
 		.github/workflows/codex-topic.yml \
 		.github/workflows/codex.yml \
 		.github/workflows/codex-branch.sh \
-		.github/workflows/main.yml \
 		codex \
 		publish \
 		rebuild \
@@ -8216,7 +8239,11 @@ topic_control_paths_unchanged () (
 	git diff --quiet "$base_oid" "$head_oid" -- \
 		':(glob).github/workflows/*.yml' \
 		':(glob).github/workflows/*.yaml' \
-		':(exclude).github/workflows/codex-release.yml'
+		':(exclude).github/workflows/check-style.yml' \
+		':(exclude).github/workflows/check-whitespace.yml' \
+		':(exclude).github/workflows/main.yml' \
+		':(exclude).github/workflows/codex-release.yml' &&
+	ci_workflow_pins_are_reviewed "$base_oid" "$head_oid"
 )
 
 verify_unstable_control_paths () (


### PR DESCRIPTION
The controller rejects the full-SHA action pins in #80, so the topic cannot enter the stable plan even though the repository's Actions policy requires those pins.

Allow the three exact before/after workflow blobs from that patch through the source-range and generated-tree checks. File modes must match too. Other workflow edits remain subject to controller review, and the existing topic approval and plan checks still apply.

Once the topic is admitted to `codex`, `codex-unstable` inherits the pinned workflows from its stable base. The release workflow's six action pins already fit the existing release-workflow policy.

Validation: syntax and whitespace checks pass. Checks against the real pinning patch accept the replacements and reject unpinning, extra edits, deletion, executable or symlink modes, and added workflows. All 136 tests in the existing controller regression suite pass.

<!-- codex-thread: 01a062fc-0bc2-7e72-a212-7e3df70a3cd4 -->
