### PR TITLE
Codex plan: prepare URI authentication prerequisite change

### DIFF
--- a/codex.plan
+++ b/codex.plan
@@ -12,7 +12,6 @@
 	topic = refs/heads/tb/codex/parallel-packfile-uris
 	topic = refs/heads/tb/codex/release-tooling
 	topic = refs/heads/tb/codex/pin-ci-actions
-	topic = refs/heads/af/codex/packfile-uri-credentials
 	topic = refs/heads/dr/codex/trace2-redact-url-signatures
 
 [branch "tb/codex/automation"]
@@ -84,13 +83,6 @@
 	source-tip = 026ca78e79986a60637df0fec4f2089e84f19f7a
 	source-base = 67ba20645b1792f43c8c8ea69c716687bda87ec3
 	merge = refs/heads/tb/codex/lto-pgo
-
-[branch "af/codex/packfile-uri-credentials"]
-	remote = .
-	source-ref = refs/heads/af/codex/packfile-uri-credentials
-	source-tip = 409df2c11ff1465d7f587026ec3a0d9375c105ef
-	source-base = 2c3adbb2c475981e340c79fdc5e7f4f9b5d9054e
-	merge = refs/heads/master
 
 [branch "dr/codex/trace2-redact-url-signatures"]
 	remote = .


### PR DESCRIPTION
The stable rebuild for #106 stops because the URI-authentication topic and the new progress writer overlap. #108 restacks authentication onto the parallel-packfile topic and preserves both behaviors.

The controller rejects changing an enrolled topic's prerequisite through `alter` (`bot-projected alter may not change a topic prerequisite`). Its supported sequence is to remove the old plan entry, then add the reviewed source with the inferred prerequisite. This PR is the removal step, generated and validated by the pinned controller.

Do not merge this until #108 is approved. After this merges, immediately propose and admit the replacement entry:

- Topic: `af/codex/packfile-uri-credentials`
- Source tip: `51ad3937d18480ab9f149d568e70e34448e12d10`
- Prerequisite: `tb/codex/parallel-packfile-uris`
- Source boundary: `6e4bb83123acb8fdb3d929c22bd446f8eb6a7b33`
- Source review: #108

Run `Meta/rebuild --local` only after the replacement entry is merged. No release is to be built or published from the intermediate plan; authentication remains in the currently published stable binary throughout.

The restacked source passes its developer build, `t5702` (94), `t5563` (38), `t5550` (63), and the live download-progress and diagnostic-pipe checks.

<!-- codex-thread: 01a08c65-8361-7c62-807b-bf7718660c74 -->
