### PR TITLE
Codex plan: require symlink support in the release test

### DIFF
--- a/codex.plan
+++ b/codex.plan
@@ -72,7 +72,7 @@
 [branch "tb/codex/release-tooling"]
 	remote = .
 	source-ref = refs/heads/tb/codex/release-tooling
-	source-tip = 3a54f5acc4df456497fb7d20ae9dfe19d9f7ac03
+	source-tip = 877755f59eb7b0075b8b117a0092519ce68291e8
 	source-base = 67ba20645b1792f43c8c8ea69c716687bda87ec3
 	merge = refs/heads/tb/codex/lto-pgo
 


### PR DESCRIPTION
Update the release-tooling pin from #83 after its Windows test fix. The symlink assertion now requires `SYMLINKS`, while unexpected-file rejection still runs on every platform.

Only one source pin changes. The release workflow and manifest helper are unchanged. All nine manifest cases pass with Bash 3.2; with symlinks unavailable, eight pass and the symlink case skips.
