### PR TITLE
Codex plan: add dr/codex/trace2-redact-url-signatures in codex

### DIFF
--- a/codex.plan
+++ b/codex.plan
@@ -13,6 +13,7 @@
 	topic = refs/heads/tb/codex/release-tooling
 	topic = refs/heads/tb/codex/pin-ci-actions
 	topic = refs/heads/af/codex/packfile-uri-credentials
+	topic = refs/heads/dr/codex/trace2-redact-url-signatures
 
 [branch "tb/codex/automation"]
 	remote = .
@@ -89,4 +90,11 @@
 	source-ref = refs/heads/af/codex/packfile-uri-credentials
 	source-tip = 409df2c11ff1465d7f587026ec3a0d9375c105ef
 	source-base = 2c3adbb2c475981e340c79fdc5e7f4f9b5d9054e
+	merge = refs/heads/master
+
+[branch "dr/codex/trace2-redact-url-signatures"]
+	remote = .
+	source-ref = refs/heads/dr/codex/trace2-redact-url-signatures
+	source-tip = 764f04785bdeb2888365b234ae3eae2062130e8d
+	source-base = b8242b093d9e941a34460d715e3ce616a34ac3fe
 	merge = refs/heads/master


### PR DESCRIPTION
Bot-generated pinned plan transition.

- Lane: `codex`
- Action: `add`
- Topic: `refs/heads/dr/codex/trace2-redact-url-signatures`
- Source tip: `764f04785bdeb2888365b234ae3eae2062130e8d`
- Prerequisite: `refs/heads/master`
- Reviewed topic PR: `#79`

The plan blob and immutable `codex-pins/*` refs are authoritative.

<!-- codex-thread: 01a062fc-0bc2-7e72-a212-7e3df70a3cd4 -->
