### PR TITLE
codex: admit stable topics based on older upstream commits

### DIFF
--- a/.github/workflows/codex-branch.sh
+++ b/.github/workflows/codex-branch.sh
@@ -2121,20 +2121,27 @@ pinned_root_boundary () (
 	current_base=$1
 	published_base=$2
 	tip=$3
+	lane_base=$4
 	bases=$(git merge-base --all "$current_base" "$tip") ||
 		return 1
 	test -n "$bases" || return 1
 	test "$(printf '%s\n' "$bases" | wc -l | tr -d ' ')" = 1 ||
 		return 1
 	boundary=$(printf '%s\n' "$bases" | sed -n '1p')
-	git merge-base --is-ancestor "$published_base" "$boundary" ||
-		return 1
+	# Stable topics may start at an older upstream commit. Preview topics
+	# must still include the published production base.
+	if test "$lane_base" != "$base_name"
+	then
+		git merge-base --is-ancestor "$published_base" "$boundary" ||
+			return 1
+	fi
 	printf '%s\n' "$boundary"
 )
 
 select_nearest_plan_boundary () (
 	candidates=$1
 	tip=$2
+	root_name=${3:-}
 	selected_name=
 	selected_boundary=
 	while IFS="$tab" read -r name boundary
@@ -2150,8 +2157,15 @@ select_nearest_plan_boundary () (
 		fi
 		if test "$boundary" = "$selected_boundary"
 		then
-			test "$name" = "$selected_name" ||
+			# An upstreamed topic can share the lane root commit.
+			if test "$name" = "$root_name"
+			then
+				selected_name=$name
+			elif test "$selected_name" != "$root_name" &&
+			     test "$name" != "$selected_name"
+			then
 				die "pinned topic has two equally near prerequisites '$selected_name' and '$name'"
+			fi
 			continue
 		fi
 		if git merge-base --is-ancestor "$selected_boundary" \
@@ -2181,7 +2195,7 @@ infer_added_plan_boundary () (
 	candidates=$tmp_dir/add-boundary-candidates
 	: >"$candidates"
 	if boundary=$(pinned_root_boundary "$current_base" \
-		"$published_base" "$tip")
+		"$published_base" "$tip" "$lane_base")
 	then
 		printf '%s\t%s\n' "$lane_base" "$boundary" >>"$candidates"
 	fi
@@ -2193,7 +2207,7 @@ infer_added_plan_boundary () (
 			printf '%s\t%s\n' "$name" "$generated_tip" \
 				>>"$candidates"
 	done <"$rows"
-	select_nearest_plan_boundary "$candidates" "$tip" ||
+	select_nearest_plan_boundary "$candidates" "$tip" "$lane_base" ||
 		die "new pinned topic is not based on a unique lane boundary"
 )
 
@@ -2216,7 +2230,7 @@ infer_altered_plan_boundary () (
 	if test "$prerequisite" = "$lane_base"
 	then
 		if boundary=$(pinned_root_boundary "$current_base" \
-			"$published_base" "$tip")
+			"$published_base" "$tip" "$lane_base")
 		then
 			printf '%s\t%s\n' "$prerequisite" "$boundary" \
 				>>"$candidates"

--- a/t/t9905-codex-branch.sh
+++ b/t/t9905-codex-branch.sh
@@ -10905,4 +10905,63 @@ test_expect_success SHA1 'reviewed CI image updates retain exact workflow entrie
 	)
 '
 
+test_expect_success 'new stable topics may start before the published upstream base' '
+	test_create_repo older-topic-base &&
+	(
+		cd older-topic-base &&
+		test_commit base &&
+		old_base=$(git rev-parse HEAD) &&
+		git switch -c topic &&
+		test_commit topic &&
+		topic=$(git rev-parse HEAD) &&
+		git switch master &&
+		test_commit upstream &&
+		current_base=$(git rev-parse HEAD) &&
+		sed -n "/^pinned_root_boundary () ($/,/^)/p;
+			/^select_nearest_plan_boundary () ($/,/^)/p;
+			/^infer_added_plan_boundary () ($/,/^)/p;
+			/^published_tip () ($/,/^)/p" \
+			"$codex_branch" >boundary-functions &&
+		. ./boundary-functions &&
+		die () { echo "$*" >&2; exit 1; } &&
+		base_name=master &&
+		tab=$(printf "\t") &&
+		tmp_dir=$PWD &&
+		: >rows &&
+		: >published &&
+		infer_added_plan_boundary rows published master \
+			"$current_base" "$current_base" "$topic" >actual &&
+		printf "master\t%s\n" "$old_base" >expect &&
+		test_cmp expect actual &&
+		test_expect_code 1 infer_added_plan_boundary rows published codex \
+			"$current_base" "$current_base" "$topic" 2>err &&
+		test_grep "not based on a unique lane boundary" err
+	)
+'
+
+test_expect_success 'an upstreamed topic does not compete with the lane root' '
+	(
+		cd older-topic-base &&
+		. ./boundary-functions &&
+		die () { echo "$*" >&2; exit 1; } &&
+		base_name=master &&
+		tab=$(printf "\t") &&
+		tmp_dir=$PWD &&
+		current_base=$(git rev-parse master) &&
+		printf "aa/codex/upstreamed\t%s\tmaster\n" "$current_base" >rows &&
+		cp rows published &&
+		git switch -c new-topic master &&
+		test_commit new-topic &&
+		infer_added_plan_boundary rows published master \
+			"$current_base" "$current_base" HEAD >actual &&
+		printf "master\t%s\n" "$current_base" >expect &&
+		test_cmp expect actual &&
+		printf "aa/codex/one\t%s\nbb/codex/two\t%s\n" \
+			"$(git rev-parse HEAD)" "$(git rev-parse HEAD)" >candidates &&
+		test_expect_code 1 select_nearest_plan_boundary candidates HEAD master \
+			2>err &&
+		test_grep "two equally near prerequisites" err
+	)
+'
+
 test_done


### PR DESCRIPTION
New stable topics are rejected when their upstream base predates the last release, even though existing pinned topics retain older source boundaries. Use the unique upstream merge base for stable topics and preserve the published-base requirement for preview topics. When an upstreamed topic and the lane root name the same commit, prefer the root.

This lets #95 enter the release plan at its original approved head, without rebasing its three commits.

Validation: the five selected tests in `t9905-codex-branch.sh --run=123-124,128,139-140` pass. Both new regressions fail before the fix and pass afterward, including checks that stale preview bases and genuine prerequisite ambiguity remain rejected. A local `propose-plan --no-push` succeeds for #95 at `409df2c11ff1465d7f587026ec3a0d9375c105ef`; the resulting plan also passes transition validation with the expected pin in a local fixture.

<!-- codex-thread: 01a082b7-af30-7571-9607-0a34c89f59c3 -->
