### PR TITLE
Codex plan: refresh reusable release source pin

### DIFF
--- a/codex.plan
+++ b/codex.plan
@@ -72,8 +72,8 @@
 [branch "tb/codex/release-tooling"]
 	remote = .
 	source-ref = refs/heads/tb/codex/release-tooling
-	source-tip = 4209f5e2907f3e96266ce9eabe8db70653dbaef9
-	source-base = 88fcb4ac12c583bedf010e97ebf83cec240e3120
+	source-tip = 8a710bf9b86c6500ecd56ccc5feee8cc8e0ba90a
+	source-base = 67ba20645b1792f43c8c8ea69c716687bda87ec3
 	merge = refs/heads/tb/codex/lto-pgo
 
 [branch "tb/codex/pin-ci-actions"]


### PR DESCRIPTION
Update #83's source pin after restacking its release changes on #80's action
pins. The three release files are identical to the previously approved
version; the restack removes conflicts when replaying the topics together.

Only the source tip and boundary change. Existing topics and the preview
plan are preserved. The planner's five-topic release composition passes,
and its output matches the tested release files and controller guards.
