### PR TITLE
Codex plan: remove the unstable status preview

### DIFF
--- a/codex-unstable.plan
+++ b/codex-unstable.plan
@@ -2,11 +2,3 @@
 	version = 1
 	lane = codex-unstable
 	base-ref = refs/heads/codex
-	topic = refs/heads/tb/codex/status-preview-unstable
-
-[branch "tb/codex/status-preview-unstable"]
-	remote = .
-	source-ref = refs/heads/tb/codex/status-preview-unstable
-	source-tip = cbf6ae4e9b3c705182b1e2573cee19aae7d4b877
-	source-base = 00ee4fe98b17036715a005ff47027f00a646d099
-	merge = refs/heads/codex


### PR DESCRIPTION
Remove the remaining custom status preview from the unstable release plan after #98 lands. The controller will retain codex-unstable with the same tree as the rebuilt stable release.

This is stacked on #98; retarget it to meta after that removal lands. Both individual removal transitions passed the current controller validation locally. Source branches and immutable pins are retained.

<!-- codex-thread: 01a081d2-ce48-7270-b46a-b7cafe8b642f -->
