### PR TITLE
fetch-pack: aggregate progress for parallel URI packs

### DIFF
--- a/Documentation/config/fetch.adoc
+++ b/Documentation/config/fetch.adoc
@@ -94,6 +94,16 @@ A value of 0 will give some reasonable default. If unset, it defaults to 1.
 For submodules, this setting can be overridden using the `submodule.fetchJobs`
 config setting.
 
+`fetch.packfileUriJobs`::
+	Specifies the maximum number of packfile URI downloads and indexers
+	to run at once. The default is 1, which preserves advertised URI
+	order.
++
+Values greater than 1 are used only when the server advertises and the
+client requests the `no-ref-delta` promise. Each URI pack is then checked
+with `index-pack --no-ref-delta` before it is accepted.
+Responses with one URI retain the serial path.
+
 `fetch.writeCommitGraph`::
 	Set to true to write a commit-graph after every `git fetch` command
 	that downloads a pack-file from a remote. Using the `--split` option,

--- a/Documentation/config/uploadpack.adoc
+++ b/Documentation/config/uploadpack.adoc
@@ -86,3 +86,14 @@ uploadpack.allowRefInWant::
 	is intended for the benefit of load-balanced servers which may
 	not have the same view of what OIDs their refs point to due to
 	replication delay.
+
+uploadpack.allowNoRefDelta::
+	If this option is set, `upload-pack` may advertise the
+	`no-ref-delta` feature of the protocol version 2 `fetch`
+	command. When a client requests the feature, `upload-pack` passes
+	`--no-ref-delta` to `pack-objects` for the inline pack and promises
+	that every pack named in a `packfile-uris` response section also
+	contains no `REF_DELTA` entries. `upload-pack` does not inspect
+	configured URI packs, so the server administrator must create each
+	pack with `pack-objects --no-ref-delta` or otherwise verify this
+	property. The default is `false`.

--- a/Documentation/git-http-fetch.adoc
+++ b/Documentation/git-http-fetch.adoc
@@ -48,8 +48,9 @@ commit-id::
 	line (which is not expected in
 	this case), 'git http-fetch' fetches the packfile directly at the given
 	URL and uses index-pack to generate corresponding .idx and .keep files.
-	The hash is used to determine the name of the temporary file and is
-	arbitrary. The output of index-pack is printed to stdout. Requires
+	The hash is used to determine the name of the temporary file. It need
+	not be the pack hash, but it must uniquely identify the pack contents
+	for resumption. The output of index-pack is printed to stdout. Requires
 	one or more --index-pack-arg options.
 
 --index-pack-arg=<arg>::

--- a/Documentation/git-http-fetch.adoc
+++ b/Documentation/git-http-fetch.adoc
@@ -50,11 +50,12 @@ commit-id::
 	URL and uses index-pack to generate corresponding .idx and .keep files.
 	The hash is used to determine the name of the temporary file and is
 	arbitrary. The output of index-pack is printed to stdout. Requires
-	--index-pack-args.
+	one or more --index-pack-arg options.
 
---index-pack-args=<args>::
-	For internal use only. The command to run on the contents of the
-	downloaded pack. Arguments are URL-encoded separated by spaces.
+--index-pack-arg=<arg>::
+	For internal use only. The first instance specifies the command run on
+	the contents of the downloaded pack. Subsequent instances specify its
+	arguments.
 
 --recover::
 	Verify that everything reachable from target is fetched.  Used after

--- a/Documentation/git-http-fetch.adoc
+++ b/Documentation/git-http-fetch.adoc
@@ -58,6 +58,12 @@ commit-id::
 	the contents of the downloaded pack. Subsequent instances specify its
 	arguments.
 
+--report-progress::
+	For internal use only. With --packfile, report the cumulative number
+	of bytes received as `bytes <count>` lines on stdout, before the
+	index-pack output. Bytes already present in a resumed download are
+	not included.
+
 --recover::
 	Verify that everything reachable from target is fetched.  Used after
 	an earlier fetch is interrupted.

--- a/Documentation/git-index-pack.adoc
+++ b/Documentation/git-index-pack.adoc
@@ -9,8 +9,10 @@ git-index-pack - Build pack index file for an existing packed archive
 SYNOPSIS
 --------
 [verse]
-'git index-pack' [-v] [-o <index-file>] [--[no-]rev-index] <pack-file>
-'git index-pack' --stdin [--fix-thin] [--keep] [-v] [-o <index-file>]
+'git index-pack' [-v] [-o <index-file>] [--no-ref-delta]
+		[--[no-]rev-index] <pack-file>
+'git index-pack' --stdin [--fix-thin] [--keep] [--no-ref-delta]
+		[-v] [-o <index-file>]
 		  [--[no-]rev-index] [<pack-file>]
 
 
@@ -59,6 +61,11 @@ OPTIONS
 	linkgit:git-pack-objects[1] for details) by adding the
 	excluded objects the deltified objects are based on to the
 	pack. This option only makes sense in conjunction with --stdin.
+
+--no-ref-delta::
+	Reject a pack containing a `REF_DELTA` entry. `OFS_DELTA` entries
+	are accepted. This option can be used to verify a protocol promise
+	that a pack contains no `REF_DELTA` entries.
 
 --keep::
 	Before moving the index into its final destination

--- a/Documentation/git-pack-objects.adoc
+++ b/Documentation/git-pack-objects.adoc
@@ -10,7 +10,8 @@ SYNOPSIS
 --------
 [verse]
 'git pack-objects' [-q | --progress | --all-progress] [--all-progress-implied]
-		   [--no-reuse-delta] [--delta-base-offset] [--non-empty]
+		   [--no-reuse-delta] [--delta-base-offset] [--no-ref-delta]
+		   [--non-empty]
 		   [--local] [--incremental] [--window=<n>] [--depth=<n>]
 		   [--revs [--unpacked | --all]] [--keep-pack=<pack-name>]
 		   [--cruft] [--cruft-expiration=<time>]
@@ -296,6 +297,11 @@ Note: Porcelain commands such as `git gc` (see linkgit:git-gc[1]),
 `git repack` (see linkgit:git-repack[1]) pass this option by default
 in modern Git when they put objects in your repository into pack files.
 So does `git bundle` (see linkgit:git-bundle[1]) when it creates a bundle.
+
+--no-ref-delta::
+	Do not emit deltas which represent their base by their literal
+	object ID. This is independent of `--delta-base-offset`;
+	without that option, no deltas are emitted.
 
 --threads=<n>::
 	Specifies the number of threads to spawn when searching for best

--- a/Documentation/gitprotocol-capabilities.adoc
+++ b/Documentation/gitprotocol-capabilities.adoc
@@ -34,9 +34,9 @@ were sent.  Server MUST NOT ignore capabilities that client requested
 and server advertised.  As a consequence of these rules, server MUST
 NOT advertise capabilities it does not understand.
 
-The 'atomic', 'report-status', 'report-status-v2', 'delete-refs', 'quiet',
-and 'push-cert' capabilities are sent and recognized by the receive-pack
-(push to server) process.
+The 'atomic', 'report-status', 'report-status-v2', 'delete-refs',
+'no-ref-delta', 'quiet', and 'push-cert' capabilities are sent and
+recognized by the receive-pack (push to server) process.
 
 The 'ofs-delta' and 'side-band-64k' capabilities are sent and recognized
 by both upload-pack and receive-pack protocols.  The 'agent' and 'session-id'
@@ -173,6 +173,17 @@ ofs-delta
 The server can send, and the client can understand, PACKv2 with delta referring to
 its base by position in pack rather than by an obj-id.  That is, they can
 send/read OBJ_OFS_DELTA (aka type 6) in a packfile.
+
+no-ref-delta
+------------
+
+The receive-pack server can request, and the client can send, PACKv2
+without deltas referring to their bases by an obj-id. That is, the
+client MUST NOT send OBJ_REF_DELTA (aka type 7) in a packfile when the
+server advertises this capability.
+
+This does not imply that the server understands OBJ_OFS_DELTA entries;
+that is negotiated separately with the 'ofs-delta' capability.
 
 agent
 -----

--- a/Documentation/gitprotocol-capabilities.adoc
+++ b/Documentation/gitprotocol-capabilities.adoc
@@ -185,6 +185,10 @@ server advertises this capability.
 This does not imply that the server understands OBJ_OFS_DELTA entries;
 that is negotiated separately with the 'ofs-delta' capability.
 
+Protocol v2 `fetch` uses the same name for the corresponding
+upload-pack request. There, the promise covers both the inline pack and
+any packs named by a `packfile-uris` section.
+
 agent
 -----
 

--- a/Documentation/gitprotocol-v2.adoc
+++ b/Documentation/gitprotocol-v2.adoc
@@ -376,6 +376,18 @@ to the server.
 	client should download from all given URIs. Currently, the
 	protocols supported are "http" and "https".
 
+If the 'no-ref-delta' feature is advertised, the following argument can
+be included in the client's request:
+
+    no-ref-delta
+	Indicates that the server MUST NOT include a `REF_DELTA` entry in
+	the inline `packfile` section or any pack named by a
+	`packfile-uris` section.
++
+`no-ref-delta` does not imply `ofs-delta`. The server may use `OFS_DELTA`
+only when the client also requests `ofs-delta`. By definition, an
+`OFS_DELTA` refers to an earlier entry in the same pack.
+
 If the 'wait-for-done' feature is advertised, the following argument
 can be included in the client's request.
 

--- a/Documentation/technical/packfile-uri.adoc
+++ b/Documentation/technical/packfile-uri.adoc
@@ -25,6 +25,13 @@ Clients should then download and index all the given URIs (in addition to
 downloading and indexing the packfile given in the `packfile` section of the
 response) before performing the connectivity check.
 
+URI packs are normally indexed in advertised order, since a later pack may
+contain a `REF_DELTA` whose base is installed by an earlier response pack.
+If the server advertises `no-ref-delta` and the client requests it, the
+promise covers the inline pack and every URI pack. A client may then index
+URI packs concurrently, while rejecting any pack that contains a
+`REF_DELTA`.
+
 Server design
 -------------
 

--- a/builtin/index-pack.c
+++ b/builtin/index-pack.c
@@ -33,7 +33,7 @@
 #include "strvec.h"
 
 static const char index_pack_usage[] =
