### PR TITLE
Codex plan: add tb/codex/release-tooling in codex

### DIFF
--- a/codex.plan
+++ b/codex.plan
@@ -10,6 +10,7 @@
 	topic = refs/heads/tb/codex/packfile-uri-concurrency
 	topic = refs/heads/af/codex/pack-bytes
 	topic = refs/heads/tb/codex/parallel-packfile-uris
+	topic = refs/heads/tb/codex/release-tooling
 
 [branch "tb/codex/automation"]
 	remote = .
@@ -66,3 +67,10 @@
 	source-tip = a08b8d8bb7e3082e9d8e3d29e1535579234784be
 	source-base = 4cc8b3223b233aa3b795b1265e6e7cf3d63c7170
 	merge = refs/heads/tb/codex/packfile-uri-concurrency
+
+[branch "tb/codex/release-tooling"]
+	remote = .
+	source-ref = refs/heads/tb/codex/release-tooling
+	source-tip = 4209f5e2907f3e96266ce9eabe8db70653dbaef9
+	source-base = 88fcb4ac12c583bedf010e97ebf83cec240e3120
+	merge = refs/heads/tb/codex/lto-pgo


### PR DESCRIPTION
Admit the approved release workflow from #83 as a stable topic after
`tb/codex/lto-pgo`. The source boundary is the existing PGO pin, so replay
uses the three-file change reviewed in #83. All existing stable and preview
topics retain their order, source pins, and prerequisites.

- Source: `4209f5e2907f3e96266ce9eabe8db70653dbaef9`
- Boundary: `88fcb4ac12c583bedf010e97ebf83cec240e3120`
- Immutable pin: `refs/heads/codex-pins/4209f5e2907f3e96266ce9eabe8db70653dbaef9`

The current trusted controller generated this eight-line addition and
validated the topic approval and plan policy. This admits the desired
source; the normal rebuild and staging checks still govern publication.
