### PR TITLE
Codex plan: include the release receipt fix

### DIFF
--- a/codex.plan
+++ b/codex.plan
@@ -72,7 +72,7 @@
 [branch "tb/codex/release-tooling"]
 	remote = .
 	source-ref = refs/heads/tb/codex/release-tooling
-	source-tip = 5059f7d29d51ef5336be36e09c68c5bcd15936bd
+	source-tip = 66c1ed633a371bccb1abbe2297bfd3b27a498d87
 	source-base = 67ba20645b1792f43c8c8ea69c716687bda87ec3
 	merge = refs/heads/tb/codex/lto-pgo
 


### PR DESCRIPTION
Use the reviewed release-tooling fix from #100 so Windows CRLF receipts compare successfully during release manifest publication. The source change passed all ten manifest tests.

This generated plan transition advances only the release-tooling source pin to `66c1ed633a371bccb1abbe2297bfd3b27a498d87`. Its prerequisite and position are unchanged. Both unstable status removals have already landed in `meta`.

<!-- codex-thread: 01a081d2-ce48-7270-b46a-b7cafe8b642f -->