-"git index-pack [-v] [-o <index-file>] [--keep | --keep=<msg>] [--[no-]rev-index] [--verify] [--strict[=<msg-id>=<severity>...]] [--fsck-objects[=<msg-id>=<severity>...]] (<pack-file> | --stdin [--fix-thin] [<pack-file>])";
+"git index-pack [-v] [-o <index-file>] [--keep | --keep=<msg>] [--[no-]rev-index] [--verify] [--strict[=<msg-id>=<severity>...]] [--fsck-objects[=<msg-id>=<severity>...]] [--no-ref-delta] (<pack-file> | --stdin [--fix-thin] [<pack-file>])";
 
 struct object_entry {
 	struct pack_idx_entry idx;
@@ -138,6 +138,7 @@ static int strict;
 static int do_fsck_object;
 static struct fsck_options fsck_options;
 static int verbose;
+static int no_ref_delta;
 static const char *progress_title;
 static int show_resolving_progress;
 static int show_stat;
@@ -550,6 +551,9 @@ static void *unpack_raw_entry(struct object_entry *obj,
 
 	switch (obj->type) {
 	case OBJ_REF_DELTA:
+		if (no_ref_delta)
+			bad_object(obj->idx.offset,
+				   _("REF_DELTA not allowed by --no-ref-delta"));
 		oidread(ref_oid, fill(the_hash_algo->rawsz),
 			the_repository->hash_algo);
 		use(the_hash_algo->rawsz);
@@ -1937,6 +1941,8 @@ int cmd_index_pack(int argc,
 				from_stdin = 1;
 			} else if (!strcmp(arg, "--fix-thin")) {
 				fix_thin_pack = 1;
+			} else if (!strcmp(arg, "--no-ref-delta")) {
+				no_ref_delta = 1;
 			} else if (skip_to_optional_arg(arg, "--strict", &arg)) {
 				strict = 1;
 				do_fsck_object = 1;

--- a/builtin/pack-objects.c
+++ b/builtin/pack-objects.c
@@ -2207,6 +2207,13 @@ static int can_reuse_delta(const struct object_id *base_oid,
 	 */
 	base = packlist_find(&to_pack, base_oid);
 	if (base) {
+		/*
+		 * A preferred base is omitted from the resulting pack, so it
+		 * can only be referenced by object ID.
+		 */
+		if (base->preferred_base && !allow_ref_delta)
+			return 0;
+
 		if (!in_same_island(&delta->idx.oid, &base->idx.oid))
 			return 0;
 		*base_out = base;
@@ -2218,7 +2225,8 @@ static int can_reuse_delta(const struct object_id *base_oid,
 	 * even if it was buried too deep in history to make it into the
 	 * packing list.
 	 */
-	if (thin && bitmap_has_oid_in_uninteresting(bitmap_git, base_oid)) {
+	if (allow_ref_delta && thin &&
+	    bitmap_has_oid_in_uninteresting(bitmap_git, base_oid)) {
 		if (use_delta_islands) {
 			if (!in_same_island(&delta->idx.oid, base_oid))
 				return 0;
@@ -4716,7 +4724,7 @@ static int pack_options_allow_reuse(void)
 	       !ignore_packed_keep_on_disk &&
 	       !ignore_packed_keep_in_core &&
 	       (!local || !have_non_local_packs) &&
-	       !incremental && allow_ref_delta;
+	       !incremental && (allow_ref_delta || allow_ofs_delta);
 }
 
 static int get_object_list_from_bitmap(struct rev_info *revs)
@@ -4738,7 +4746,8 @@ static int get_object_list_from_bitmap(struct rev_info *revs)
 						   &reuse_packfiles,
 						   &reuse_packfiles_nr,
 						   &reuse_packfile_bitmap,
-						   allow_pack_reuse == MULTI_PACK_REUSE);
+						   allow_pack_reuse == MULTI_PACK_REUSE,
+						   allow_ref_delta);
 
 	if (reuse_packfiles) {
 		reuse_packfile_objects = bitmap_popcount(reuse_packfile_bitmap);
@@ -5369,7 +5378,7 @@ int cmd_pack_objects(int argc,
 	if (unpack_unreachable || keep_unreachable || pack_loose_unreachable)
 		use_internal_rev_list = 1;
 
-	if (!reuse_object || !allow_ref_delta)
+	if (!reuse_object || (!allow_ref_delta && !allow_ofs_delta))
 		reuse_delta = 0;
 	if (cfg->pack_compression_level == -1)
 		cfg->pack_compression_level = Z_DEFAULT_COMPRESSION;

--- a/builtin/pack-objects.c
+++ b/builtin/pack-objects.c
@@ -191,7 +191,8 @@ static inline void oe_set_delta_size(struct packing_data *pack,
 
 static const char *const pack_usage[] = {
 	N_("git pack-objects [-q | --progress | --all-progress] [--all-progress-implied]\n"
-	   "                 [--no-reuse-delta] [--delta-base-offset] [--non-empty]\n"
+	   "                 [--no-reuse-delta] [--delta-base-offset] [--no-ref-delta]\n"
+	   "                 [--non-empty]\n"
 	   "                 [--local] [--incremental] [--window=<n>] [--depth=<n>]\n"
 	   "                 [--revs [--unpacked | --all]] [--keep-pack=<pack-name>]\n"
 	   "                 [--cruft] [--cruft-expiration=<time>]\n"
@@ -222,6 +223,7 @@ static int ignore_packed_keep_in_core;
 static int ignore_packed_keep_in_core_open;
 static int ignore_packed_keep_in_core_has_cruft;
 static int allow_ofs_delta;
+static int allow_ref_delta = 1;
 static struct pack_idx_option pack_idx_opts;
 static const char *base_name;
 static int progress = 1;
@@ -3405,6 +3407,9 @@ static int should_attempt_deltas(struct object_entry *entry)
 	if (entry->no_try_delta)
 		return 0;
 
+	if (entry->preferred_base && !allow_ref_delta)
+		return 0;
+
 	if (!entry->preferred_base) {
 		if (oe_type(entry) < 0)
 			die(_("unable to get type of object %s"),
@@ -3647,7 +3652,8 @@ static void prepare_pack(int window, int depth)
 	if (!pack_to_stdout)
 		do_check_packed_object_crc = 1;
 
-	if (!to_pack.nr_objects || !window || !depth)
+	if (!to_pack.nr_objects || !window || !depth ||
+	    (!allow_ref_delta && !allow_ofs_delta))
 		return;
 
 	if (path_walk)
@@ -4710,7 +4716,7 @@ static int pack_options_allow_reuse(void)
 	       !ignore_packed_keep_on_disk &&
 	       !ignore_packed_keep_in_core &&
 	       (!local || !have_non_local_packs) &&
-	       !incremental;
+	       !incremental && allow_ref_delta;
 }
 
 static int get_object_list_from_bitmap(struct rev_info *revs)
@@ -5163,6 +5169,8 @@ int cmd_pack_objects(int argc,
 			 N_("reuse existing objects")),
 		OPT_BOOL(0, "delta-base-offset", &allow_ofs_delta,
 			 N_("use OFS_DELTA objects")),
+		OPT_BOOL(0, "ref-delta", &allow_ref_delta,
+			 N_("use REF_DELTA objects")),
 		OPT_INTEGER(0, "threads", &delta_search_threads,
 			    N_("use threads when searching for best delta matches")),
 		OPT_BOOL(0, "non-empty", &non_empty,
@@ -5361,7 +5369,7 @@ int cmd_pack_objects(int argc,
 	if (unpack_unreachable || keep_unreachable || pack_loose_unreachable)
 		use_internal_rev_list = 1;
 
-	if (!reuse_object)
+	if (!reuse_object || !allow_ref_delta)
 		reuse_delta = 0;
 	if (cfg->pack_compression_level == -1)
 		cfg->pack_compression_level = Z_DEFAULT_COMPRESSION;

--- a/builtin/receive-pack.c
+++ b/builtin/receive-pack.c
@@ -65,6 +65,7 @@ static struct strbuf fsck_msg_types = STRBUF_INIT;
 static int receive_unpack_limit = -1;
 static int transfer_unpack_limit = -1;
 static int advertise_atomic_push = 1;
+static int advertise_no_ref_delta;
 static int advertise_push_options;
 static int advertise_sid;
 static int unpack_limit = 100;
@@ -287,6 +288,8 @@ static void show_ref(const char *path, const struct object_id *oid)
 			strbuf_addstr(&cap, " atomic");
 		if (prefer_ofs_delta)
 			strbuf_addstr(&cap, " ofs-delta");
+		if (advertise_no_ref_delta)
+			strbuf_addstr(&cap, " no-ref-delta");
 		if (push_cert_nonce)
 			strbuf_addf(&cap, " push-cert=%s", push_cert_nonce);
 		if (advertise_push_options)
@@ -2629,6 +2632,8 @@ int cmd_receive_pack(int argc,
 		OPT_HIDDEN_BOOL(0, "http-backend-info-refs", &advertise_refs, NULL),
 		OPT_ALIAS(0, "advertise-refs", "http-backend-info-refs"),
 		OPT_HIDDEN_BOOL(0, "reject-thin-pack-for-testing", &reject_thin, NULL),
+		OPT_HIDDEN_BOOL(0, "advertise-no-ref-delta-for-testing",
+				&advertise_no_ref_delta, NULL),
 		OPT_END()
 	};
 

--- a/fetch-pack.c
+++ b/fetch-pack.c
@@ -1854,9 +1854,10 @@ static struct ref *do_fetch_pack_v2(struct fetch_pack_args *args,
 	}
 
 	for (i = 0; i < packfile_uris.nr; i++) {
+		bool created_keep;
 		int j;
 		struct child_process cmd = CHILD_PROCESS_INIT;
-		char packname[GIT_MAX_HEXSZ + 1];
+		char packhash[GIT_MAX_HEXSZ + 1];
 		const char *uri = packfile_uris.items[i].string +
 			the_hash_algo->hexsz + 1;
 
@@ -1874,16 +1875,17 @@ static struct ref *do_fetch_pack_v2(struct fetch_pack_args *args,
 		if (start_command(&cmd))
 			die("fetch-pack: unable to spawn http-fetch");
 
-		if (read_in_full(cmd.out, packname, 5) < 0 ||
-		    memcmp(packname, "keep\t", 5))
-			die("fetch-pack: expected keep then TAB at start of http-fetch output");
+		if (read_in_full(cmd.out, packhash, 5) != 5 ||
+		    (memcmp(packhash, "keep\t", 5) &&
+		     memcmp(packhash, "pack\t", 5)))
+			die("fetch-pack: expected pack or keep then TAB at start of http-fetch output");
+		created_keep = !memcmp(packhash, "keep\t", 5);
 
-		if (read_in_full(cmd.out, packname,
-				 the_hash_algo->hexsz + 1) < 0 ||
-		    packname[the_hash_algo->hexsz] != '\n')
-			die("fetch-pack: expected hash then LF at end of http-fetch output");
-
-		packname[the_hash_algo->hexsz] = '\0';
+		if (read_in_full(cmd.out, packhash,
+				 the_hash_algo->hexsz + 1) != the_hash_algo->hexsz + 1 ||
+		    packhash[the_hash_algo->hexsz] != '\n')
+			die("fetch-pack: expected hash then LF in http-fetch output");
+		packhash[the_hash_algo->hexsz] = '\0';
 
 		parse_gitmodules_oids(cmd.out, &fsck_options.gitmodules_found);
 
@@ -1892,16 +1894,17 @@ static struct ref *do_fetch_pack_v2(struct fetch_pack_args *args,
 		if (finish_command(&cmd))
 			die("fetch-pack: unable to finish http-fetch");
 
-		if (memcmp(packfile_uris.items[i].string, packname,
+		if (memcmp(packfile_uris.items[i].string, packhash,
 			   the_hash_algo->hexsz))
 			die("fetch-pack: pack downloaded from %s does not match expected hash %.*s",
 			    uri, (int) the_hash_algo->hexsz,
 			    packfile_uris.items[i].string);
 
-		string_list_append_nodup(pack_lockfiles,
-					 xstrfmt("%s/pack/pack-%s.keep",
-						 repo_get_object_directory(the_repository),
-						 packname));
+		if (created_keep)
+			string_list_append_nodup(pack_lockfiles,
+						 xstrfmt("%s/pack/pack-%s.keep",
+							 repo_get_object_directory(the_repository),
+							 packhash));
 	}
 	string_list_clear(&packfile_uris, 0);
 	strvec_clear(&index_pack_args);

--- a/fetch-pack.c
+++ b/fetch-pack.c
@@ -49,6 +49,7 @@ static int fetch_fsck_objects = -1;
 static int transfer_fsck_objects = -1;
 static int agent_supported;
 static int server_supports_filtering;
+static int fetch_packfile_uri_jobs = 1;
 static struct shallow_lock shallow_lock;
 static const char *alternate_shallow_file;
 static struct strbuf fsck_msg_types = STRBUF_INIT;
@@ -960,6 +961,7 @@ static void add_index_pack_keep_option(struct strvec *args)
 static int get_pack(struct fetch_pack_args *args,
 		    int xd[2], struct string_list *pack_lockfiles,
 		    struct strvec *index_pack_args,
+		    int no_ref_delta,
 		    struct ref **sought, int nr_sought,
 		    struct oidset *gitmodules_oids)
 {
@@ -988,7 +990,8 @@ static int get_pack(struct fetch_pack_args *args,
 	else
 		demux.out = xd[0];
 
-	if (!args->keep_pack && unpack_limit && !index_pack_args) {
+	if (!args->keep_pack && unpack_limit && !index_pack_args &&
+	    !no_ref_delta) {
 
 		if (read_pack_header(demux.out, &header))
 			die(_("protocol error: bad pack header"));
@@ -1006,12 +1009,15 @@ static int get_pack(struct fetch_pack_args *args,
 
 	fsck_objects = fetch_pack_fsck_objects();
 
-	if (do_keep || args->from_promisor || index_pack_args || fsck_objects) {
+	if (do_keep || args->from_promisor || index_pack_args ||
+	    no_ref_delta || fsck_objects) {
 		if (pack_lockfiles || fsck_objects)
 			cmd.out = -1;
 		cmd_name = "index-pack";
 		strvec_push(&cmd.args, cmd_name);
 		strvec_push(&cmd.args, "--stdin");
+		if (no_ref_delta)
+			strvec_push(&cmd.args, "--no-ref-delta");
 		if (!args->quiet && !args->no_progress)
 			strvec_push(&cmd.args, "-v");
 		if (args->use_thin_pack)
@@ -1264,7 +1270,7 @@ static struct ref *do_fetch_pack(struct fetch_pack_args *args,
 		alternate_shallow_file = NULL;
 
 	fsck_options_init(&fsck_options, the_repository, FSCK_OPTIONS_MISSING_GITMODULES);
-	if (get_pack(args, fd, pack_lockfiles, NULL, sought, nr_sought,
+	if (get_pack(args, fd, pack_lockfiles, NULL, 0, sought, nr_sought,
 		     &fsck_options.gitmodules_found))
 		die(_("git fetch-pack: fetch failed."));
 	if (fsck_finish(&fsck_options))
@@ -1380,7 +1386,8 @@ static int send_fetch_request(struct fetch_negotiator *negotiator, int fd_out,
 			      const struct ref *wants, struct oidset *common,
 			      int *haves_to_send, int *in_vain,
 			      int sideband_all, int seen_ack,
-			      struct oidset *negotiation_include_oids)
+			      struct oidset *negotiation_include_oids,
+			      int *no_ref_delta)
 {
 	int haves_added;
 	int done_sent = 0;
@@ -1425,6 +1432,12 @@ static int send_fetch_request(struct fetch_negotiator *negotiator, int fd_out,
 		if (to_send.len) {
 			packet_buf_write(&req_buf, "packfile-uris %s",
 					 to_send.buf);
+			if (fetch_packfile_uri_jobs > 1 &&
+			    server_supports_feature(
+				    "fetch", "no-ref-delta", 0)) {
+				packet_buf_write(&req_buf, "no-ref-delta");
+				*no_ref_delta = 1;
+			}
 			strbuf_release(&to_send);
 		}
 	}
@@ -1643,14 +1656,176 @@ static void receive_packfile_uris(struct packet_reader *reader,
 {
 	process_section_header(reader, "packfile-uris", 0);
 	while (packet_reader_read(reader) == PACKET_READ_NORMAL) {
-		if (reader->pktlen < the_hash_algo->hexsz ||
-		    reader->line[the_hash_algo->hexsz] != ' ')
+		struct object_id oid;
+		const char *end;
+
+		if (parse_oid_hex(reader->line, &oid, &end) || *end != ' ')
 			die("expected '<hash> <uri>', got: %s", reader->line);
 
 		string_list_append(uris, reader->line);
 	}
 	if (reader->status != PACKET_READ_DELIM)
 		die("expected DELIM");
+}
+
+static int index_pack_arg_is_keep(const char *arg)
+{
+	const char *suffix;
+
+	return skip_prefix(arg, "--keep", &suffix) &&
+		(!*suffix || *suffix == '=');
+}
+
+static int index_pack_args_have_keep(struct strvec *index_pack_args)
+{
+	for (size_t i = 0; i < index_pack_args->nr; i++)
+		if (index_pack_arg_is_keep(index_pack_args->v[i]))
+			return 1;
+
+	return 0;
+}
+
+static void precreate_packfile_uri_keep(const struct object_id *oid,
+					struct string_list *pack_lockfiles)
+{
+	struct strbuf keep = STRBUF_INIT;
+	int keep_fd;
+
+	odb_pack_name(the_repository, &keep, oid->hash, "keep");
+	keep_fd = safe_create_file_with_leading_directories(the_repository,
+							    keep.buf);
+	if (keep_fd < 0) {
+		if (errno != EEXIST)
+			die_errno("fetch-pack: unable to create URI keep");
+		strbuf_release(&keep);
+		return;
+	}
+	string_list_append_nodup(pack_lockfiles,
+				 strbuf_detach(&keep, NULL));
+	if (close(keep_fd))
+		die_errno("fetch-pack: unable to close URI keep");
+}
+
+struct packfile_uri_task {
+	struct child_process cmd;
+	struct object_id oid;
+	const char *uri;
+};
+
+static void start_packfile_uri_task(
+	struct packfile_uri_task *task, const char *entry,
+	struct strvec *index_pack_args, struct string_list *pack_lockfiles,
+	int precreate_keeps)
+{
+	if (parse_oid_hex(entry, &task->oid, &task->uri) ||
+	    *task->uri++ != ' ')
+		BUG("invalid packfile URI entry");
+	if (precreate_keeps)
+		precreate_packfile_uri_keep(&task->oid, pack_lockfiles);
+
+	child_process_init(&task->cmd);
+	strvec_push(&task->cmd.args, "http-fetch");
+	strvec_pushf(&task->cmd.args, "--packfile=%s",
+		     oid_to_hex(&task->oid));
+	for (size_t i = 0; i < index_pack_args->nr; i++) {
+		if (index_pack_arg_is_keep(index_pack_args->v[i]))
+			continue;
+		strvec_pushf(&task->cmd.args, "--index-pack-arg=%s",
+			     index_pack_args->v[i]);
+	}
+	strvec_push(&task->cmd.args, task->uri);
+	task->cmd.git_cmd = 1;
+	task->cmd.no_stdin = 1;
+	task->cmd.clean_on_exit = 1;
+	task->cmd.out = -1;
+	if (start_command(&task->cmd))
+		die("fetch-pack: unable to spawn http-fetch");
+}
+
+static void finish_packfile_uri_task(struct packfile_uri_task *task,
+				     struct oidset *gitmodules_oids)
+{
+	char packhash[GIT_MAX_HEXSZ + 1];
+	struct object_id oid;
+
+	if (read_in_full(task->cmd.out, packhash, 5) != 5 ||
+	    memcmp(packhash, "pack\t", 5))
+		die("fetch-pack: expected pack then TAB at start of http-fetch output");
+	if (read_in_full(task->cmd.out, packhash,
+			 the_hash_algo->hexsz + 1) != the_hash_algo->hexsz + 1 ||
+	    packhash[the_hash_algo->hexsz] != '\n')
+		die("fetch-pack: expected hash then LF in http-fetch output");
+	packhash[the_hash_algo->hexsz] = '\0';
+	if (get_oid_hex(packhash, &oid))
+		die("fetch-pack: expected hash then LF in http-fetch output");
+
+	parse_gitmodules_oids(task->cmd.out, gitmodules_oids);
+	close(task->cmd.out);
+	task->cmd.out = -1;
+
+	if (finish_command(&task->cmd))
+		die("fetch-pack: unable to finish http-fetch");
+	if (!oideq(&task->oid, &oid))
+		die("fetch-pack: pack downloaded from %s does not match expected hash %s",
+		    task->uri, oid_to_hex(&task->oid));
+}
+
+static void fetch_packfile_uris_parallel(
+	struct string_list *uris, struct strvec *index_pack_args,
+	struct string_list *pack_lockfiles, struct oidset *gitmodules_oids)
+{
+	size_t task_nr = uris->nr;
+	struct packfile_uri_task *tasks;
+	struct pollfd *pollfds;
+	int precreate_keeps = index_pack_args_have_keep(index_pack_args);
+	size_t next = 0, running = 0;
+
+	if (task_nr > (size_t)fetch_packfile_uri_jobs)
+		task_nr = fetch_packfile_uri_jobs;
+	CALLOC_ARRAY(tasks, task_nr);
+	CALLOC_ARRAY(pollfds, task_nr);
+
+	for (; next < task_nr; next++)
+		start_packfile_uri_task(&tasks[next],
+					uris->items[next].string, index_pack_args,
+					pack_lockfiles, precreate_keeps);
+	running = next;
+
+	while (running) {
+		size_t ready = task_nr;
+		int ret;
+
+		for (size_t i = 0; i < task_nr; i++) {
+			pollfds[i].fd = tasks[i].cmd.out;
+			pollfds[i].events = POLLIN | POLLHUP;
+		}
+		do
+			ret = poll(pollfds, task_nr, -1);
+		while (ret < 0 && errno == EINTR);
+		if (ret < 0)
+			die_errno("fetch-pack: unable to poll http-fetch");
+		for (size_t i = 0; i < task_nr; i++) {
+			if (pollfds[i].revents) {
+				ready = i;
+				break;
+			}
+		}
+		if (ready == task_nr)
+			BUG("poll returned without a ready http-fetch");
+
+		finish_packfile_uri_task(&tasks[ready], gitmodules_oids);
+		if (next < uris->nr) {
+			start_packfile_uri_task(&tasks[ready],
+						uris->items[next].string,
+						index_pack_args, pack_lockfiles,
+						precreate_keeps);
+			next++;
+		} else
+			running--;
+	}
+
+	free(pollfds);
+	free(tasks);
 }
 
 enum fetch_state {
@@ -1691,8 +1866,9 @@ static struct ref *do_fetch_pack_v2(struct fetch_pack_args *args,
 	int seen_ack = 0;
 	struct object_id common_oid;
 	int received_ready = 0;
+	int no_ref_delta = 0;
 	struct string_list packfile_uris = STRING_LIST_INIT_DUP;
-	int i;
+	int parallel_uri_indexing;
 	struct strvec index_pack_args = STRVEC_INIT;
 	const char *promisor_remote_config;
 
@@ -1777,7 +1953,8 @@ static struct ref *do_fetch_pack_v2(struct fetch_pack_args *args,
 					       &haves_to_send, &in_vain,
 					       reader.use_sideband,
 					       seen_ack,
-					       &negotiation_include_oids)) {
+					       &negotiation_include_oids,
+					       &no_ref_delta)) {
 				trace2_region_leave_printf("negotiation_v2", "round",
 							   the_repository, "%d",
 							   negotiation_round);
@@ -1842,6 +2019,7 @@ static struct ref *do_fetch_pack_v2(struct fetch_pack_args *args,
 
 			if (get_pack(args, fd, pack_lockfiles,
 				     packfile_uris.nr ? &index_pack_args : NULL,
+				     no_ref_delta,
 				     sought, nr_sought, &fsck_options.gitmodules_found))
 				die(_("git fetch-pack: fetch failed."));
 			do_check_stateless_delimiter(args->stateless_rpc, &reader);
@@ -1853,9 +2031,25 @@ static struct ref *do_fetch_pack_v2(struct fetch_pack_args *args,
 		}
 	}
 
-	for (i = 0; i < packfile_uris.nr; i++) {
+	parallel_uri_indexing = no_ref_delta &&
+		pack_lockfiles &&
+		fetch_packfile_uri_jobs > 1 &&
+		packfile_uris.nr > 1;
+	if (parallel_uri_indexing) {
+		/*
+		 * Bound total indexer threads by the number of URI jobs. The
+		 * URI packs are independent, so each indexer can stay single
+		 * threaded while several indexers run at once.
+		 */
+		strvec_push(&index_pack_args, "--threads=1");
+		fetch_packfile_uris_parallel(&packfile_uris, &index_pack_args,
+					    pack_lockfiles,
+					    &fsck_options.gitmodules_found);
+		goto packfile_uris_done;
+	}
+
+	for (size_t i = 0; i < packfile_uris.nr; i++) {
 		bool created_keep;
-		int j;
 		struct child_process cmd = CHILD_PROCESS_INIT;
 		char packhash[GIT_MAX_HEXSZ + 1];
 		const char *uri = packfile_uris.items[i].string +
@@ -1865,7 +2059,7 @@ static struct ref *do_fetch_pack_v2(struct fetch_pack_args *args,
 		strvec_pushf(&cmd.args, "--packfile=%.*s",
 			     (int) the_hash_algo->hexsz,
 			     packfile_uris.items[i].string);
-		for (j = 0; j < index_pack_args.nr; j++)
+		for (size_t j = 0; j < index_pack_args.nr; j++)
 			strvec_pushf(&cmd.args, "--index-pack-arg=%s",
 				     index_pack_args.v[j]);
 		strvec_push(&cmd.args, uri);
@@ -1906,6 +2100,8 @@ static struct ref *do_fetch_pack_v2(struct fetch_pack_args *args,
 							 repo_get_object_directory(the_repository),
 							 packhash));
 	}
+
+packfile_uris_done:
 	string_list_clear(&packfile_uris, 0);
 	strvec_clear(&index_pack_args);
 
@@ -1956,6 +2152,12 @@ static int fetch_pack_config_cb(const char *var, const char *value,
 				const struct config_context *ctx, void *cb)
 {
 	int ret = fetch_pack_fsck_config(var, value, &fsck_msg_types);
+
+	if (!strcmp(var, "fetch.packfileurijobs")) {
+		fetch_packfile_uri_jobs = git_config_int(var, value, ctx->kvi);
+		return 0;
+	}
+
 	if (ret > 0)
 		return git_default_config(var, value, ctx, cb);
 

--- a/fetch-pack.c
+++ b/fetch-pack.c
@@ -37,6 +37,7 @@
 #include "mergesort.h"
 #include "prio-queue.h"
 #include "promisor-remote.h"
+#include "progress.h"
 
 static int transfer_unpack_limit = -1;
 static int fetch_unpack_limit = -1;
@@ -1708,6 +1709,9 @@ static void precreate_packfile_uri_keep(const struct object_id *oid,
 
 struct packfile_uri_task {
 	struct child_process cmd;
+	struct strbuf output;
+	uint64_t bytes;
+	int got_pack;
 	struct object_id oid;
 	const char *uri;
 };
@@ -1715,7 +1719,7 @@ struct packfile_uri_task {
 static void start_packfile_uri_task(
 	struct packfile_uri_task *task, const char *entry,
 	struct strvec *index_pack_args, struct string_list *pack_lockfiles,
-	int precreate_keeps)
+	int precreate_keeps, int progress)
 {
 	if (parse_oid_hex(entry, &task->oid, &task->uri) ||
 	    *task->uri++ != ' ')
@@ -1724,11 +1728,17 @@ static void start_packfile_uri_task(
 		precreate_packfile_uri_keep(&task->oid, pack_lockfiles);
 
 	child_process_init(&task->cmd);
+	strbuf_init(&task->output, 0);
+	task->bytes = 0;
+	task->got_pack = 0;
 	strvec_push(&task->cmd.args, "http-fetch");
+	if (progress)
+		strvec_push(&task->cmd.args, "--report-progress");
 	strvec_pushf(&task->cmd.args, "--packfile=%s",
 		     oid_to_hex(&task->oid));
 	for (size_t i = 0; i < index_pack_args->nr; i++) {
-		if (index_pack_arg_is_keep(index_pack_args->v[i]))
+		if (index_pack_arg_is_keep(index_pack_args->v[i]) ||
+		    !strcmp(index_pack_args->v[i], "-v"))
 			continue;
 		strvec_pushf(&task->cmd.args, "--index-pack-arg=%s",
 			     index_pack_args->v[i]);
@@ -1738,91 +1748,163 @@ static void start_packfile_uri_task(
 	task->cmd.no_stdin = 1;
 	task->cmd.clean_on_exit = 1;
 	task->cmd.out = -1;
+	task->cmd.err = -1;
 	if (start_command(&task->cmd))
 		die("fetch-pack: unable to spawn http-fetch");
 }
 
-static void finish_packfile_uri_task(struct packfile_uri_task *task,
-				     struct oidset *gitmodules_oids)
+static void read_packfile_uri_task(struct packfile_uri_task *task,
+				   struct oidset *gitmodules_oids,
+				   uint64_t *total_bytes)
 {
-	char packhash[GIT_MAX_HEXSZ + 1];
-	struct object_id oid;
+	char *eol;
+	size_t consumed = 0;
+	ssize_t n = strbuf_read_once(&task->output, task->cmd.out, 0);
 
-	if (read_in_full(task->cmd.out, packhash, 5) != 5 ||
-	    memcmp(packhash, "pack\t", 5))
-		die("fetch-pack: expected pack then TAB at start of http-fetch output");
-	if (read_in_full(task->cmd.out, packhash,
-			 the_hash_algo->hexsz + 1) != the_hash_algo->hexsz + 1 ||
-	    packhash[the_hash_algo->hexsz] != '\n')
-		die("fetch-pack: expected hash then LF in http-fetch output");
-	packhash[the_hash_algo->hexsz] = '\0';
-	if (get_oid_hex(packhash, &oid))
-		die("fetch-pack: expected hash then LF in http-fetch output");
+	if (n < 0)
+		die_errno("fetch-pack: unable to read http-fetch output");
+	if (!n) {
+		close(task->cmd.out);
+		task->cmd.out = -1;
+	}
 
-	parse_gitmodules_oids(task->cmd.out, gitmodules_oids);
-	close(task->cmd.out);
-	task->cmd.out = -1;
+	while ((eol = memchr(task->output.buf + consumed, '\n',
+			     task->output.len - consumed))) {
+		const char *line = task->output.buf + consumed;
+		const char *end;
+		struct object_id oid;
 
+		*eol = '\0';
+		if (!task->got_pack && skip_prefix(line, "bytes ", &line)) {
+			char *end;
+			uint64_t bytes;
+
+			errno = 0;
+			bytes = strtoumax(line, &end, 10);
+			if (!isdigit(*line) || end != eol || errno ||
+			    bytes < task->bytes ||
+			    UINT64_MAX - *total_bytes < bytes - task->bytes)
+				die("fetch-pack: invalid download byte count");
+			*total_bytes += bytes - task->bytes;
+			task->bytes = bytes;
+		} else {
+			if (!task->got_pack && !skip_prefix(line, "pack\t", &line))
+				die("fetch-pack: expected pack then TAB at start of http-fetch output");
+			if (parse_oid_hex(line, &oid, &end) || end != eol)
+				die("fetch-pack: invalid hash in http-fetch output");
+			if (task->got_pack)
+				oidset_insert(gitmodules_oids, &oid);
+			else if (!oideq(&task->oid, &oid))
+				die("fetch-pack: pack downloaded from %s does not match expected hash %s",
+				    task->uri, oid_to_hex(&task->oid));
+			task->got_pack = 1;
+		}
+		consumed = eol - task->output.buf + 1;
+	}
+	strbuf_remove(&task->output, 0, consumed);
+	if (task->output.len > GIT_MAX_HEXSZ + 5)
+		die("fetch-pack: invalid http-fetch output");
+}
+
+static void finish_packfile_uri_task(struct packfile_uri_task *task)
+{
 	if (finish_command(&task->cmd))
 		die("fetch-pack: unable to finish http-fetch");
-	if (!oideq(&task->oid, &oid))
-		die("fetch-pack: pack downloaded from %s does not match expected hash %s",
-		    task->uri, oid_to_hex(&task->oid));
+	if (!task->got_pack || task->output.len)
+		die("fetch-pack: incomplete http-fetch output");
+	strbuf_release(&task->output);
 }
 
 static void fetch_packfile_uris_parallel(
 	struct string_list *uris, struct strvec *index_pack_args,
-	struct string_list *pack_lockfiles, struct oidset *gitmodules_oids)
+	struct string_list *pack_lockfiles, struct oidset *gitmodules_oids,
+	int show_progress)
 {
 	size_t task_nr = uris->nr;
 	struct packfile_uri_task *tasks;
 	struct pollfd *pollfds;
 	int precreate_keeps = index_pack_args_have_keep(index_pack_args);
-	size_t next = 0, running = 0;
+	size_t next = 0, running = 0, completed = 0;
+	uint64_t total_bytes = 0;
+	struct progress *progress = NULL;
+	int diagnostic_incomplete = 0;
+
+	if (show_progress) {
+		progress = start_progress(the_repository, _("Fetching packs"), uris->nr);
+		display_throughput(progress, 0);
+		display_progress(progress, 0);
+	}
 
 	if (task_nr > (size_t)fetch_packfile_uri_jobs)
 		task_nr = fetch_packfile_uri_jobs;
 	CALLOC_ARRAY(tasks, task_nr);
-	CALLOC_ARRAY(pollfds, task_nr);
+	CALLOC_ARRAY(pollfds, 2 * task_nr);
 
 	for (; next < task_nr; next++)
 		start_packfile_uri_task(&tasks[next],
 					uris->items[next].string, index_pack_args,
-					pack_lockfiles, precreate_keeps);
+					pack_lockfiles, precreate_keeps, show_progress);
 	running = next;
 
 	while (running) {
-		size_t ready = task_nr;
 		int ret;
 
-		for (size_t i = 0; i < task_nr; i++) {
-			pollfds[i].fd = tasks[i].cmd.out;
-			pollfds[i].events = POLLIN | POLLHUP;
+		if (!diagnostic_incomplete) {
+			display_throughput(progress, total_bytes);
+			display_progress(progress, completed);
 		}
-		do
-			ret = poll(pollfds, task_nr, -1);
-		while (ret < 0 && errno == EINTR);
+
+		for (size_t i = 0; i < task_nr; i++) {
+			pollfds[2 * i].fd = tasks[i].cmd.out;
+			pollfds[2 * i + 1].fd = tasks[i].cmd.err;
+			pollfds[2 * i].events = pollfds[2 * i + 1].events = POLLIN | POLLHUP;
+		}
+		ret = poll(pollfds, 2 * task_nr, -1);
+		if (ret < 0 && errno == EINTR)
+			continue; /* Refresh progress after its timer fires. */
 		if (ret < 0)
 			die_errno("fetch-pack: unable to poll http-fetch");
 		for (size_t i = 0; i < task_nr; i++) {
-			if (pollfds[i].revents) {
-				ready = i;
-				break;
-			}
-		}
-		if (ready == task_nr)
-			BUG("poll returned without a ready http-fetch");
+			struct packfile_uri_task *task = &tasks[i];
 
-		finish_packfile_uri_task(&tasks[ready], gitmodules_oids);
-		if (next < uris->nr) {
-			start_packfile_uri_task(&tasks[ready],
-						uris->items[next].string,
+			if (!pollfds[2 * i].revents && !pollfds[2 * i + 1].revents)
+				continue;
+			if (pollfds[2 * i + 1].revents) {
+				char buf[8192];
+				ssize_t n = xread(task->cmd.err, buf, sizeof(buf));
+
+				if (n < 0)
+					die_errno("fetch-pack: unable to read http-fetch errors");
+				if (n) {
+					if (!diagnostic_incomplete)
+						clear_progress(progress);
+					write_or_die(2, buf, n);
+					diagnostic_incomplete = buf[n - 1] != '\n';
+				} else {
+					close(task->cmd.err);
+					task->cmd.err = -1;
+				}
+			}
+			if (pollfds[2 * i].revents)
+				read_packfile_uri_task(task, gitmodules_oids, &total_bytes);
+			if (task->cmd.out >= 0 || task->cmd.err >= 0)
+				continue;
+
+			finish_packfile_uri_task(task);
+			completed++;
+			if (next < uris->nr)
+				start_packfile_uri_task(task, uris->items[next++].string,
 						index_pack_args, pack_lockfiles,
-						precreate_keeps);
-			next++;
-		} else
-			running--;
+						precreate_keeps, show_progress);
+			else
+				running--;
+		}
 	}
+	if (diagnostic_incomplete)
+		fputc('\n', stderr);
+	display_throughput(progress, total_bytes);
+	display_progress(progress, completed);
+	stop_progress(&progress);
 
 	free(pollfds);
 	free(tasks);
@@ -2044,7 +2126,8 @@ static struct ref *do_fetch_pack_v2(struct fetch_pack_args *args,
 		strvec_push(&index_pack_args, "--threads=1");
 		fetch_packfile_uris_parallel(&packfile_uris, &index_pack_args,
 					    pack_lockfiles,
-					    &fsck_options.gitmodules_found);
+					    &fsck_options.gitmodules_found,
+					    !args->quiet && !args->no_progress);
 		goto packfile_uris_done;
 	}
 

--- a/http-fetch.c
+++ b/http-fetch.c
@@ -70,7 +70,8 @@ static void fetch_single_packfile(struct object_id *packfile_hash,
 
 	if (start_active_slot(preq->slot)) {
 		run_active_slot(preq->slot);
-		if (results.curl_result != CURLE_OK) {
+		if (results.curl_result != CURLE_OK &&
+		    results.http_code != 416) {
 			struct url_info url;
 			char *nurl = url_normalize(preq->url, &url);
 			if (!nurl || !git_env_bool("GIT_TRACE_REDACT", 1)) {

--- a/http-fetch.c
+++ b/http-fetch.c
@@ -155,7 +155,7 @@ int cmd_main(int argc, const char **argv)
 
 	if (packfile) {
 		if (!index_pack_args.nr)
-			die(_("the option '%s' requires '%s'"), "--packfile", "--index-pack-args");
+			die(_("the option '%s' requires '%s'"), "--packfile", "--index-pack-arg");
 
 		fetch_single_packfile(&packfile_hash, argv[arg],
 				      index_pack_args.v);
@@ -164,7 +164,7 @@ int cmd_main(int argc, const char **argv)
 	}
 
 	if (index_pack_args.nr)
-		die(_("the option '%s' requires '%s'"), "--index-pack-args", "--packfile");
+		die(_("the option '%s' requires '%s'"), "--index-pack-arg", "--packfile");
 
 	if (commits_on_stdin) {
 		commits = walker_targets_stdin(&commit_id, &write_ref);

--- a/http-fetch.c
+++ b/http-fetch.c
@@ -11,6 +11,7 @@
 #include "strvec.h"
 #include "url.h"
 #include "urlmatch.h"
+#include "trace.h"
 #include "trace2.h"
 
 static const char http_fetch_usage[] = "git http-fetch "
@@ -52,11 +53,36 @@ static int fetch_using_walker(const char *raw_url, int get_verbosely,
 	return rc;
 }
 
+struct packfile_progress {
+	uint64_t bytes;
+	uint64_t last_update;
+};
+
+static void report_packfile_progress(struct packfile_progress *progress)
+{
+	printf("bytes %"PRIu64"\n", progress->bytes);
+	if (fflush(stdout))
+		die_errno("unable to report packfile download progress");
+	progress->last_update = getnanotime();
+}
+
+static void update_packfile_progress(void *data, size_t bytes)
+{
+	struct packfile_progress *progress = data;
+
+	progress->bytes += bytes;
+	if (getnanotime() - progress->last_update >= 500000000)
+		report_packfile_progress(progress);
+}
+
 static void fetch_single_packfile(struct object_id *packfile_hash,
 				  const char *url,
-				  const char **index_pack_args) {
+				  const char **index_pack_args,
+				  int report_progress)
+{
 	struct http_pack_request *preq;
 	struct slot_results results;
+	struct packfile_progress progress = { 0 };
 	int ret;
 
 	http_init(NULL, url, 0);
@@ -67,6 +93,11 @@ static void fetch_single_packfile(struct object_id *packfile_hash,
 	preq->slot->results = &results;
 	preq->index_pack_args = index_pack_args;
 	preq->preserve_index_pack_stdout = 1;
+	if (report_progress) {
+		progress.last_update = getnanotime();
+		preq->progress = update_packfile_progress;
+		preq->progress_data = &progress;
+	}
 
 	if (start_active_slot(preq->slot)) {
 		run_active_slot(preq->slot);
@@ -88,6 +119,9 @@ static void fetch_single_packfile(struct object_id *packfile_hash,
 		die("Unable to start request");
 	}
 
+	if (report_progress)
+		report_packfile_progress(&progress);
+
 	if ((ret = finish_http_pack_request(preq)))
 		die("finish_http_pack_request gave result %d", ret);
 
@@ -105,6 +139,7 @@ int cmd_main(int argc, const char **argv)
 	int get_verbosely = 0;
 	int get_recover = 0;
 	int packfile = 0;
+	int report_progress = 0;
 	int nongit;
 	struct object_id packfile_hash;
 	struct strvec index_pack_args = STRVEC_INIT;
@@ -129,6 +164,8 @@ int cmd_main(int argc, const char **argv)
 			get_recover = 1;
 		} else if (!strcmp(argv[arg], "--stdin")) {
 			commits_on_stdin = 1;
+		} else if (!strcmp(argv[arg], "--report-progress")) {
+			report_progress = 1;
 		} else if (skip_prefix(argv[arg], "--packfile=", &p)) {
 			const char *end;
 
@@ -159,10 +196,13 @@ int cmd_main(int argc, const char **argv)
 			die(_("the option '%s' requires '%s'"), "--packfile", "--index-pack-arg");
 
 		fetch_single_packfile(&packfile_hash, argv[arg],
-				      index_pack_args.v);
+				      index_pack_args.v, report_progress);
 		ret = 0;
 		goto out;
 	}
+
+	if (report_progress)
+		die(_("the option '%s' requires '%s'"), "--report-progress", "--packfile");
 
 	if (index_pack_args.nr)
 		die(_("the option '%s' requires '%s'"), "--index-pack-arg", "--packfile");

--- a/http-push.c
+++ b/http-push.c
@@ -595,7 +595,8 @@ static void finish_request(struct transfer_request *request)
 
 	} else if (request->state == RUN_FETCH_PACKED) {
 		int fail = 1;
-		if (request->curl_result != CURLE_OK) {
+		if (request->curl_result != CURLE_OK &&
+		    request->http_code != 416) {
 			fprintf(stderr, "Unable to get pack file %s\n%s",
 				request->url, curl_errorstr);
 		} else {

--- a/http-walker.c
+++ b/http-walker.c
@@ -451,7 +451,8 @@ static int http_fetch_pack(struct walker *walker, struct alt_base *repo,
 
 	if (start_active_slot(preq->slot)) {
 		run_active_slot(preq->slot);
-		if (results.curl_result != CURLE_OK) {
+		if (results.curl_result != CURLE_OK &&
+		    results.http_code != 416) {
 			error("Unable to get pack file %s\n%s", preq->url,
 			      curl_errorstr);
 			goto abort;

--- a/http.c
+++ b/http.c
@@ -2704,13 +2704,8 @@ int finish_http_pack_request(struct http_pack_request *preq)
 	else
 		ip.no_stdout = 1;
 
-	if (run_command(&ip)) {
+	if (run_command(&ip))
 		ret = -1;
-		goto cleanup;
-	}
-
-cleanup:
-	close(tmpfile_fd);
 	unlink(preq->tmpfile.buf);
 	return ret;
 }

--- a/http.c
+++ b/http.c
@@ -2746,7 +2746,22 @@ struct http_pack_request *new_direct_http_pack_request(
 
 	odb_pack_name(the_repository, &preq->tmpfile, packed_git_hash, "pack");
 	strbuf_addstr(&preq->tmpfile, ".temp");
-	fd = open(preq->tmpfile.buf, O_RDWR | O_CREAT, 0666);
+	/*
+	 * MinGW's non-append O_RDWR open grants FILE_SHARE_DELETE only for an
+	 * existing file; reopen a newly created file so others may unlink it.
+	 */
+	for (;;) {
+		fd = open(preq->tmpfile.buf, O_RDWR);
+		if (fd >= 0 || errno != ENOENT)
+			break;
+		fd = open(preq->tmpfile.buf, O_RDWR | O_CREAT | O_EXCL, 0666);
+		if (fd >= 0) {
+			close(fd);
+			continue;
+		}
+		if (errno != EEXIST)
+			break;
+	}
 	if (fd < 0) {
 		error_errno("unable to open local file %s for pack",
 			    preq->tmpfile.buf);

--- a/http.c
+++ b/http.c
@@ -2688,10 +2688,13 @@ int finish_http_pack_request(struct http_pack_request *preq)
 	int tmpfile_fd;
 	int ret = 0;
 
+	/* Another downloader may unlink the staging path while we index it. */
+	tmpfile_fd = xdup(fileno(preq->packfile));
 	fclose(preq->packfile);
 	preq->packfile = NULL;
-
-	tmpfile_fd = xopen(preq->tmpfile.buf, O_RDONLY);
+	if (lseek(tmpfile_fd, 0, SEEK_SET) < 0)
+		die_errno("unable to seek local file %s for pack",
+			  preq->tmpfile.buf);
 
 	ip.git_cmd = 1;
 	ip.in = tmpfile_fd;
@@ -2733,22 +2736,30 @@ struct http_pack_request *new_http_pack_request(
 struct http_pack_request *new_direct_http_pack_request(
 	const unsigned char *packed_git_hash, char *url)
 {
-	off_t prev_posn = 0;
+	off_t prev_posn;
 	struct http_pack_request *preq;
+	int fd;
 
 	CALLOC_ARRAY(preq, 1);
 	strbuf_init(&preq->tmpfile, 0);
-
 	preq->url = url;
 
 	odb_pack_name(the_repository, &preq->tmpfile, packed_git_hash, "pack");
 	strbuf_addstr(&preq->tmpfile, ".temp");
-	preq->packfile = fopen(preq->tmpfile.buf, "a");
-	if (!preq->packfile) {
-		error("Unable to open local file %s for pack",
-		      preq->tmpfile.buf);
+	fd = open(preq->tmpfile.buf, O_RDWR | O_CREAT, 0666);
+	if (fd < 0) {
+		error_errno("unable to open local file %s for pack",
+			    preq->tmpfile.buf);
 		goto abort;
 	}
+	prev_posn = lseek(fd, 0, SEEK_END);
+	if (prev_posn < 0) {
+		error_errno("unable to seek local file %s for pack",
+			    preq->tmpfile.buf);
+		close(fd);
+		goto abort;
+	}
+	preq->packfile = xfdopen(fd, "w");
 
 	preq->slot = get_active_slot();
 	preq->headers = object_request_headers();
@@ -2757,12 +2768,7 @@ struct http_pack_request *new_direct_http_pack_request(
 	curl_easy_setopt(preq->slot->curl, CURLOPT_URL, preq->url);
 	curl_easy_setopt(preq->slot->curl, CURLOPT_HTTPHEADER, preq->headers);
 
-	/*
-	 * If there is data present from a previous transfer attempt,
-	 * resume where it left off
-	 */
-	prev_posn = ftello(preq->packfile);
-	if (prev_posn>0) {
+	if (prev_posn > 0) {
 		if (http_is_verbose)
 			fprintf(stderr,
 				"Resuming fetch of pack %s at byte %"PRIuMAX"\n",

--- a/http.c
+++ b/http.c
@@ -2698,6 +2698,7 @@ int finish_http_pack_request(struct http_pack_request *preq)
 
 	ip.git_cmd = 1;
 	ip.in = tmpfile_fd;
+	ip.clean_on_exit = 1;
 	strvec_pushv(&ip.args, preq->index_pack_args ?
 		     preq->index_pack_args :
 		     default_index_pack_args);

--- a/http.c
+++ b/http.c
@@ -2722,6 +2722,16 @@ void http_install_packfile(struct packed_git *p,
 	packfile_store_add_pack(files->packed, p);
 }
 
+static size_t fwrite_http_pack(char *ptr, size_t size, size_t nmemb, void *data)
+{
+	struct http_pack_request *preq = data;
+	size_t written = fwrite(ptr, 1, st_mult(size, nmemb), preq->packfile);
+
+	if (preq->progress)
+		preq->progress(preq->progress_data, written);
+	return written;
+}
+
 struct http_pack_request *new_http_pack_request(
 	const unsigned char *packed_git_hash, const char *base_url) {
 
@@ -2779,8 +2789,8 @@ struct http_pack_request *new_direct_http_pack_request(
 
 	preq->slot = get_active_slot();
 	preq->headers = object_request_headers();
-	curl_easy_setopt(preq->slot->curl, CURLOPT_WRITEDATA, preq->packfile);
-	curl_easy_setopt(preq->slot->curl, CURLOPT_WRITEFUNCTION, fwrite);
+	curl_easy_setopt(preq->slot->curl, CURLOPT_WRITEDATA, preq);
+	curl_easy_setopt(preq->slot->curl, CURLOPT_WRITEFUNCTION, fwrite_http_pack);
 	curl_easy_setopt(preq->slot->curl, CURLOPT_URL, preq->url);
 	curl_easy_setopt(preq->slot->curl, CURLOPT_HTTPHEADER, preq->headers);
 

--- a/http.h
+++ b/http.h
@@ -212,6 +212,8 @@ int http_get_info_packs(const char *base_url,
 const char *http_get_accept_language_header(void);
 
 struct http_pack_request {
+	void (*progress)(void *data, size_t bytes);
+	void *progress_data;
 	char *url;
 
 	/*

--- a/pack-bitmap.c
+++ b/pack-bitmap.c
@@ -2286,7 +2286,8 @@ static int try_partial_reuse(struct bitmap_index *bitmap_git,
 			     uint32_t pack_pos,
 			     off_t offset,
 			     struct bitmap *reuse,
-			     struct pack_window **w_curs)
+			     struct pack_window **w_curs,
+			     int allow_ref_delta)
 {
 	off_t delta_obj_offset;
 	enum object_type type;
@@ -2304,6 +2305,9 @@ static int try_partial_reuse(struct bitmap_index *bitmap_git,
 		off_t base_offset;
 		uint32_t base_pos;
 		uint32_t base_bitmap_pos;
+
+		if (type == OBJ_REF_DELTA && !allow_ref_delta)
+			return 0;
 
 		/*
 		 * Find the position of the base object so we can look it up
@@ -2377,20 +2381,19 @@ static int try_partial_reuse(struct bitmap_index *bitmap_git,
 
 static void reuse_partial_packfile_from_bitmap_1(struct bitmap_index *bitmap_git,
 						 struct bitmapped_pack *pack,
-						 struct bitmap *reuse)
+						 struct bitmap *reuse,
+						 int allow_ref_delta)
 {
 	struct bitmap *result = bitmap_git->result;
 	struct pack_window *w_curs = NULL;
 	size_t pos = pack->bitmap_pos / BITS_IN_EWORD;
 
-	if (!pack->bitmap_pos) {
+	if (allow_ref_delta && !pack->bitmap_pos) {
 		/*
 		 * If we're processing the first (in the case of a MIDX, the
 		 * preferred pack) or the only (in the case of single-pack
-		 * bitmaps) pack, then we can reuse whole words at a time.
-		 *
-		 * This is because we know that any deltas in this range *must*
-		 * have their bases chosen from the same pack, since:
+		 * bitmaps) pack, then any delta in this range must have its
+		 * base chosen from the same pack:
 		 *
 		 * - In the single pack case, there is no other pack to choose
 		 *   them from.
@@ -2399,6 +2402,10 @@ static void reuse_partial_packfile_from_bitmap_1(struct bitmap_index *bitmap_git
 		 *   all ties are broken in favor of that pack (i.e. the one
 		 *   we're currently processing). So any duplicate bases will be
 		 *   resolved in favor of the pack we're processing.
+		 *
+		 * When REF_DELTAs are allowed, we can therefore reuse whole
+		 * words at a time without inspecting object headers. Otherwise,
+		 * inspect each object below to avoid reusing a REF_DELTA entry.
 		 */
 		while (pos < result->word_alloc &&
 		       pos < pack->bitmap_nr / BITS_IN_EWORD &&
@@ -2448,7 +2455,8 @@ static void reuse_partial_packfile_from_bitmap_1(struct bitmap_index *bitmap_git
 			}
 
 			if (try_partial_reuse(bitmap_git, pack, bit_pos,
-					      pack_pos, ofs, reuse, &w_curs) < 0) {
+					      pack_pos, ofs, reuse, &w_curs,
+					      allow_ref_delta) < 0) {
 				/*
 				 * try_partial_reuse indicated we couldn't reuse
 				 * any bits, so there is no point in trying more
@@ -2483,7 +2491,8 @@ void reuse_partial_packfile_from_bitmap(struct bitmap_index *bitmap_git,
 					struct bitmapped_pack **packs_out,
 					size_t *packs_nr_out,
 					struct bitmap **reuse_out,
-					int multi_pack_reuse)
+					int multi_pack_reuse,
+					int allow_ref_delta)
 {
 	struct repository *r = bitmap_repo(bitmap_git);
 	struct bitmapped_pack *packs = NULL;
@@ -2578,7 +2587,8 @@ void reuse_partial_packfile_from_bitmap(struct bitmap_index *bitmap_git,
 	reuse = bitmap_word_alloc(word_alloc);
 
 	for (i = 0; i < packs_nr; i++)
-		reuse_partial_packfile_from_bitmap_1(bitmap_git, &packs[i], reuse);
+		reuse_partial_packfile_from_bitmap_1(bitmap_git, &packs[i], reuse,
+						     allow_ref_delta);
 
 	if (bitmap_is_empty(reuse)) {
 		free(packs);

--- a/pack-bitmap.h
+++ b/pack-bitmap.h
@@ -122,7 +122,8 @@ void reuse_partial_packfile_from_bitmap(struct bitmap_index *bitmap_git,
 					struct bitmapped_pack **packs_out,
 					size_t *packs_nr_out,
 					struct bitmap **reuse_out,
-					int multi_pack_reuse);
+					int multi_pack_reuse,
+					int allow_ref_delta);
 int rebuild_existing_bitmaps(struct bitmap_index *, struct packing_data *mapping,
 			     kh_oid_map_t *reused_bitmaps, int show_progress);
 void free_bitmap_index(struct bitmap_index *);

--- a/progress.c
+++ b/progress.c
@@ -172,6 +172,20 @@ static void display(struct progress *progress, uint64_t n, const char *done)
 	}
 }
 
+/* Make room for a diagnostic without finishing the progress display. */
+void clear_progress(struct progress *progress)
+{
+	if (!progress || !progress->counters_sb.len ||
+	    !is_foreground_fd(fileno(stderr)))
+		return;
+
+	fprintf(stderr, "\r%*s\r",
+		(int)progress->counters_sb.len + 2 +
+		(progress->split ? 0 : progress->title_len), "");
+	fflush(stderr);
+	progress_update = 1;
+}
+
 static void throughput_string(struct strbuf *buf, uint64_t total,
 			      unsigned int rate)
 {

--- a/progress.h
+++ b/progress.h
@@ -14,6 +14,7 @@ void progress_test_force_update(void);
 #endif
 
 void display_throughput(struct progress *progress, uint64_t total);
+void clear_progress(struct progress *progress);
 void display_progress(struct progress *progress, uint64_t n);
 struct progress *start_progress(struct repository *r,
 				const char *title, uint64_t total);

--- a/send-pack.c
+++ b/send-pack.c
@@ -80,6 +80,8 @@ static int pack_objects(struct repository *r,
 		strvec_push(&po.args, "--thin");
 	if (args->use_ofs_delta)
 		strvec_push(&po.args, "--delta-base-offset");
+	if (args->no_ref_delta)
+		strvec_push(&po.args, "--no-ref-delta");
 	if (args->quiet || !args->progress)
 		strvec_push(&po.args, "-q");
 	if (args->progress)
@@ -570,6 +572,8 @@ int send_pack(struct repository *r,
 		allow_deleting_refs = 1;
 	if (server_supports("ofs-delta"))
 		args->use_ofs_delta = 1;
+	if (server_supports("no-ref-delta"))
+		args->no_ref_delta = 1;
 	if (server_supports("side-band-64k"))
 		use_sideband = 1;
 	if (server_supports("quiet"))

--- a/send-pack.h
+++ b/send-pack.h
@@ -28,6 +28,7 @@ struct send_pack_args {
 		force_update:1,
 		use_thin_pack:1,
 		use_ofs_delta:1,
+		no_ref_delta:1,
 		dry_run:1,
 		/* One of the SEND_PACK_PUSH_CERT_* constants. */
 		push_cert:2,

--- a/t/helper/test-pack-deltas.c
+++ b/t/helper/test-pack-deltas.c
@@ -7,6 +7,7 @@
 #include "hash.h"
 #include "hex.h"
 #include "pack.h"
+#include "packfile.h"
 #include "pack-objects.h"
 #include "parse-options.h"
 #include "setup.h"
@@ -15,6 +16,7 @@
 
 static const char *usage_str[] = {
 	"test-tool pack-deltas --num-objects <num-objects>",
+	"test-tool pack-deltas --list-deltas <pack>.idx",
 	NULL
 };
 
@@ -80,18 +82,85 @@ static void write_ref_delta(struct hashfile *f,
 	free(delta_buf);
 }
 
+static int list_delta(const struct object_id *oid,
+		      struct packed_git *p,
+		      uint32_t pos,
+		      void *_w_curs)
+{
+	struct pack_window **w_curs = _w_curs;
+	off_t obj_offset = nth_packed_object_offset(p, pos);
+	off_t cur = obj_offset;
+	size_t size;
+	enum object_type type = unpack_object_header(p, w_curs, &cur,
+						      &size);
+
+	if (type < 0)
+		die("unable to parse object at position %"PRIu32, pos);
+	if (type != OBJ_REF_DELTA && type != OBJ_OFS_DELTA)
+		return 0;
+
+	if (type == OBJ_REF_DELTA) {
+		struct object_id base_oid;
+		const unsigned char *base = use_pack(p, w_curs, cur,
+						     NULL);
+
+		oidread(&base_oid, base, p->repo->hash_algo);
+		printf("%s REF_DELTA %s\n", oid_to_hex(oid),
+		       oid_to_hex(&base_oid));
+	} else {
+		off_t base_offset = get_delta_base(p, w_curs, &cur,
+						   type, obj_offset);
+
+		if (!base_offset)
+			die("unable to read base of object %s", oid_to_hex(oid));
+		printf("%s OFS_DELTA %"PRIuMAX"\n", oid_to_hex(oid),
+		       (uintmax_t)base_offset);
+	}
+
+	return 0;
+}
+
+static void list_deltas(const char *idx_name)
+{
+	struct packed_git *p;
+	struct pack_window *w_curs = NULL;
+
+	p = add_packed_git(the_repository, idx_name, strlen(idx_name), 1);
+	if (!p || open_pack_index(p))
+		die("unable to open pack index %s", idx_name);
+
+	if (for_each_object_in_pack(p, list_delta, &w_curs,
+				    ODB_FOR_EACH_OBJECT_PACK_ORDER))
+		die("unable to iterate over objects in %s", idx_name);
+
+	unuse_pack(&w_curs);
+	close_pack(p);
+	free(p);
+}
+
 int cmd__pack_deltas(int argc, const char **argv)
 {
 	int num_objects = -1;
+	int list_deltas_mode = 0;
 	struct hashfile *f;
 	struct strbuf line = STRBUF_INIT;
 	struct option options[] = {
 		OPT_INTEGER('n', "num-objects", &num_objects, N_("the number of objects to write")),
+		OPT_BOOL(0, "list-deltas", &list_deltas_mode,
+			 N_("list REF_DELTA and OFS_DELTA entries")),
 		OPT_END()
 	};
 
 	argc = parse_options(argc, argv, NULL,
 			     options, usage_str, 0);
+
+	if (list_deltas_mode) {
+		if (argc != 1 || num_objects >= 0)
+			usage_with_options(usage_str, options);
+		setup_git_directory(the_repository);
+		list_deltas(argv[0]);
+		return 0;
+	}
 
 	if (argc || num_objects < 0)
 		usage_with_options(usage_str, options);

--- a/t/helper/test-progress.c
+++ b/t/helper/test-progress.c
@@ -13,6 +13,7 @@
  *                                  specify the time elapsed since the
  *                                  start_progress() call.
  *   "update" - Set the 'progress_update' flag.
+ *   "clear" - Call clear_progress().
  *   "stop" - Call stop_progress().
  *
  * See 't0500-progress-display.sh' for examples.
@@ -88,6 +89,8 @@ int cmd__progress(int argc, const char **argv)
 			display_throughput(progress, byte_count);
 		} else if (!strcmp(line.buf, "update")) {
 			progress_test_force_update();
+		} else if (!strcmp(line.buf, "clear")) {
+			clear_progress(progress);
 		} else if (!strcmp(line.buf, "stop")) {
 			stop_progress(&progress);
 		} else {

--- a/t/t0500-progress-display.sh
+++ b/t/t0500-progress-display.sh
@@ -55,6 +55,41 @@ test_expect_success 'progress display with total' '
 	test_cmp expect out
 '
 
+test_expect_success 'clear progress without a total and redraw' '
+	cat >in <<-\EOF &&
+	start 0
+	update
+	progress 1
+	clear
+	progress 1
+	stop
+	EOF
+	{
+		printf "Working hard: 1\r" &&
+		printf "\r%15s\r" "" &&
+		printf "Working hard: 1\rWorking hard: 1, done.\n"
+	} >expect &&
+	test-tool progress <in 2>stderr &&
+	test_cmp expect stderr
+'
+
+test_expect_success 'clear split progress and redraw' '
+	cat >in <<-\EOF &&
+	start 3
+	progress 1
+	clear
+	progress 1
+	stop
+	EOF
+	{
+		printf "Working hard:\n   33%% (1/3)\r" &&
+		printf "\r%12s\r" "" &&
+		printf "   33%% (1/3)\r   33%% (1/3), done.\n"
+	} >expect &&
+	COLUMNS=10 test-tool progress <in 2>stderr &&
+	test_cmp expect stderr
+'
+
 test_expect_success 'progress display breaks long lines #1' '
 	sed -e "s/Z$//" >expect <<\EOF &&
 Working hard.......2.........3.........4.........5.........6:   0% (100/100000)<CR>

--- a/t/t5300-pack-object.sh
+++ b/t/t5300-pack-object.sh
@@ -211,6 +211,58 @@ test_expect_success 'pack with OFS_DELTA' '
 	test_grep " OFS_DELTA " deltas
 '
 
+test_expect_success 'pack without REF_DELTA' '
+	git pack-objects --no-ref-delta --stdout <obj-list >no-ref.pack &&
+	git index-pack -o no-ref.idx no-ref.pack &&
+
+	test-tool pack-deltas --list-deltas no-ref.idx >deltas &&
+	test_must_be_empty deltas
+'
+
+test_expect_success 'pack without REF_DELTA with OFS_DELTA' '
+	git pack-objects --delta-base-offset --no-ref-delta --stdout \
+		<obj-list >no-ref-ofs.pack &&
+	git index-pack -o no-ref-ofs.idx no-ref-ofs.pack &&
+
+	test-tool pack-deltas --list-deltas no-ref-ofs.idx >deltas &&
+	test_grep " OFS_DELTA " deltas &&
+	test_grep ! " REF_DELTA " deltas
+'
+
+test_expect_success 'pack without REF_DELTA skips excluded delta bases' '
+	test_when_finished "git read-tree $tree" &&
+
+	echo bar >>d &&
+	git update-index --add d &&
+	thin_tree=$(git write-tree) &&
+	thin_commit=$(git commit-tree $thin_tree -p $commit </dev/null) &&
+
+	{
+		echo $thin_commit &&
+		echo ^$commit
+	} >thin-revs &&
+
+	# Each type appears only once in the output, so any delta must
+	# use an excluded base and therefore be a REF_DELTA.
+	git pack-objects --thin --stdout --revs \
+		<thin-revs >thin.pack &&
+	git index-pack --fix-thin --stdin thin-fixed.pack \
+		<thin.pack >/dev/null &&
+
+	test-tool pack-deltas --list-deltas thin-fixed.idx >deltas &&
+	test_grep ! " OFS_DELTA " deltas &&
+	test_grep " REF_DELTA " deltas &&
+
+	git pack-objects --thin --stdout --revs \
+		--delta-base-offset --no-ref-delta \
+		<thin-revs >no-ref-thin.pack &&
+	git index-pack --fix-thin --stdin no-ref-thin-fixed.pack \
+		<no-ref-thin.pack >/dev/null &&
+
+	test-tool pack-deltas --list-deltas no-ref-thin-fixed.idx >deltas &&
+	test_must_be_empty deltas
+'
+
 test_expect_success 'unpack with OFS_DELTA' '
 	check_unpack test-3-${packname_3} obj-list
 '

--- a/t/t5300-pack-object.sh
+++ b/t/t5300-pack-object.sh
@@ -190,7 +190,9 @@ test_expect_success 'unpack without delta (core.fsyncmethod=batch)' '
 
 test_expect_success 'pack with REF_DELTA' '
 	packname_2=$(git pack-objects --progress test-2 <obj-list 2>stderr) &&
-	check_deltas stderr -gt 0
+	check_deltas stderr -gt 0 &&
+	test-tool pack-deltas --list-deltas test-2-$packname_2.idx >deltas &&
+	test_grep " REF_DELTA " deltas
 '
 
 test_expect_success 'unpack with REF_DELTA' '
@@ -204,7 +206,9 @@ test_expect_success 'unpack with REF_DELTA (core.fsyncmethod=batch)' '
 test_expect_success 'pack with OFS_DELTA' '
 	packname_3=$(git pack-objects --progress --delta-base-offset test-3 \
 			<obj-list 2>stderr) &&
-	check_deltas stderr -gt 0
+	check_deltas stderr -gt 0 &&
+	test-tool pack-deltas --list-deltas test-3-$packname_3.idx >deltas &&
+	test_grep " OFS_DELTA " deltas
 '
 
 test_expect_success 'unpack with OFS_DELTA' '

--- a/t/t5300-pack-object.sh
+++ b/t/t5300-pack-object.sh
@@ -229,6 +229,20 @@ test_expect_success 'pack without REF_DELTA with OFS_DELTA' '
 	test_grep ! " REF_DELTA " deltas
 '
 
+test_expect_success 'pack without REF_DELTA reuses deltas as OFS_DELTA' '
+	# Install the REF_DELTA pack above and disable delta search, so any
+	# output delta must be a reused REF_DELTA rewritten as OFS_DELTA.
+	test_when_finished "rm -f .git/objects/pack/pack-$packname_2.*" &&
+	git index-pack --stdin <test-2-${packname_2}.pack >/dev/null &&
+
+	git pack-objects --window=0 --delta-base-offset \
+		--no-ref-delta --stdout <obj-list >reused.pack &&
+	git index-pack -o reused.idx reused.pack &&
+	test-tool pack-deltas --list-deltas reused.idx >deltas &&
+	test_grep " OFS_DELTA " deltas &&
+	test_grep ! " REF_DELTA " deltas
+'
+
 test_expect_success 'pack without REF_DELTA skips excluded delta bases' '
 	test_when_finished "git read-tree $tree" &&
 
@@ -253,7 +267,12 @@ test_expect_success 'pack without REF_DELTA skips excluded delta bases' '
 	test_grep ! " OFS_DELTA " deltas &&
 	test_grep " REF_DELTA " deltas &&
 
-	git pack-objects --thin --stdout --revs \
+	# Store the REF_DELTA entries above and disable delta search below,
+	# so any output delta would have to reuse an excluded-base
+	# REF_DELTA.
+	git index-pack --stdin <thin-fixed.pack >/dev/null &&
+
+	git pack-objects --thin --window=0 --stdout --revs \
 		--delta-base-offset --no-ref-delta \
 		<thin-revs >no-ref-thin.pack &&
 	git index-pack --fix-thin --stdin no-ref-thin-fixed.pack \

--- a/t/t5300-pack-object.sh
+++ b/t/t5300-pack-object.sh
@@ -195,6 +195,19 @@ test_expect_success 'pack with REF_DELTA' '
 	test_grep " REF_DELTA " deltas
 '
 
+test_expect_success 'index-pack rejects REF_DELTA when requested' '
+	test_must_fail git index-pack --no-ref-delta \
+		-o rejected-ref-delta.idx test-2-$packname_2.pack 2>err &&
+	test_grep "REF_DELTA not allowed by --no-ref-delta" err &&
+	test_path_is_missing rejected-ref-delta.idx
+'
+
+test_expect_success 'index-pack --stdin rejects REF_DELTA when requested' '
+	test_must_fail git index-pack --stdin --no-ref-delta \
+		<test-2-$packname_2.pack 2>err &&
+	test_grep "REF_DELTA not allowed by --no-ref-delta" err
+'
+
 test_expect_success 'unpack with REF_DELTA' '
 	check_unpack test-2-${packname_2} obj-list
 '
@@ -227,6 +240,12 @@ test_expect_success 'pack without REF_DELTA with OFS_DELTA' '
 	test-tool pack-deltas --list-deltas no-ref-ofs.idx >deltas &&
 	test_grep " OFS_DELTA " deltas &&
 	test_grep ! " REF_DELTA " deltas
+'
+
+test_expect_success 'index-pack accepts OFS_DELTA when REF_DELTA is forbidden' '
+	git index-pack --no-ref-delta -o accepted-ofs-delta.idx \
+		no-ref-ofs.pack &&
+	test_path_is_file accepted-ofs-delta.idx
 '
 
 test_expect_success 'pack without REF_DELTA reuses deltas as OFS_DELTA' '

--- a/t/t5332-multi-pack-reuse.sh
+++ b/t/t5332-multi-pack-reuse.sh
@@ -111,6 +111,22 @@ test_expect_success 'reuse all objects from all packs' '
 	test_pack_objects_reused_all 9 3
 '
 
+test_expect_success '--no-ref-delta reuses REF_DELTA-free bitmapped packs' '
+	# Whole-word reuse is unavailable under --no-ref-delta, so reusing
+	# every object below exercises the per-object bitmap path.
+	: >trace2.txt &&
+	GIT_TRACE2_EVENT="$PWD/trace2.txt" \
+		git pack-objects --stdout --revs --all --delta-base-offset \
+		--no-ref-delta >got.pack &&
+
+	test_pack_reused 9 <trace2.txt &&
+	test_packs_reused 3 <trace2.txt &&
+
+	git index-pack --strict -o got.idx got.pack &&
+	test-tool pack-deltas --list-deltas got.idx >deltas &&
+	test_grep ! " REF_DELTA " deltas
+'
+
 test_expect_success 'reuse objects from first pack with middle gap' '
 	for i in D E F
 	do

--- a/t/t5516-fetch-push.sh
+++ b/t/t5516-fetch-push.sh
@@ -1548,6 +1548,20 @@ EOF
 	git push --no-thin --receive-pack="$rcvpck" no-thin/.git refs/heads/main:refs/heads/foo
 '
 
+test_expect_success 'push honors no-ref-delta capability' '
+	test_commit no-ref-delta &&
+
+	rcvpck="git receive-pack --advertise-no-ref-delta-for-testing" &&
+
+	GIT_TRACE2_EVENT="$PWD/no-ref-delta" \
+	git push --receive-pack="$rcvpck" no-thin/.git \
+		refs/heads/main:refs/heads/bar &&
+
+	test_subcommand git pack-objects --all-progress-implied --revs \
+		--stdout --thin --delta-base-offset --no-ref-delta -q \
+		<no-ref-delta
+'
+
 test_expect_success 'pushing a tag pushes the tagged object' '
 	blob=$(echo unreferenced | git hash-object -w --stdin) &&
 	git tag -m foo tag-of-blob $blob &&

--- a/t/t5550-http-fetch-dumb.sh
+++ b/t/t5550-http-fetch-dumb.sh
@@ -328,6 +328,27 @@ test_expect_success 'http-fetch --packfile resumes a partial download' '
 	git -C packfileclient-resume cat-file -e "$HASH"
 '
 
+test_expect_success 'http-fetch --packfile permits unlink while indexing' '
+	git init packfileclient-unlink &&
+	p=$(cd "$HTTPD_DOCUMENT_ROOT_PATH"/repo_pack.git &&
+		ls objects/pack/pack-*.pack) &&
+	tmpfile="packfileclient-unlink/.git/objects/pack/pack-$ARBITRARY.pack.temp" &&
+	write_script git-unlink-index-pack <<-\EOF &&
+	test -f "$GIT_TEST_PACK_TEMP" || exit 1
+	rm "$GIT_TEST_PACK_TEMP" || exit 1
+	exec git index-pack "$@"
+	EOF
+	test_when_finished "rm -f git-unlink-index-pack" &&
+	PATH="$TRASH_DIRECTORY:$PATH" \
+	GIT_TEST_PACK_TEMP="$TRASH_DIRECTORY/$tmpfile" \
+	git -C packfileclient-unlink http-fetch --packfile="$ARBITRARY" \
+		--index-pack-arg=unlink-index-pack \
+		--index-pack-arg=--stdin --index-pack-arg=--keep \
+		"$HTTPD_URL/dumb/repo_pack.git/$p" >out &&
+	test_path_is_missing "$tmpfile" &&
+	git -C packfileclient-unlink cat-file -e "$HASH"
+'
+
 test_expect_success PERL,PIPE 'concurrent http-fetch --packfile cannot corrupt an overlapping download' '
 	git init packfileclient-overlap &&
 	blob=$(test-tool genrandom pack-overlap 2m |

--- a/t/t5550-http-fetch-dumb.sh
+++ b/t/t5550-http-fetch-dumb.sh
@@ -293,6 +293,25 @@ test_expect_success 'http-fetch --packfile' '
 	git -C packfileclient cat-file -e "$HASH"
 '
 
+test_expect_success 'http-fetch --packfile accepts an already complete partial' '
+	git init packfileclient-complete &&
+	p=$(cd "$HTTPD_DOCUMENT_ROOT_PATH"/repo_pack.git &&
+		ls objects/pack/pack-*.pack) &&
+	packhash=$(basename "$p" .pack) &&
+	packhash=${packhash#pack-} &&
+	tmpfile="packfileclient-complete/.git/objects/pack/pack-$packhash.pack.temp" &&
+	cp "$HTTPD_DOCUMENT_ROOT_PATH/repo_pack.git/$p" "$tmpfile" &&
+	chmod u+w "$tmpfile" &&
+	GIT_TRACE_CURL="$TRASH_DIRECTORY/complete.trace" \
+	git -C packfileclient-complete http-fetch --packfile="$packhash" \
+		--index-pack-arg=index-pack \
+		--index-pack-arg=--stdin --index-pack-arg=--keep \
+		"$HTTPD_URL/dumb/repo_pack.git/$p" >out &&
+	test_grep "416 Requested Range Not Satisfiable" complete.trace &&
+	test_path_is_missing "$tmpfile" &&
+	git -C packfileclient-complete cat-file -e "$HASH"
+'
+
 test_expect_success 'fetch notices corrupt pack' '
 	cp -R "$HTTPD_DOCUMENT_ROOT_PATH"/repo_pack.git "$HTTPD_DOCUMENT_ROOT_PATH"/repo_bad1.git &&
 	(cd "$HTTPD_DOCUMENT_ROOT_PATH"/repo_bad1.git &&

--- a/t/t5550-http-fetch-dumb.sh
+++ b/t/t5550-http-fetch-dumb.sh
@@ -312,6 +312,170 @@ test_expect_success 'http-fetch --packfile accepts an already complete partial' 
 	git -C packfileclient-complete cat-file -e "$HASH"
 '
 
+test_expect_success 'http-fetch --packfile resumes a partial download' '
+	git init packfileclient-resume &&
+	p=$(cd "$HTTPD_DOCUMENT_ROOT_PATH"/repo_pack.git &&
+		ls objects/pack/pack-*.pack) &&
+	tmpfile="packfileclient-resume/.git/objects/pack/pack-$ARBITRARY.pack.temp" &&
+	test_copy_bytes 64 <"$HTTPD_DOCUMENT_ROOT_PATH/repo_pack.git/$p" >"$tmpfile" &&
+	GIT_TRACE_CURL="$TRASH_DIRECTORY/resume.trace" \
+	git -C packfileclient-resume http-fetch --packfile="$ARBITRARY" \
+		--index-pack-arg=index-pack --index-pack-arg=--stdin \
+		--index-pack-arg=--keep \
+		"$HTTPD_URL/dumb/repo_pack.git/$p" >out &&
+	test_grep "Range: bytes=64-" resume.trace &&
+	test_path_is_missing "$tmpfile" &&
+	git -C packfileclient-resume cat-file -e "$HASH"
+'
+
+test_expect_success PERL,PIPE 'concurrent http-fetch --packfile cannot corrupt an overlapping download' '
+	git init packfileclient-overlap &&
+	blob=$(test-tool genrandom pack-overlap 2m |
+		git -C "$HTTPD_DOCUMENT_ROOT_PATH"/repo_pack.git \
+			hash-object -w --stdin) &&
+	packhash=$(printf "%s\n" "$blob" |
+		git -C "$HTTPD_DOCUMENT_ROOT_PATH"/repo_pack.git \
+			pack-objects "$TRASH_DIRECTORY/overlap-pack") &&
+	pack="$TRASH_DIRECTORY/overlap-pack-$packhash.pack" &&
+	tmpfile="packfileclient-overlap/.git/objects/pack/pack-$packhash.pack.temp" &&
+	mkfifo server-ready first-ready &&
+	exec 7<>server-ready &&
+	exec 8<>first-ready &&
+	write_script slow-pack-server "$PERL_PATH" <<-\EOF &&
+	use strict;
+	use warnings;
+	use IO::Socket::INET;
+
+	my ($packfile, $server_ready, $first_ready) = @ARGV;
+	my $completed = 0;
+	END {
+		if (!$completed) {
+			signal_ready($server_ready, "failed");
+			signal_ready($first_ready, "failed");
+		}
+	}
+
+	$SIG{ALRM} = sub { die "timed out serving concurrent pack requests\n" };
+	alarm 60;
+
+	open(my $in, "<:raw", $packfile) or die "open $packfile: $!";
+	my $pack = do { local $/; <$in> };
+	close($in) or die "close $packfile: $!";
+	my $server = IO::Socket::INET->new(LocalAddr => "127.0.0.1",
+		LocalPort => 0, Proto => "tcp", Listen => 2, ReuseAddr => 1)
+		or die "listen: $!";
+
+	sub signal_ready {
+		my ($file, $value) = @_;
+		open(my $out, ">", $file) or die "open $file: $!";
+		print $out "$value\n" or die "write $file: $!";
+		close($out) or die "close $file: $!";
+	}
+
+	sub write_all {
+		my ($out, $data) = @_;
+		my $offset = 0;
+		while ($offset < length($data)) {
+			my $written = syswrite($out, $data,
+				length($data) - $offset, $offset);
+			defined($written) && $written or die "write response: $!";
+			$offset += $written;
+		}
+	}
+
+	sub start_response {
+		my $out = $server->accept() or die "accept: $!";
+		<$out> or die "read request: $!";
+		my $start = 0;
+		while (<$out>) {
+			last if /^\r?\n$/;
+			$start = $1 if /^Range: bytes=(\d+)-/i;
+		}
+		$start < length($pack) or die "invalid range $start";
+		my $length = length($pack) - $start;
+		my $middle = int($length / 2);
+		my $status = $start ? "206 Partial Content" : "200 OK";
+		my $headers = "HTTP/1.1 $status\r\n" .
+			"Content-Length: $length\r\n" .
+			($start ? "Content-Range: bytes $start-" .
+				(length($pack) - 1) . "/" . length($pack) . "\r\n" : "") .
+			"Connection: close\r\n\r\n";
+		write_all($out, $headers);
+		write_all($out, substr($pack, $start, $middle));
+		return ($out, $start + $middle);
+	}
+
+	signal_ready($server_ready, $server->sockport());
+	my ($first, $first_pos) = start_response();
+	signal_ready($first_ready, "ready");
+	my ($second, $second_pos) = start_response();
+	write_all($first, substr($pack, $first_pos));
+	write_all($second, substr($pack, $second_pos));
+	close($first) or die "close first response: $!";
+	close($second) or die "close second response: $!";
+	$completed = 1;
+	alarm 0;
+	EOF
+	{
+		"$TRASH_DIRECTORY/slow-pack-server" "$pack" \
+			"$TRASH_DIRECTORY/server-ready" \
+			"$TRASH_DIRECTORY/first-ready" >server.log 2>&1 &
+		server_pid=$!
+	} &&
+	test_when_finished "
+		kill $server_pid 2>/dev/null || :
+		wait $server_pid 2>/dev/null || :
+		exec 7>&-
+		exec 8>&-
+		rm -f server-ready first-ready slow-pack-server
+	" &&
+	read port <&7 &&
+	url="http://127.0.0.1:$port/pack" &&
+	{
+		(
+			if ! GIT_TRACE_CURL="$TRASH_DIRECTORY/overlap-first.trace" \
+			GIT_TRACE_CURL_NO_DATA=1 \
+			git -C packfileclient-overlap http-fetch --packfile="$packhash" \
+				--index-pack-arg=index-pack \
+				--index-pack-arg=--stdin --index-pack-arg=--keep \
+				"$url" >first.out
+			then
+				echo failed >"$TRASH_DIRECTORY/first-ready" &&
+				exit 1
+			fi
+		) &
+		first_pid=$!
+	} &&
+	test_when_finished "
+		kill $first_pid 2>/dev/null || :
+		wait $first_pid 2>/dev/null || :
+	" &&
+	read ready <&8 &&
+	test "$ready" = ready &&
+	test_path_is_file "$tmpfile" &&
+	{
+		GIT_TRACE_CURL="$TRASH_DIRECTORY/overlap-second.trace" \
+		GIT_TRACE_CURL_NO_DATA=1 \
+		git -C packfileclient-overlap http-fetch --packfile="$packhash" \
+			--index-pack-arg=index-pack \
+			--index-pack-arg=--stdin --index-pack-arg=--keep \
+			"$url" >second.out &
+		second_pid=$!
+	} &&
+	test_when_finished "
+		kill $second_pid 2>/dev/null || :
+		wait $second_pid 2>/dev/null || :
+	" &&
+	wait "$second_pid" &&
+	wait "$first_pid" &&
+	wait "$server_pid" &&
+	printf "keep\t%s\npack\t%s\n" "$packhash" "$packhash" | sort >expect &&
+	sort first.out second.out >actual &&
+	test_cmp expect actual &&
+	test_path_is_missing "$tmpfile" &&
+	git -C packfileclient-overlap cat-file -e "$blob"
+'
+
 test_expect_success 'fetch notices corrupt pack' '
 	cp -R "$HTTPD_DOCUMENT_ROOT_PATH"/repo_pack.git "$HTTPD_DOCUMENT_ROOT_PATH"/repo_bad1.git &&
 	(cd "$HTTPD_DOCUMENT_ROOT_PATH"/repo_bad1.git &&

--- a/t/t5550-http-fetch-dumb.sh
+++ b/t/t5550-http-fetch-dumb.sh
@@ -303,11 +303,12 @@ test_expect_success 'http-fetch --packfile accepts an already complete partial' 
 	cp "$HTTPD_DOCUMENT_ROOT_PATH/repo_pack.git/$p" "$tmpfile" &&
 	chmod u+w "$tmpfile" &&
 	GIT_TRACE_CURL="$TRASH_DIRECTORY/complete.trace" \
-	git -C packfileclient-complete http-fetch --packfile="$packhash" \
+	git -C packfileclient-complete http-fetch --report-progress --packfile="$packhash" \
 		--index-pack-arg=index-pack \
 		--index-pack-arg=--stdin --index-pack-arg=--keep \
 		"$HTTPD_URL/dumb/repo_pack.git/$p" >out &&
 	test_grep "416 Requested Range Not Satisfiable" complete.trace &&
+	test_grep "^bytes 0$" out &&
 	test_path_is_missing "$tmpfile" &&
 	git -C packfileclient-complete cat-file -e "$HASH"
 '
@@ -319,11 +320,13 @@ test_expect_success 'http-fetch --packfile resumes a partial download' '
 	tmpfile="packfileclient-resume/.git/objects/pack/pack-$ARBITRARY.pack.temp" &&
 	test_copy_bytes 64 <"$HTTPD_DOCUMENT_ROOT_PATH/repo_pack.git/$p" >"$tmpfile" &&
 	GIT_TRACE_CURL="$TRASH_DIRECTORY/resume.trace" \
-	git -C packfileclient-resume http-fetch --packfile="$ARBITRARY" \
+	git -C packfileclient-resume http-fetch --report-progress --packfile="$ARBITRARY" \
 		--index-pack-arg=index-pack --index-pack-arg=--stdin \
 		--index-pack-arg=--keep \
 		"$HTTPD_URL/dumb/repo_pack.git/$p" >out &&
 	test_grep "Range: bytes=64-" resume.trace &&
+	size=$(wc -c <"$HTTPD_DOCUMENT_ROOT_PATH/repo_pack.git/$p") &&
+	test_grep "^bytes $((size - 64))$" out &&
 	test_path_is_missing "$tmpfile" &&
 	git -C packfileclient-resume cat-file -e "$HASH"
 '

--- a/t/t5702-protocol-v2.sh
+++ b/t/t5702-protocol-v2.sh
@@ -1291,6 +1291,37 @@ test_expect_success 'packfile URIs with fetch instead of clone' '
 		fetch "$HTTPD_URL/smart/http_parent"
 '
 
+test_expect_success 'packfile URI preserves an existing keep file' '
+	P="$HTTPD_DOCUMENT_ROOT_PATH/http_parent" &&
+	rm -rf "$P" http_child keep.expect &&
+
+	git init "$P" &&
+	git -C "$P" config uploadpack.allowsidebandall true &&
+
+	echo my-blob >"$P/my-blob" &&
+	git -C "$P" add my-blob &&
+	git -C "$P" commit -m x &&
+	configure_exclusion "$P" my-blob >h &&
+
+	git init http_child &&
+	packhash=$(cat packh) &&
+	keep="http_child/.git/objects/pack/pack-$packhash.keep" &&
+	echo pre-existing >"$keep" &&
+	cp "$keep" keep.expect &&
+
+	GIT_TEST_SIDEBAND_ALL=1 \
+	git -C http_child -c protocol.version=2 \
+		-c fetch.uriprotocols=http,https \
+		fetch "$HTTPD_URL/smart/http_parent" &&
+
+	test_path_is_file \
+		"http_child/.git/objects/pack/pack-$packhash.pack" &&
+	test_path_is_file \
+		"http_child/.git/objects/pack/pack-$packhash.idx" &&
+	test_cmp keep.expect "$keep" &&
+	git -C http_child cat-file -e "$(cat h)"
+'
+
 test_expect_success 'fetching with valid packfile URI but invalid hash fails' '
 	P="$HTTPD_DOCUMENT_ROOT_PATH/http_parent" &&
 	rm -rf "$P" http_child log &&

--- a/t/t5702-protocol-v2.sh
+++ b/t/t5702-protocol-v2.sh
@@ -1300,6 +1300,38 @@ test_expect_success 'part of packfile response provided as URI' '
 	test_line_count = 6 filelist
 '
 
+test_expect_success 'no-ref-delta URI packs are indexed concurrently' '
+	P="$HTTPD_DOCUMENT_ROOT_PATH/http_parent" &&
+	rm -rf "$P" http_child-no-ref no-ref-* &&
+	git init "$P" &&
+	git -C "$P" config uploadpack.allowsidebandall true &&
+	git -C "$P" config uploadpack.allowNoRefDelta true &&
+	echo one >"$P/one" &&
+	echo two >"$P/two" &&
+	echo three >"$P/three" &&
+	git -C "$P" add one two three &&
+	git -C "$P" commit -m objects &&
+	# A one-object pack cannot contain a delta.
+	configure_exclusion "$P" one >/dev/null &&
+	configure_exclusion "$P" two >/dev/null &&
+	configure_exclusion "$P" three >/dev/null &&
+
+	GIT_TRACE2_EVENT="$TRASH_DIRECTORY/no-ref-index.trace" \
+	GIT_TRACE_PACKET="$TRASH_DIRECTORY/no-ref-packet.trace" \
+	GIT_TEST_SIDEBAND_ALL=1 \
+	git -c protocol.version=2 -c fetch.uriprotocols=http \
+		-c fetch.packfileUriJobs=2 \
+		clone "$HTTPD_URL/smart/http_parent" http_child-no-ref &&
+
+	test_grep "> no-ref-delta" no-ref-packet.trace &&
+	grep "\"event\":\"child_start\".*\"index-pack\".*--no-ref-delta" \
+		no-ref-index.trace >no-ref-indexers &&
+	test_line_count = 4 no-ref-indexers &&
+	grep "\"event\":\"child_start\".*\"index-pack\".*--no-ref-delta.*--threads=1" \
+		no-ref-index.trace >no-ref-uri-indexers &&
+	test_line_count = 3 no-ref-uri-indexers
+'
+
 test_expect_success 'packfile URIs with fetch instead of clone' '
 	P="$HTTPD_DOCUMENT_ROOT_PATH/http_parent" &&
 	rm -rf "$P" http_child log &&

--- a/t/t5702-protocol-v2.sh
+++ b/t/t5702-protocol-v2.sh
@@ -972,6 +972,36 @@ test_expect_success 'reject client packfile-uris if not advertised' '
 		upload-pack client <input
 '
 
+test_expect_success 'fetch no-ref-delta requires advertisement' '
+	rm -rf no-ref-advertisement &&
+	git init no-ref-advertisement &&
+	test_commit -C no-ref-advertisement one &&
+	env GIT_CONFIG_COUNT=1 \
+		GIT_CONFIG_KEY_0=uploadpack.allowNoRefDelta \
+		GIT_CONFIG_VALUE_0=true \
+		test-tool -C no-ref-advertisement serve-v2 \
+		--advertise-capabilities \
+		>advertisement &&
+	test_grep "fetch=.*no-ref-delta" advertisement &&
+	{
+		packetize command=fetch &&
+		packetize object-format=$(test_oid algo) &&
+		printf 0001 &&
+		packetize no-ref-delta &&
+		packetize "want $(git -C no-ref-advertisement rev-parse HEAD)" &&
+		packetize done &&
+		printf 0000
+	} >input &&
+	test_must_fail env GIT_PROTOCOL=version=2 \
+		git upload-pack no-ref-advertisement <input &&
+	GIT_TRACE2_EVENT="$PWD/no-ref-upload.trace" \
+	GIT_PROTOCOL=version=2 \
+		git -c uploadpack.allowNoRefDelta=true \
+		upload-pack no-ref-advertisement <input >out &&
+	test_grep "\"event\":\"child_start\".*\"pack-objects\".*--no-ref-delta" \
+		no-ref-upload.trace
+'
+
 # Test protocol v2 with 'http://' transport
 #
 . "$TEST_DIRECTORY"/lib-httpd.sh

--- a/t/t5702-protocol-v2.sh
+++ b/t/t5702-protocol-v2.sh
@@ -1321,7 +1321,8 @@ test_expect_success 'no-ref-delta URI packs are indexed concurrently' '
 	GIT_TEST_SIDEBAND_ALL=1 \
 	git -c protocol.version=2 -c fetch.uriprotocols=http \
 		-c fetch.packfileUriJobs=2 \
-		clone "$HTTPD_URL/smart/http_parent" http_child-no-ref &&
+		clone --progress "$HTTPD_URL/smart/http_parent" http_child-no-ref \
+		2>no-ref-progress &&
 
 	test_grep "> no-ref-delta" no-ref-packet.trace &&
 	grep "\"event\":\"child_start\".*\"index-pack\".*--no-ref-delta" \
@@ -1329,7 +1330,42 @@ test_expect_success 'no-ref-delta URI packs are indexed concurrently' '
 	test_line_count = 4 no-ref-indexers &&
 	grep "\"event\":\"child_start\".*\"index-pack\".*--no-ref-delta.*--threads=1" \
 		no-ref-index.trace >no-ref-uri-indexers &&
-	test_line_count = 3 no-ref-uri-indexers
+	test_line_count = 3 no-ref-uri-indexers &&
+	test_grep ! "\"-v\"" no-ref-uri-indexers &&
+	bytes=0 &&
+	git -C "$P" config --get-all uploadpack.blobpackfileuri >no-ref-uris &&
+	while read object pack uri
+	do
+		size=$(wc -c <"$HTTPD_DOCUMENT_ROOT_PATH/mypack-$pack.pack") &&
+		bytes=$((bytes + size)) || return 1
+	done <no-ref-uris &&
+	test_grep "Fetching packs: 100% (3/3), $bytes bytes |.*done" no-ref-progress &&
+	test_grep ! "^bytes " no-ref-progress
+'
+
+test_expect_success 'parallel URI progress respects quiet and no-progress' '
+	for option in --quiet --no-progress
+	do
+		GIT_TEST_SIDEBAND_ALL=1 \
+		git -c protocol.version=2 -c fetch.uriprotocols=http \
+			-c fetch.packfileUriJobs=2 clone "$option" \
+			"$HTTPD_URL/smart/http_parent" "http_child-$option" \
+			2>no-ref-progress &&
+		test_grep ! -E "Fetching packs|Receiving objects|^bytes " no-ref-progress ||
+		return 1
+	done
+'
+
+test_expect_success 'parallel URI progress preserves worker errors' '
+	test_when_finished "mv missing.pack \"$HTTPD_DOCUMENT_ROOT_PATH/mypack-$(cat packh).pack\"" &&
+	mv "$HTTPD_DOCUMENT_ROOT_PATH/mypack-$(cat packh).pack" missing.pack &&
+	test_must_fail env GIT_TEST_SIDEBAND_ALL=1 \
+		git -c protocol.version=2 -c fetch.uriprotocols=http \
+		-c fetch.packfileUriJobs=2 clone --progress \
+		"$HTTPD_URL/smart/http_parent" http_child-missing \
+		2>no-ref-error &&
+	test_grep "404" no-ref-error &&
+	test_grep ! "Fetching packs: 100%.*done" no-ref-error
 '
 
 test_expect_success 'packfile URIs with fetch instead of clone' '

--- a/upload-pack.c
+++ b/upload-pack.c
@@ -120,6 +120,8 @@ struct upload_pack_data {
 	unsigned allow_sideband_all : 1;			/* v2 only */
 	unsigned seen_haves : 1;				/* v2 only */
 	unsigned allow_packfile_uris : 1;			/* v2 only */
+	unsigned allow_no_ref_delta : 1;			/* v2 only */
+	unsigned use_no_ref_delta : 1;			/* v2 only */
 	unsigned advertise_sid : 1;
 	unsigned sent_capabilities : 1;
 };
@@ -333,6 +335,8 @@ static void create_pack_file(struct upload_pack_data *pack_data,
 		strvec_push(&pack_objects.args, "--progress");
 	if (pack_data->use_ofs_delta)
 		strvec_push(&pack_objects.args, "--delta-base-offset");
+	if (pack_data->use_no_ref_delta)
+		strvec_push(&pack_objects.args, "--no-ref-delta");
 	if (pack_data->use_include_tag)
 		strvec_push(&pack_objects.args, "--include-tag");
 	if (repo_has_accepted_promisor_remote(the_repository))
@@ -1363,6 +1367,8 @@ static int upload_pack_config(const char *var, const char *value,
 		data->allow_ref_in_want = git_config_bool(var, value);
 	} else if (!strcmp("uploadpack.allowsidebandall", var)) {
 		data->allow_sideband_all = git_config_bool(var, value);
+	} else if (!strcmp("uploadpack.allownorefdelta", var)) {
+		data->allow_no_ref_delta = git_config_bool(var, value);
 	} else if (!strcmp("uploadpack.blobpackfileuri", var)) {
 		if (value)
 			data->allow_packfile_uris = 1;
@@ -1668,6 +1674,11 @@ static void process_args(struct packet_reader *request,
 			string_list_split(&data->uri_protocols, p, ",", -1);
 			continue;
 		}
+		if (data->allow_no_ref_delta &&
+		    !strcmp(arg, "no-ref-delta")) {
+			data->use_no_ref_delta = 1;
+			continue;
+		}
 
 		/* ignore unknown lines maybe? */
 		die("unexpected line: '%s'", arg);
@@ -1854,6 +1865,9 @@ int upload_pack_advertise(struct repository *r,
 
 		if (data.allow_packfile_uris)
 			strbuf_addstr(value, " packfile-uris");
+
+		if (data.allow_no_ref_delta)
+			strbuf_addstr(value, " no-ref-delta");
 	}
 
 	upload_pack_data_clear(&data);


### PR DESCRIPTION
Parallel URI-pack indexers each write their own progress to stderr. Their lines overwrite one another and leave a completion line for every pack; the reported throughput measures indexing of a downloaded file rather than the HTTP transfer.

Use Git's progress API to show one `Fetching packs` line with completed packs, downloaded bytes, and throughput. Count a pack after indexing and hash verification, exclude any existing prefix from resumed-download byte counts, and preserve worker diagnostics. Quiet and no-progress fetches do not request byte reports.

The new work is [one commit](https://github.com/openai/git/commit/6e4bb83123acb8fdb3d929c22bd446f8eb6a7b33). The earlier topic history was reviewed in #65; [this comparison](https://github.com/openai/git/compare/a08b8d8bb7e3082e9d8e3d29e1535579234784be...6e4bb83123acb8fdb3d929c22bd446f8eb6a7b33) isolates the change from the currently enrolled source pin.

### Validation

- Developer build passes.
- `t0500-progress-display.sh`: 18/18, including clearing a split line and repainting a display with an unknown total.
- `t5550-http-fetch-dumb.sh`: 63/63, including exact byte counts for resumed and already-complete downloads.
- `t5702-protocol-v2.sh`: 90/90, including aggregate progress, quiet/no-progress, and worker errors.
- The local replay onto `codex` at `0d779fa987a6d214f24d68d36b2d22c32fe85fbc` also passes its developer build and all 94 protocol-v2 tests, including URI authentication coverage.
- A gated HTTP transfer shows byte progress before any pack completes, reports exactly 1,573,470 bytes, and passes `git fsck --full`. Three workers emitting 128 KiB of diagnostics each complete without a pipe deadlock.

The source topic needs integration with the newer HTTP authentication changes in `codex`. A local replay resolves the two overlapping files while retaining the newer authentication and error-response handling. This PR requests approval of the source topic; release-plan admission and the controller rebuild follow separately.

GitHub CI currently stops during setup because this older source topic's existing workflow references `actions/github-script@v9`, while repository policy requires full-SHA action pins ([failed run](https://github.com/openai/git/actions/runs/34520106547)). No GitHub build or test job ran. The release plan carries action pinning as a separate topic.

<!-- codex-thread: 01a08c65-8361-7c62-807b-bf7718660c74 -->
