### PR TITLE
codex: preserve the stable base when freezing recovery

### DIFF
--- a/.github/workflows/codex-branch.sh
+++ b/.github/workflows/codex-branch.sh
@@ -5265,6 +5265,19 @@ assemble_candidate () {
 			"$candidate" "$state" "$require_automation"
 	fi
 
+	if test -f "$state/unstable/topic-updates"
+	then
+		recovered=$(state_value "$state/unstable" base-oid)
+		git merge-base --is-ancestor "$base_oid" "$recovered" &&
+			test "$(git rev-parse "$candidate^{tree}")" = \
+			"$(git rev-parse "$recovered^{tree}")" &&
+			codex_has_expected_integrations "$state" "$recovered" ||
+			die "completed unstable recovery has a different stable base"
+		# Keep the exact base of the recovered graph after validating its
+		# tree and integrations against the freshly assembled candidate.
+		candidate=$recovered
+	fi
+
 	printf '%s\n' "$candidate"
 }
 

--- a/t/t9905-codex-branch.sh
+++ b/t/t9905-codex-branch.sh
@@ -9394,6 +9394,7 @@ test_expect_success 'pinned merge chain preserves recoverable overlap state' '
 		sh "$codex_branch" continue --worktree "$private" \
 			>continue.out 2>continue.err &&
 		test_grep "source refs unchanged" continue.out &&
+		test_tick &&
 		sh "$codex_branch" publish-topics --worktree resolution \
 			>publish.out 2>publish.err &&
 		test_grep "Pinned recovery session" publish.out &&
@@ -9401,6 +9402,7 @@ test_expect_success 'pinned merge chain preserves recoverable overlap state' '
 		session=$(sed -n \
 			"s/^Pinned recovery session: //p" publish.out) &&
 		test -n "$session" &&
+		test_cmp "$state/unstable/base-oid" "$session/codex-candidate" &&
 		sh "$codex_branch" verify-output \
 			--inputs "$session/codex-inputs" \
 			--updates "$session/codex-updates" \


### PR DESCRIPTION
After resolving an unstable conflict, `publish-topics` rebuilds the unchanged stable candidate with new merge timestamps. The recovered preview still descends from the original commit, so freezing fails with “completed unstable recovery belongs to a different stable candidate.”

Reuse the original base after checking its ancestry, tree, and expected topic integrations against the rebuilt candidate. Complete output verification and the exact preview-base check still run before freezing.

Validation: advance the test clock between recovery and freezing. The regression fails on the current controller and passes with this change, retaining the exact stable base and leaving remote refs unchanged. The full controller suite was not rerun for this change.
