### PR TITLE
Codex plan: restore URI authentication with aggregate progress

### DIFF
--- a/codex.plan
+++ b/codex.plan
@@ -13,6 +13,7 @@
 	topic = refs/heads/tb/codex/release-tooling
 	topic = refs/heads/tb/codex/pin-ci-actions
 	topic = refs/heads/dr/codex/trace2-redact-url-signatures
+	topic = refs/heads/af/codex/packfile-uri-credentials
 
 [branch "tb/codex/automation"]
 	remote = .
@@ -90,3 +91,10 @@
 	source-tip = 764f04785bdeb2888365b234ae3eae2062130e8d
 	source-base = b8242b093d9e941a34460d715e3ce616a34ac3fe
 	merge = refs/heads/master
+
+[branch "af/codex/packfile-uri-credentials"]
+	remote = .
+	source-ref = refs/heads/af/codex/packfile-uri-credentials
+	source-tip = 51ad3937d18480ab9f149d568e70e34448e12d10
+	source-base = 6e4bb83123acb8fdb3d929c22bd446f8eb6a7b33
+	merge = refs/heads/tb/codex/parallel-packfile-uris


### PR DESCRIPTION
Restore URI authentication to the stable release plan after #109, using the source approved in #108. The authentication topic now depends on the parallel packfile URI topic, so aggregate byte progress and credential handling compose together.

The controller inferred prerequisite `tb/codex/parallel-packfile-uris` and source boundary `6e4bb83123acb8fdb3d929c22bd446f8eb6a7b33`, and validated Friel's approval of source `51ad3937d18480ab9f149d568e70e34448e12d10`.

The complete local composition passed the HTTP/progress checks and all 129 t5516 tests. Its installed Git also displayed aggregate progress during a real Pando fetch with 89 packfile URIs. The release will go through the controller's staging and promotion checks after this plan is admitted and merged.

<!-- codex-thread: 01a08c65-8361-7c62-807b-bf7718660c74 -->
