### PR TITLE
Codex plan: update parallel packfile URI progress in stable

### DIFF
--- a/codex.plan
+++ b/codex.plan
@@ -67,7 +67,7 @@
 [branch "tb/codex/parallel-packfile-uris"]
 	remote = .
 	source-ref = refs/heads/tb/codex/parallel-packfile-uris
-	source-tip = a08b8d8bb7e3082e9d8e3d29e1535579234784be
+	source-tip = 6e4bb83123acb8fdb3d929c22bd446f8eb6a7b33
 	source-base = 4cc8b3223b233aa3b795b1265e6e7cf3d63c7170
 	merge = refs/heads/tb/codex/packfile-uri-concurrency
 


### PR DESCRIPTION
Advance the stable plan's `tb/codex/parallel-packfile-uris` pin to `6e4bb83123acb8fdb3d929c22bd446f8eb6a7b33`, approved by Friel in #106. This adds aggregate pack-download progress with transferred bytes and throughput.

Only the source tip changes; the topic order and prerequisite remain unchanged. The pinned controller generated this transition and verified the source review. The local planner was used because the automatic planner's GitHub App private-key input is unavailable.

After trusted plan admission, merge this plan through the normal rebase path and rebuild stable with `Meta/rebuild --local`.

<!-- codex-thread: 01a08c65-8361-7c62-807b-bf7718660c74 -->
