### PR TITLE
Codex plan: remove the unstable status preview

### DIFF
--- a/codex-unstable.plan
+++ b/codex-unstable.plan
@@ -2,11 +2,3 @@
 	version = 1
 	lane = codex-unstable
 	base-ref = refs/heads/codex
-	topic = refs/heads/tb/codex/status-preview-unstable
-
-[branch "tb/codex/status-preview-unstable"]
-	remote = .
-	source-ref = refs/heads/tb/codex/status-preview-unstable
-	source-tip = cbf6ae4e9b3c705182b1e2573cee19aae7d4b877
-	source-base = 00ee4fe98b17036715a005ff47027f00a646d099
-	merge = refs/heads/codex


### PR DESCRIPTION
Remove the remaining custom status preview from codex-unstable. With #98 merged, this leaves the unstable plan empty; the controller will keep codex-unstable enabled with the same source tree as the rebuilt stable release.

This PR replaces #99 and replays its removal onto the current meta branch. The resulting tree is unchanged, and the controller validates the transition from a3d672ea3e29 to 0f3cab144d06. Source branches and immutable pins are retained.

<!-- codex-thread: 01a081d2-ce48-7270-b46a-b7cafe8b642f -->
