### PR TITLE
codex: allow the reviewed Debian CI image update

### DIFF
--- a/.github/workflows/codex-branch.sh
+++ b/.github/workflows/codex-branch.sh
@@ -377,20 +377,22 @@ ci_workflow_pins_are_reviewed () (
 	base_oid=$1
 	head_oid=$2
 
-	# Permit only the reviewed full-SHA replacements of the inherited CI
-	# workflows. Comparing tree entries also rejects mode changes, symlinks,
+	# Permit only the reviewed CI pins and optional image update.
+	# Comparing tree entries also rejects mode changes, symlinks,
 	# and deletions. New upstream workflow contents need a new review.
-	while read -r path old_blob new_blob
+	while read -r path old_blob new_blob updated_blob
 	do
 		old=$(git ls-tree "$base_oid" -- "$path") || return 1
 		new=$(git ls-tree "$head_oid" -- "$path") || return 1
 		test "$old" = "$new" && continue
-		test "$old" = "100644 blob $old_blob$tab$path" &&
-		test "$new" = "100644 blob $new_blob$tab$path" || return 1
+		{ test "$old" = "100644 blob $old_blob$tab$path" ||
+		  test "$old" = "100644 blob $new_blob$tab$path"; } &&
+		{ test "$new" = "100644 blob $new_blob$tab$path" ||
+		  test "$new" = "100644 blob $updated_blob$tab$path"; } || return 1
 	done <<-\EOF
 	.github/workflows/check-style.yml 108a2de903310cfd0f6327353ee700d99d54edc3 b265fe35cbfc51db4cd53729e602de5d36b6632e
 	.github/workflows/check-whitespace.yml ea6f49f742108e27812decc666e6839ab84080f1 3379f89a814abd439ac13efaa572264be5b75080
-	.github/workflows/main.yml 205325eb33b06444f24a11271a9e669841e29cb9 485e3be66581518bca55b62d97ebd2217be194b1
+	.github/workflows/main.yml 205325eb33b06444f24a11271a9e669841e29cb9 485e3be66581518bca55b62d97ebd2217be194b1 09dbf0c59a288b752c9a41a2c8ed749e3af1a1e8
 	EOF
 )
 

--- a/t/t9905-codex-branch.sh
+++ b/t/t9905-codex-branch.sh
@@ -10870,4 +10870,37 @@ test_expect_success 'both release lanes start CI before either lane waits' '
 	)
 '
 
+test_expect_success SHA1 'reviewed CI image updates retain exact workflow entries' '
+	test_create_repo ci-image-policy &&
+	(
+		cd ci-image-policy &&
+		tab=$(printf "\t") &&
+		sed -n "/^ci_workflow_pins_are_reviewed () ($/,/^)/p" \
+			"$codex_branch" >policy.sh &&
+		. ./policy.sh &&
+		ci_tree () {
+			workflow=$(printf "%s blob %s\tmain.yml\n" \
+				"${2:-100644}" "$1" | git mktree --missing) &&
+			github=$(printf "040000 tree %s\tworkflows\n" \
+				"$workflow" | git mktree) &&
+			printf "040000 tree %s\t.github\n" "$github" |
+				git mktree
+		} &&
+		before=$(ci_tree 205325eb33b06444f24a11271a9e669841e29cb9) &&
+		pinned=$(ci_tree 485e3be66581518bca55b62d97ebd2217be194b1) &&
+		updated=$(ci_tree 09dbf0c59a288b752c9a41a2c8ed749e3af1a1e8) &&
+		unknown=$(ci_tree 1111111111111111111111111111111111111111) &&
+		mode=$(ci_tree 09dbf0c59a288b752c9a41a2c8ed749e3af1a1e8 100755) &&
+		empty=$(git mktree </dev/null) &&
+		ci_workflow_pins_are_reviewed "$before" "$pinned" &&
+		ci_workflow_pins_are_reviewed "$before" "$updated" &&
+		ci_workflow_pins_are_reviewed "$pinned" "$updated" &&
+		test_expect_code 1 ci_workflow_pins_are_reviewed "$pinned" "$unknown" &&
+		test_expect_code 1 ci_workflow_pins_are_reviewed "$unknown" "$updated" &&
+		test_expect_code 1 ci_workflow_pins_are_reviewed "$pinned" "$mode" &&
+		test_expect_code 1 ci_workflow_pins_are_reviewed "$pinned" "$empty" &&
+		test_expect_code 1 ci_workflow_pins_are_reviewed "$updated" "$pinned"
+	)
+'
+
 test_done


### PR DESCRIPTION
Debian 11 CI fails during `apt-get update` because its security metadata has expired. [Debian 11 reached the end of LTS support on August 31](https://www.debian.org/News/2026/20260831); the [three-line source change in #80](https://github.com/openai/git/commit/026ca78e79986a60637df0fec4f2089e84f19f7a) moves the job to Debian 12.

Allow that exact workflow blob through the controller, from either the inherited workflow or the version with pinned actions. Existing plans remain valid. Other contents, mode changes, deletions, and rollback to the old image remain rejected.

Validation: the focused regression fails on the current controller and passes with this change. Checks against the real workflow objects pass for all three permitted transitions; five negative cases pass. Shell syntax and whitespace checks pass. The full controller suite was not rerun for this change.
