### PR TITLE
release: pin the Windows x64 SDK before the UCRT migration

### DIFF
--- a/.github/workflows/check-style.yml
+++ b/.github/workflows/check-style.yml
@@ -20,7 +20,7 @@ jobs:
       jobname: ClangFormat
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       with:
         fetch-depth: 0
 

--- a/.github/workflows/check-whitespace.yml
+++ b/.github/workflows/check-whitespace.yml
@@ -19,7 +19,7 @@ jobs:
   check-whitespace:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       with:
         fetch-depth: 0
 

--- a/.github/workflows/codex-pgo-training.sh
+++ b/.github/workflows/codex-pgo-training.sh
@@ -1,0 +1,60 @@
+#!/bin/sh
+
+# Keep this workload short and biased toward the local Git operations Codex
+# invokes frequently. The full Git test suite is too slow for each release
+# target and would weight test-harness paths more heavily than status, diff,
+# clone, fetch, and repository maintenance.
+
+set -eu
+
+git_bin="$PWD/bin-wrappers/git"
+training_dir=$(mktemp -d "${TMPDIR:-/tmp}/codex-git-pgo.XXXXXX")
+repo="$training_dir/repo"
+clone="$training_dir/clone"
+
+cleanup () {
+	rm -rf "$training_dir"
+}
+trap cleanup EXIT HUP INT TERM
+
+mkdir -p "$training_dir/home"
+export HOME="$training_dir/home"
+export GIT_CONFIG_NOSYSTEM=1
+export GIT_TERMINAL_PROMPT=0
+
+"$git_bin" clone --quiet --no-local "$PWD" "$repo"
+"$git_bin" -C "$repo" config user.name "Codex Git PGO"
+"$git_bin" -C "$repo" config user.email "codex-git-pgo@openai.com"
+
+i=0
+while test "$i" -lt 256
+do
+	dir="$repo/training/$((i % 16))"
+	mkdir -p "$dir"
+	printf '%s\n' "$i" >"$dir/file-$i"
+	i=$((i + 1))
+done
+
+"$git_bin" -C "$repo" status --porcelain=v2 --branch >/dev/null
+"$git_bin" -C "$repo" status --porcelain=v2 --branch --untracked-files=all >/dev/null
+"$git_bin" -C "$repo" ls-files --others --exclude-standard >/dev/null
+"$git_bin" -C "$repo" add training
+"$git_bin" -C "$repo" diff --cached --stat >/dev/null
+"$git_bin" -C "$repo" commit --quiet -m "add training files"
+
+printf 'changed\n' >>"$repo/training/0/file-0"
+rm "$repo/training/1/file-1"
+mkdir -p "$repo/untracked"
+printf 'new\n' >"$repo/untracked/file"
+
+"$git_bin" -C "$repo" status --porcelain=v2 --branch >/dev/null
+"$git_bin" -C "$repo" diff --stat >/dev/null
+"$git_bin" -C "$repo" diff --name-status >/dev/null
+"$git_bin" -C "$repo" ls-files --stage >/dev/null
+"$git_bin" -C "$repo" log --oneline --decorate -20 >/dev/null
+"$git_bin" -C "$repo" rev-list --objects --all >/dev/null
+"$git_bin" -C "$repo" for-each-ref --format='%(refname) %(objectname)' >/dev/null
+"$git_bin" -C "$repo" repack -ad
+"$git_bin" clone --quiet --no-local "$repo" "$clone"
+"$git_bin" -C "$clone" status --porcelain=v2 --branch >/dev/null
+"$git_bin" -C "$clone" fetch --quiet "$repo"

--- a/.github/workflows/codex-release.yml
+++ b/.github/workflows/codex-release.yml
@@ -94,7 +94,7 @@ jobs:
             file_pattern: ELF 64-bit.*x86-64
             has_gcm: true
           - name: Windows arm64
-            os: windows-2025
+            os: windows-11-arm
             target_platform: win32
             asset_platform: windows
             arch: arm64
@@ -314,8 +314,8 @@ jobs:
           grep -E "$FILE_PATTERN" /tmp/git-file-type
           strings "$GIT_BINARY" | grep -F "$GITHUB_SHA"
 
-      - name: Smoke-test the native x64 distribution
-        if: matrix.arch == 'x64'
+      - name: Smoke-test the native distribution
+        if: matrix.arch == 'x64' || matrix.target_platform == 'win32'
         shell: bash
         env:
           TARGET_PLATFORM: ${{ matrix.target_platform }}

--- a/.github/workflows/codex-release.yml
+++ b/.github/workflows/codex-release.yml
@@ -278,7 +278,7 @@ jobs:
             NO_INSTALL_HARDLINKS=YesPlease
             NO_CROSS_DIRECTORY_HARDLINKS=YesPlease
           )
-          jobs="$(nproc)"
+          jobs="${NUMBER_OF_PROCESSORS:-2}"
           make -j"$jobs" "${make_args[@]}" all
           make "${make_args[@]}" DESTDIR=/tmp/build/git strip install
 

--- a/.github/workflows/codex-release.yml
+++ b/.github/workflows/codex-release.yml
@@ -68,7 +68,8 @@ jobs:
             arch: arm64
             binary: /tmp/build/git/bin/git
             file_pattern: Mach-O 64-bit executable arm64
-            has_gcm: true
+            has_gcm: false
+            max_tar_bytes: 33554432
           - name: macOS x64
             os: macos-15-intel
             target_platform: macOS
@@ -76,7 +77,8 @@ jobs:
             arch: x64
             binary: /tmp/build/git/bin/git
             file_pattern: Mach-O 64-bit executable x86_64
-            has_gcm: true
+            has_gcm: false
+            max_tar_bytes: 33554432
           - name: Linux arm64
             os: ubuntu-22.04
             target_platform: ubuntu
@@ -85,6 +87,7 @@ jobs:
             binary: /tmp/build/git/bin/git
             file_pattern: ELF 64-bit.*ARM aarch64
             has_gcm: false
+            max_tar_bytes: 41943040
           - name: Linux x64
             os: ubuntu-22.04
             target_platform: ubuntu
@@ -92,7 +95,8 @@ jobs:
             arch: x64
             binary: /tmp/build/git/bin/git
             file_pattern: ELF 64-bit.*x86-64
-            has_gcm: true
+            has_gcm: false
+            max_tar_bytes: 41943040
           - name: Windows arm64
             os: windows-11-arm
             target_platform: win32
@@ -101,6 +105,7 @@ jobs:
             binary: /tmp/build/git/clangarm64/bin/git.exe
             file_pattern: PE32\+.*ARM64
             has_gcm: true
+            max_tar_bytes: 83886080
             sdk_arch: aarch64
             sdk_flavor: full
             mingw_dir: clangarm64
@@ -116,6 +121,7 @@ jobs:
             binary: /tmp/build/git/mingw64/bin/git.exe
             file_pattern: PE32\+.*x86-64
             has_gcm: true
+            max_tar_bytes: 83886080
             sdk_arch: x86_64
             sdk_flavor: full
             mingw_dir: mingw64
@@ -235,6 +241,20 @@ jobs:
             dependencies.json >"$updated"
           mv "$updated" dependencies.json
 
+      # Codex does not configure or invoke GCM on macOS or Linux. The
+      # self-contained .NET payload accounts for most of those bundles, while
+      # Windows MinGit configures credential.helper=manager and must retain it.
+      - name: Omit unused GCM from POSIX bundles
+        if: matrix.target_platform != 'win32'
+        shell: bash
+        working-directory: dugite-native
+        run: |
+          set -euo pipefail
+          updated="$(mktemp)"
+          jq '."git-credential-manager".files = []' \
+            dependencies.json >"$updated"
+          mv "$updated" dependencies.json
+
       # Dugite cross-compiles several targets. Keep Git's optional Rust
       # library disabled until its Makefile can direct Cargo at those targets.
       - name: Build the Dugite Native distribution
@@ -259,6 +279,8 @@ jobs:
       # Dugite Native compiles its Git submodule on macOS and Linux. On
       # Windows it starts from MinGit, so replace MinGit's Git programs with
       # the build from this repository while retaining the portable runtime.
+      # MinGit omits dashed builtin aliases; installing them as copies would
+      # add hundreds of redundant MiB to the archive.
       - name: Install this Git build into the Windows distribution
         if: matrix.target_platform == 'win32'
         shell: bash
@@ -276,6 +298,7 @@ jobs:
             NO_GETTEXT=YesPlease
             NO_INSTALL_HARDLINKS=YesPlease
             NO_CROSS_DIRECTORY_HARDLINKS=YesPlease
+            SKIP_DASHED_BUILT_INS=YesPlease
           )
           jobs="${NUMBER_OF_PROCESSORS:-2}"
           make -j"$jobs" "${make_args[@]}" all
@@ -296,6 +319,7 @@ jobs:
             test -f /tmp/build/git/cmd/git.exe
             test -f "/tmp/build/git/$MINGW_DIR/libexec/git-core/git-lfs.exe"
             test -d "/tmp/build/git/$MINGW_DIR/share/git-core/templates"
+            test ! -e "/tmp/build/git/$MINGW_DIR/libexec/git-core/git-add.exe"
             if test "$HAS_GCM" = true
             then
               test -f "/tmp/build/git/$MINGW_DIR/bin/git-credential-manager.exe"
@@ -306,6 +330,8 @@ jobs:
             if test "$HAS_GCM" = true
             then
               test -x /tmp/build/git/libexec/git-core/git-credential-manager
+            else
+              test ! -e /tmp/build/git/libexec/git-core/git-credential-manager
             fi
           fi
           test -f /tmp/build/git/etc/gitconfig
@@ -320,6 +346,7 @@ jobs:
         env:
           TARGET_PLATFORM: ${{ matrix.target_platform }}
           MINGW_DIR: ${{ matrix.mingw_dir }}
+          HAS_GCM: ${{ matrix.has_gcm }}
         run: |
           set -euo pipefail
           smoke=/tmp/codex-git-smoke
@@ -352,7 +379,10 @@ jobs:
           printf '%s\n' "$build_options"
           grep -F "built from commit: $GITHUB_SHA" <<<"$build_options"
           env "${git_env[@]}" "$git_binary" lfs version
-          env "${git_env[@]}" "$git_binary" credential-manager --version
+          if test "$HAS_GCM" = true
+          then
+            env "${git_env[@]}" "$git_binary" credential-manager --version
+          fi
 
           env "${git_env[@]}" "$git_binary" init --quiet "$smoke/repo"
           echo test >"$smoke/repo/file"
@@ -371,6 +401,7 @@ jobs:
           TARGET_PLATFORM: ${{ matrix.target_platform }}
           TARGET_ARCH: ${{ matrix.arch }}
           VERSION: ${{ needs.version.outputs.version }}
+          MAX_TAR_BYTES: ${{ matrix.max_tar_bytes }}
         run: |
           set -euo pipefail
           script/package.sh
@@ -400,6 +431,11 @@ jobs:
             fi
             test "$actual" = "$expected"
           done
+
+          tarball="output/git-$VERSION-$ASSET_PLATFORM-$TARGET_ARCH.tar.gz"
+          tar_bytes="$(wc -c <"$tarball")"
+          printf '%s bytes: %s\n' "$tar_bytes" "$tarball"
+          test "$tar_bytes" -le "$MAX_TAR_BYTES"
 
       - name: Upload release assets
         uses: actions/upload-artifact@v7

--- a/.github/workflows/codex-release.yml
+++ b/.github/workflows/codex-release.yml
@@ -117,6 +117,7 @@ jobs:
             binary: /tmp/build/git/bin/git
             file_pattern: Mach-O 64-bit executable arm64
             has_gcm: false
+            lto: thin
             max_tar_bytes: 67108864
           - name: macOS x64
             os: macos-15-intel
@@ -126,6 +127,7 @@ jobs:
             binary: /tmp/build/git/bin/git
             file_pattern: Mach-O 64-bit executable x86_64
             has_gcm: false
+            lto: thin
             max_tar_bytes: 67108864
           # Keep arm64 builds native so release smoke tests can execute them.
           - name: Linux arm64
@@ -136,6 +138,7 @@ jobs:
             binary: /tmp/build/git/bin/git
             file_pattern: ELF 64-bit.*ARM aarch64
             has_gcm: false
+            lto: auto
             max_tar_bytes: 67108864
           - name: Linux x64
             os: ubuntu-22.04
@@ -145,6 +148,7 @@ jobs:
             binary: /tmp/build/git/bin/git
             file_pattern: ELF 64-bit.*x86-64
             has_gcm: false
+            lto: auto
             max_tar_bytes: 67108864
           - name: Windows arm64
             os: windows-11-arm
@@ -154,6 +158,7 @@ jobs:
             binary: /tmp/build/git/clangarm64/bin/git.exe
             file_pattern: PE32\+.*ARM64
             has_gcm: true
+            lto: thin
             max_tar_bytes: 134217728
             sdk_arch: aarch64
             sdk_flavor: full
@@ -170,6 +175,7 @@ jobs:
             binary: /tmp/build/git/mingw64/bin/git.exe
             file_pattern: PE32\+.*x86-64
             has_gcm: true
+            lto: auto
             max_tar_bytes: 134217728
             sdk_arch: x86_64
             sdk_flavor: full
@@ -209,6 +215,11 @@ jobs:
             -c 'user.name=github-actions[bot]' \
             -c 'user.email=41898282+github-actions[bot]@users.noreply.github.com' \
             tag -a "$VERSION" -m "$VERSION"
+
+      - name: Install OpenAI build configuration
+        shell: bash
+        working-directory: dugite-native/git
+        run: cp config.mak.openai config.mak
 
       # Match Dugite Native's compatibility choice for its macOS x64 build.
       - name: Select Xcode 16.4
@@ -305,6 +316,7 @@ jobs:
         working-directory: dugite-native
         env:
           NO_RUST: 1
+          OPENAI_LTO: ${{ matrix.lto }}
           TARGET_PLATFORM: ${{ matrix.target_platform }}
           TARGET_ARCH: ${{ matrix.arch }}
         run: |
@@ -330,6 +342,7 @@ jobs:
         working-directory: dugite-native/git
         env:
           MINGW_DIR: ${{ matrix.mingw_dir }}
+          OPENAI_LTO: ${{ matrix.lto }}
         run: |
           set -euo pipefail
 
@@ -355,6 +368,7 @@ jobs:
           GIT_BINARY: ${{ matrix.binary }}
           FILE_PATTERN: ${{ matrix.file_pattern }}
           HAS_GCM: ${{ matrix.has_gcm }}
+          LTO: ${{ matrix.lto }}
         run: |
           set -euo pipefail
           if test "$TARGET_PLATFORM" = win32
@@ -382,6 +396,7 @@ jobs:
           file "$GIT_BINARY" | tee /tmp/git-file-type
           grep -E "$FILE_PATTERN" /tmp/git-file-type
           strings "$GIT_BINARY" | grep -F "$GITHUB_SHA"
+          grep -F -- "-flto=$LTO" dugite-native/git/GIT-CFLAGS
 
       - name: Smoke-test the native distribution
         shell: bash

--- a/.github/workflows/codex-release.yml
+++ b/.github/workflows/codex-release.yml
@@ -69,7 +69,7 @@ jobs:
             binary: /tmp/build/git/bin/git
             file_pattern: Mach-O 64-bit executable arm64
             has_gcm: false
-            max_tar_bytes: 33554432
+            max_tar_bytes: 67108864
           - name: macOS x64
             os: macos-15-intel
             target_platform: macOS
@@ -78,7 +78,7 @@ jobs:
             binary: /tmp/build/git/bin/git
             file_pattern: Mach-O 64-bit executable x86_64
             has_gcm: false
-            max_tar_bytes: 33554432
+            max_tar_bytes: 67108864
           - name: Linux arm64
             os: ubuntu-22.04
             target_platform: ubuntu
@@ -87,7 +87,7 @@ jobs:
             binary: /tmp/build/git/bin/git
             file_pattern: ELF 64-bit.*ARM aarch64
             has_gcm: false
-            max_tar_bytes: 41943040
+            max_tar_bytes: 67108864
           - name: Linux x64
             os: ubuntu-22.04
             target_platform: ubuntu
@@ -96,7 +96,7 @@ jobs:
             binary: /tmp/build/git/bin/git
             file_pattern: ELF 64-bit.*x86-64
             has_gcm: false
-            max_tar_bytes: 41943040
+            max_tar_bytes: 67108864
           - name: Windows arm64
             os: windows-11-arm
             target_platform: win32
@@ -105,7 +105,7 @@ jobs:
             binary: /tmp/build/git/clangarm64/bin/git.exe
             file_pattern: PE32\+.*ARM64
             has_gcm: true
-            max_tar_bytes: 83886080
+            max_tar_bytes: 134217728
             sdk_arch: aarch64
             sdk_flavor: full
             mingw_dir: clangarm64
@@ -121,7 +121,7 @@ jobs:
             binary: /tmp/build/git/mingw64/bin/git.exe
             file_pattern: PE32\+.*x86-64
             has_gcm: true
-            max_tar_bytes: 83886080
+            max_tar_bytes: 134217728
             sdk_arch: x86_64
             sdk_flavor: full
             mingw_dir: mingw64

--- a/.github/workflows/codex-release.yml
+++ b/.github/workflows/codex-release.yml
@@ -127,8 +127,9 @@ jobs:
             file_pattern: Mach-O 64-bit executable x86_64
             has_gcm: false
             max_tar_bytes: 67108864
+          # Keep arm64 builds native so release smoke tests can execute them.
           - name: Linux arm64
-            os: ubuntu-22.04
+            os: ubuntu-22.04-arm
             target_platform: ubuntu
             asset_platform: ubuntu
             arch: arm64
@@ -243,19 +244,13 @@ jobs:
       - name: Install Linux arm64 build dependencies
         if: matrix.target_platform == 'ubuntu' && matrix.arch == 'arm64'
         run: |
-          sudo sed -i "s/^deb/deb [arch=amd64,i386]/g" /etc/apt/sources.list
-          release="$(lsb_release -s -c)"
-          echo "deb [arch=arm64,armhf] http://azure.ports.ubuntu.com/ ${release} main universe multiverse restricted" | sudo tee -a /etc/apt/sources.list
-          echo "deb [arch=arm64,armhf] http://azure.ports.ubuntu.com/ ${release}-updates main universe multiverse restricted" | sudo tee -a /etc/apt/sources.list
-          sudo dpkg --add-architecture arm64
-          sudo apt-get update
           sudo apt-get install -y \
             binutils-aarch64-linux-gnu \
             gcc-aarch64-linux-gnu \
-            libcurl4-gnutls-dev:arm64 \
-            libexpat1-dev:arm64 \
-            libssl-dev:arm64 \
-            zlib1g-dev:arm64
+            libcurl4-gnutls-dev \
+            libexpat1-dev \
+            libssl-dev \
+            zlib1g-dev
 
       # Dugite Native currently pins MinGit 2.53. Keep its build script and
       # dependency schema, but match the runtime to the Git series we compile.
@@ -389,7 +384,6 @@ jobs:
           strings "$GIT_BINARY" | grep -F "$GITHUB_SHA"
 
       - name: Smoke-test the native distribution
-        if: matrix.arch == 'x64' || matrix.target_platform == 'win32'
         shell: bash
         env:
           TARGET_PLATFORM: ${{ matrix.target_platform }}

--- a/.github/workflows/codex-release.yml
+++ b/.github/workflows/codex-release.yml
@@ -13,8 +13,42 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  publication:
+    name: Verify controller publication
+    runs-on: ubuntu-24.04
+    outputs:
+      published: ${{ steps.verify.outputs.published }}
+    steps:
+      - name: Check the published controller output
+        id: verify
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          meta=$(gh api \
+            "repos/$GITHUB_REPOSITORY/git/ref/heads/meta" \
+            --jq '.object.sha')
+          recorded=$(gh api \
+            "repos/$GITHUB_REPOSITORY/contents/codex.config?ref=$meta" \
+            -H 'Accept: application/vnd.github.raw+json' |
+            git config --no-includes --file /dev/stdin \
+              --get codex.output-tip)
+
+          if test "$GITHUB_SHA" = "$recorded"
+          then
+            printf 'published=true\n' >>"$GITHUB_OUTPUT"
+            printf 'Releasing controller-published commit %s.\n' "$GITHUB_SHA"
+          else
+            printf 'published=false\n' >>"$GITHUB_OUTPUT"
+            printf 'Skipping non-controller publication %s.\n' "$GITHUB_SHA"
+          fi
+
   version:
     name: Determine version
+    needs: publication
+    if: needs.publication.outputs.published == 'true'
     runs-on: ubuntu-24.04
     outputs:
       describe: ${{ steps.version.outputs.describe }}

--- a/.github/workflows/codex-release.yml
+++ b/.github/workflows/codex-release.yml
@@ -235,14 +235,6 @@ jobs:
             dependencies.json >"$updated"
           mv "$updated" dependencies.json
 
-      - name: Set up Git for Windows SDK
-        if: matrix.target_platform == 'win32'
-        uses: git-for-windows/setup-git-for-windows-sdk@v2
-        with:
-          architecture: ${{ matrix.sdk_arch }}
-          flavor: ${{ matrix.sdk_flavor }}
-          cache: false
-
       # Dugite cross-compiles several targets. Keep Git's optional Rust
       # library disabled until its Makefile can direct Cargo at those targets.
       - name: Build the Dugite Native distribution
@@ -254,11 +246,15 @@ jobs:
           TARGET_ARCH: ${{ matrix.arch }}
         run: |
           set -euo pipefail
-          if test "$TARGET_PLATFORM" = win32
-          then
-            . /etc/profile
-          fi
           script/build.sh
+
+      - name: Set up Git for Windows SDK
+        if: matrix.target_platform == 'win32'
+        uses: git-for-windows/setup-git-for-windows-sdk@v2
+        with:
+          architecture: ${{ matrix.sdk_arch }}
+          flavor: ${{ matrix.sdk_flavor }}
+          cache: false
 
       # Dugite Native compiles its Git submodule on macOS and Linux. On
       # Windows it starts from MinGit, so replace MinGit's Git programs with

--- a/.github/workflows/codex-release.yml
+++ b/.github/workflows/codex-release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - codex
+      - codex-unstable
 
 permissions:
   contents: read
@@ -16,6 +17,7 @@ jobs:
   publication:
     name: Verify controller publication
     runs-on: ubuntu-24.04
+    if: github.event.deleted == false
     outputs:
       published: ${{ steps.verify.outputs.published }}
     steps:
@@ -26,6 +28,18 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
+          case "$GITHUB_REF" in
+          refs/heads/codex)
+            output_key=codex.output-tip
+            ;;
+          refs/heads/codex-unstable)
+            output_key=codex-unstable.output-tip
+            ;;
+          *)
+            printf 'unexpected release ref: %s\n' "$GITHUB_REF" >&2
+            exit 1
+            ;;
+          esac
 
           meta=$(gh api \
             "repos/$GITHUB_REPOSITORY/git/ref/heads/meta" \
@@ -34,7 +48,7 @@ jobs:
             "repos/$GITHUB_REPOSITORY/contents/codex.config?ref=$meta" \
             -H 'Accept: application/vnd.github.raw+json' |
             git config --no-includes --file /dev/stdin \
-              --get codex.output-tip)
+              --get "$output_key")
 
           if test "$GITHUB_SHA" = "$recorded"
           then

--- a/.github/workflows/codex-release.yml
+++ b/.github/workflows/codex-release.yml
@@ -117,7 +117,7 @@ jobs:
             file_pattern: PE32\+.*x86-64
             has_gcm: true
             sdk_arch: x86_64
-            sdk_flavor: minimal
+            sdk_flavor: full
             mingw_dir: mingw64
             mingit_arch: amd64
             mingit_filename: MinGit-2.55.0.2-64-bit.zip
@@ -267,7 +267,6 @@ jobs:
           MINGW_DIR: ${{ matrix.mingw_dir }}
         run: |
           set -euo pipefail
-          . /etc/profile
 
           make_args=(
             "prefix=/$MINGW_DIR"
@@ -294,7 +293,6 @@ jobs:
           set -euo pipefail
           if test "$TARGET_PLATFORM" = win32
           then
-            . /etc/profile
             test -f /tmp/build/git/cmd/git.exe
             test -f "/tmp/build/git/$MINGW_DIR/libexec/git-core/git-lfs.exe"
             test -d "/tmp/build/git/$MINGW_DIR/share/git-core/templates"
@@ -329,7 +327,6 @@ jobs:
 
           if test "$TARGET_PLATFORM" = win32
           then
-            . /etc/profile
             git_binary=/tmp/build/git/cmd/git.exe
             git_env=(
               "PATH=/tmp/build/git/cmd:/tmp/build/git/$MINGW_DIR/bin:/tmp/build/git/usr/bin:$PATH"
@@ -376,10 +373,6 @@ jobs:
           VERSION: ${{ needs.version.outputs.version }}
         run: |
           set -euo pipefail
-          if test "$TARGET_PLATFORM" = win32
-          then
-            . /etc/profile
-          fi
           script/package.sh
 
           for extension in tar.gz lzma
@@ -415,6 +408,15 @@ jobs:
           path: dugite-native/output/git-*
           if-no-files-found: error
           retention-days: 7
+
+      # The arm64 SDK puts its target Git first on PATH, but action cleanup
+      # runs on the x64 host and therefore needs the runner's native Git.
+      - name: Restore native Git for action cleanup
+        if: always() && matrix.target_platform == 'win32'
+        shell: pwsh
+        run: |
+          "C:\Program Files\Git\cmd" |
+            Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
   release:
     name: Publish GitHub prerelease

--- a/.github/workflows/codex-release.yml
+++ b/.github/workflows/codex-release.yml
@@ -99,7 +99,7 @@ jobs:
             asset_platform: windows
             arch: arm64
             binary: /tmp/build/git/clangarm64/bin/git.exe
-            file_pattern: PE32\+.*Aarch64
+            file_pattern: PE32\+.*ARM64
             has_gcm: true
             sdk_arch: aarch64
             sdk_flavor: full

--- a/.github/workflows/codex-release.yml
+++ b/.github/workflows/codex-release.yml
@@ -69,7 +69,7 @@ jobs:
       upstream_tag: ${{ steps.version.outputs.upstream_tag }}
       version: ${{ steps.version.outputs.version }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -198,7 +198,7 @@ jobs:
       # Keep the packaging contract, dependency pins, and platform build logic
       # aligned with the artifacts already consumed by Codex and GitHub Desktop.
       - name: Check out Dugite Native
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           repository: desktop/dugite-native
           ref: f97e50add48cdcff053a69d95aa343a4a4a258c2
@@ -207,7 +207,7 @@ jobs:
           persist-credentials: false
 
       - name: Check out this Git revision
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           ref: ${{ github.sha }}
           path: dugite-native/git
@@ -338,7 +338,7 @@ jobs:
 
       - name: Set up Git for Windows SDK
         if: matrix.target_platform == 'win32'
-        uses: git-for-windows/setup-git-for-windows-sdk@v2
+        uses: git-for-windows/setup-git-for-windows-sdk@335917db02da4280d3d5e87915d7b86196677f9f # v2
         with:
           architecture: ${{ matrix.sdk_arch }}
           flavor: ${{ matrix.sdk_flavor }}
@@ -517,7 +517,7 @@ jobs:
           test "$tar_bytes" -le "$MAX_TAR_BYTES"
 
       - name: Upload release assets
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: git-${{ matrix.asset_platform }}-${{ matrix.arch }}
           path: dugite-native/output/git-*
@@ -544,7 +544,7 @@ jobs:
       contents: write
     steps:
       - name: Download release assets
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           pattern: git-*
           path: artifacts

--- a/.github/workflows/codex-release.yml
+++ b/.github/workflows/codex-release.yml
@@ -1,0 +1,461 @@
+name: Codex Git release
+
+on:
+  push:
+    branches:
+      - codex
+
+permissions:
+  contents: read
+
+concurrency:
+  group: codex-git-release-${{ github.sha }}
+  cancel-in-progress: false
+
+jobs:
+  version:
+    name: Determine version
+    runs-on: ubuntu-24.04
+    outputs:
+      describe: ${{ steps.version.outputs.describe }}
+      upstream_tag: ${{ steps.version.outputs.upstream_tag }}
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Derive OpenAI version from git describe
+        id: version
+        shell: bash
+        run: |
+          set -euo pipefail
+          describe="$(git describe \
+            --match 'v[0-9]*' \
+            --exclude 'v*-openai.*' \
+            --long \
+            --always \
+            --abbrev=12 \
+            "$GITHUB_SHA")"
+
+          if [[ "$describe" =~ ^(.+)-([0-9]+)-g([0-9a-f]+)$ ]]
+          then
+            upstream_tag="${BASH_REMATCH[1]}"
+            version="$upstream_tag-openai.${BASH_REMATCH[2]}.g${BASH_REMATCH[3]}"
+          else
+            upstream_tag=
+            version="openai-$describe"
+          fi
+          git check-ref-format "refs/tags/$version"
+          printf 'describe=%s\n' "$describe" | tee -a "$GITHUB_OUTPUT"
+          printf 'upstream_tag=%s\n' "$upstream_tag" | tee -a "$GITHUB_OUTPUT"
+          printf 'version=%s\n' "$version" | tee -a "$GITHUB_OUTPUT"
+
+  build:
+    name: ${{ matrix.name }}
+    needs: version
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: macOS arm64
+            os: macos-15
+            target_platform: macOS
+            asset_platform: macOS
+            arch: arm64
+            binary: /tmp/build/git/bin/git
+            file_pattern: Mach-O 64-bit executable arm64
+            has_gcm: true
+          - name: macOS x64
+            os: macos-15-intel
+            target_platform: macOS
+            asset_platform: macOS
+            arch: x64
+            binary: /tmp/build/git/bin/git
+            file_pattern: Mach-O 64-bit executable x86_64
+            has_gcm: true
+          - name: Linux arm64
+            os: ubuntu-22.04
+            target_platform: ubuntu
+            asset_platform: ubuntu
+            arch: arm64
+            binary: /tmp/build/git/bin/git
+            file_pattern: ELF 64-bit.*ARM aarch64
+            has_gcm: false
+          - name: Linux x64
+            os: ubuntu-22.04
+            target_platform: ubuntu
+            asset_platform: ubuntu
+            arch: x64
+            binary: /tmp/build/git/bin/git
+            file_pattern: ELF 64-bit.*x86-64
+            has_gcm: true
+          - name: Windows arm64
+            os: windows-2025
+            target_platform: win32
+            asset_platform: windows
+            arch: arm64
+            binary: /tmp/build/git/clangarm64/bin/git.exe
+            file_pattern: PE32\+.*Aarch64
+            has_gcm: true
+            sdk_arch: aarch64
+            sdk_flavor: full
+            mingw_dir: clangarm64
+            mingit_arch: arm64
+            mingit_filename: MinGit-2.55.0.2-arm64.zip
+            mingit_url: https://github.com/git-for-windows/git/releases/download/v2.55.0.windows.2/MinGit-2.55.0.2-arm64.zip
+            mingit_sha256: 0b2b81fdce284efd174cbb51b886ccea2fd271679c4b5c21f07d9e03bae51413
+          - name: Windows x64
+            os: windows-2025
+            target_platform: win32
+            asset_platform: windows
+            arch: x64
+            binary: /tmp/build/git/mingw64/bin/git.exe
+            file_pattern: PE32\+.*x86-64
+            has_gcm: true
+            sdk_arch: x86_64
+            sdk_flavor: minimal
+            mingw_dir: mingw64
+            mingit_arch: amd64
+            mingit_filename: MinGit-2.55.0.2-64-bit.zip
+            mingit_url: https://github.com/git-for-windows/git/releases/download/v2.55.0.windows.2/MinGit-2.55.0.2-64-bit.zip
+            mingit_sha256: e3ea2944cea4b3fabcd69c7c1669ef69b1b66c05ac7806d81224d0abad2dec31
+
+    steps:
+      # Keep the packaging contract, dependency pins, and platform build logic
+      # aligned with the artifacts already consumed by Codex and GitHub Desktop.
+      - name: Check out Dugite Native
+        uses: actions/checkout@v6
+        with:
+          repository: desktop/dugite-native
+          ref: f97e50add48cdcff053a69d95aa343a4a4a258c2
+          path: dugite-native
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Check out this Git revision
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.sha }}
+          path: dugite-native/git
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Give the source an immutable package version
+        shell: bash
+        working-directory: dugite-native/git
+        env:
+          VERSION: ${{ needs.version.outputs.version }}
+        run: |
+          git \
+            -c 'user.name=github-actions[bot]' \
+            -c 'user.email=41898282+github-actions[bot]@users.noreply.github.com' \
+            tag -a "$VERSION" -m "$VERSION"
+
+      # Match Dugite Native's compatibility choice for its macOS x64 build.
+      - name: Select Xcode 16.4
+        if: matrix.target_platform == 'macOS' && matrix.arch == 'x64'
+        run: |
+          sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer/
+          sudo rm -rf /Library/Developer/CommandLineTools
+
+      - name: Install Linux build dependencies
+        if: matrix.target_platform == 'ubuntu'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            autoconf \
+            automake \
+            build-essential \
+            ca-certificates \
+            curl \
+            gettext \
+            jq \
+            lsb-release \
+            pkg-config
+
+      - name: Install Linux x64 build dependencies
+        if: matrix.target_platform == 'ubuntu' && matrix.arch == 'x64'
+        run: |
+          sudo apt-get install -y \
+            libcurl4-gnutls-dev \
+            libexpat1-dev \
+            libssl-dev \
+            zlib1g-dev
+
+      - name: Install Linux arm64 build dependencies
+        if: matrix.target_platform == 'ubuntu' && matrix.arch == 'arm64'
+        run: |
+          sudo sed -i "s/^deb/deb [arch=amd64,i386]/g" /etc/apt/sources.list
+          release="$(lsb_release -s -c)"
+          echo "deb [arch=arm64,armhf] http://azure.ports.ubuntu.com/ ${release} main universe multiverse restricted" | sudo tee -a /etc/apt/sources.list
+          echo "deb [arch=arm64,armhf] http://azure.ports.ubuntu.com/ ${release}-updates main universe multiverse restricted" | sudo tee -a /etc/apt/sources.list
+          sudo dpkg --add-architecture arm64
+          sudo apt-get update
+          sudo apt-get install -y \
+            binutils-aarch64-linux-gnu \
+            gcc-aarch64-linux-gnu \
+            libcurl4-gnutls-dev:arm64 \
+            libexpat1-dev:arm64 \
+            libssl-dev:arm64 \
+            zlib1g-dev:arm64
+
+      # Dugite Native currently pins MinGit 2.53. Keep its build script and
+      # dependency schema, but match the runtime to the Git series we compile.
+      - name: Select the matching MinGit runtime
+        if: matrix.target_platform == 'win32'
+        shell: bash
+        working-directory: dugite-native
+        env:
+          MINGIT_ARCH: ${{ matrix.mingit_arch }}
+          MINGIT_FILENAME: ${{ matrix.mingit_filename }}
+          MINGIT_SHA256: ${{ matrix.mingit_sha256 }}
+          MINGIT_URL: ${{ matrix.mingit_url }}
+          MINGIT_VERSION: v2.55.0
+          SOURCE_UPSTREAM_TAG: ${{ needs.version.outputs.upstream_tag }}
+        run: |
+          set -euo pipefail
+          test "$SOURCE_UPSTREAM_TAG" = "$MINGIT_VERSION"
+          updated="$(mktemp)"
+          jq \
+            --arg arch "$MINGIT_ARCH" \
+            --arg checksum "$MINGIT_SHA256" \
+            --arg filename "$MINGIT_FILENAME" \
+            --arg url "$MINGIT_URL" \
+            --arg version "$MINGIT_VERSION" \
+            '.git.version = $version |
+             (.git.files[] |
+                select(.platform == "windows" and .arch == $arch)) |=
+               (.filename = $filename |
+                .url = $url |
+                .checksum = $checksum)' \
+            dependencies.json >"$updated"
+          mv "$updated" dependencies.json
+
+      - name: Set up Git for Windows SDK
+        if: matrix.target_platform == 'win32'
+        uses: git-for-windows/setup-git-for-windows-sdk@v2
+        with:
+          architecture: ${{ matrix.sdk_arch }}
+          flavor: ${{ matrix.sdk_flavor }}
+          cache: false
+
+      # Dugite cross-compiles several targets. Keep Git's optional Rust
+      # library disabled until its Makefile can direct Cargo at those targets.
+      - name: Build the Dugite Native distribution
+        shell: bash
+        working-directory: dugite-native
+        env:
+          NO_RUST: 1
+          TARGET_PLATFORM: ${{ matrix.target_platform }}
+          TARGET_ARCH: ${{ matrix.arch }}
+        run: |
+          set -euo pipefail
+          if test "$TARGET_PLATFORM" = win32
+          then
+            . /etc/profile
+          fi
+          script/build.sh
+
+      # Dugite Native compiles its Git submodule on macOS and Linux. On
+      # Windows it starts from MinGit, so replace MinGit's Git programs with
+      # the build from this repository while retaining the portable runtime.
+      - name: Install this Git build into the Windows distribution
+        if: matrix.target_platform == 'win32'
+        shell: bash
+        working-directory: dugite-native/git
+        env:
+          MINGW_DIR: ${{ matrix.mingw_dir }}
+        run: |
+          set -euo pipefail
+          . /etc/profile
+
+          make_args=(
+            "prefix=/$MINGW_DIR"
+            NO_PERL=YesPlease
+            NO_RUST=YesPlease
+            NO_TCLTK=YesPlease
+            NO_GETTEXT=YesPlease
+            NO_INSTALL_HARDLINKS=YesPlease
+            NO_CROSS_DIRECTORY_HARDLINKS=YesPlease
+          )
+          jobs="$(nproc)"
+          make -j"$jobs" "${make_args[@]}" all
+          make "${make_args[@]}" DESTDIR=/tmp/build/git strip install
+
+      - name: Verify distribution layout and provenance
+        shell: bash
+        env:
+          TARGET_PLATFORM: ${{ matrix.target_platform }}
+          MINGW_DIR: ${{ matrix.mingw_dir }}
+          GIT_BINARY: ${{ matrix.binary }}
+          FILE_PATTERN: ${{ matrix.file_pattern }}
+          HAS_GCM: ${{ matrix.has_gcm }}
+        run: |
+          set -euo pipefail
+          if test "$TARGET_PLATFORM" = win32
+          then
+            . /etc/profile
+            test -f /tmp/build/git/cmd/git.exe
+            test -f "/tmp/build/git/$MINGW_DIR/libexec/git-core/git-lfs.exe"
+            test -d "/tmp/build/git/$MINGW_DIR/share/git-core/templates"
+            if test "$HAS_GCM" = true
+            then
+              test -f "/tmp/build/git/$MINGW_DIR/bin/git-credential-manager.exe"
+            fi
+          else
+            test -x /tmp/build/git/libexec/git-core/git-lfs
+            test -d /tmp/build/git/share/git-core/templates
+            if test "$HAS_GCM" = true
+            then
+              test -x /tmp/build/git/libexec/git-core/git-credential-manager
+            fi
+          fi
+          test -f /tmp/build/git/etc/gitconfig
+
+          file "$GIT_BINARY" | tee /tmp/git-file-type
+          grep -E "$FILE_PATTERN" /tmp/git-file-type
+          strings "$GIT_BINARY" | grep -F "$GITHUB_SHA"
+
+      - name: Smoke-test the native x64 distribution
+        if: matrix.arch == 'x64'
+        shell: bash
+        env:
+          TARGET_PLATFORM: ${{ matrix.target_platform }}
+          MINGW_DIR: ${{ matrix.mingw_dir }}
+        run: |
+          set -euo pipefail
+          smoke=/tmp/codex-git-smoke
+          mkdir -p "$smoke/home"
+
+          if test "$TARGET_PLATFORM" = win32
+          then
+            . /etc/profile
+            git_binary=/tmp/build/git/cmd/git.exe
+            git_env=(
+              "PATH=/tmp/build/git/cmd:/tmp/build/git/$MINGW_DIR/bin:/tmp/build/git/usr/bin:$PATH"
+            )
+          else
+            git_binary=/tmp/build/git/bin/git
+            git_env=(
+              GIT_CONFIG_SYSTEM=/tmp/build/git/etc/gitconfig
+              GIT_EXEC_PATH=/tmp/build/git/libexec/git-core
+              GIT_TEMPLATE_DIR=/tmp/build/git/share/git-core/templates
+            )
+            if test "$TARGET_PLATFORM" = ubuntu
+            then
+              git_env+=(
+                GIT_SSL_CAINFO=/tmp/build/git/ssl/cacert.pem
+                PREFIX=/tmp/build/git
+              )
+            fi
+          fi
+          git_env+=("HOME=$smoke/home" GIT_TERMINAL_PROMPT=0)
+
+          build_options="$(env "${git_env[@]}" "$git_binary" --version --build-options)"
+          printf '%s\n' "$build_options"
+          grep -F "built from commit: $GITHUB_SHA" <<<"$build_options"
+          env "${git_env[@]}" "$git_binary" lfs version
+          env "${git_env[@]}" "$git_binary" credential-manager --version
+
+          env "${git_env[@]}" "$git_binary" init --quiet "$smoke/repo"
+          echo test >"$smoke/repo/file"
+          env "${git_env[@]}" "$git_binary" -C "$smoke/repo" add file
+          env "${git_env[@]}" "$git_binary" -C "$smoke/repo" \
+            -c user.name='Codex Git CI' \
+            -c user.email='codex-git-ci@openai.com' \
+            commit --quiet -m initial
+          test -z "$(env "${git_env[@]}" "$git_binary" -C "$smoke/repo" status --porcelain)"
+
+      - name: Package with Dugite Native
+        shell: bash
+        working-directory: dugite-native
+        env:
+          ASSET_PLATFORM: ${{ matrix.asset_platform }}
+          TARGET_PLATFORM: ${{ matrix.target_platform }}
+          TARGET_ARCH: ${{ matrix.arch }}
+          VERSION: ${{ needs.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          if test "$TARGET_PLATFORM" = win32
+          then
+            . /etc/profile
+          fi
+          script/package.sh
+
+          for extension in tar.gz lzma
+          do
+            matches=(
+              output/dugite-native-"$VERSION"-*-"$ASSET_PLATFORM"-"$TARGET_ARCH.$extension"
+            )
+            test "${#matches[@]}" -eq 1
+            test -f "${matches[0]}"
+
+            destination="output/git-$VERSION-$ASSET_PLATFORM-$TARGET_ARCH.$extension"
+            mv "${matches[0]}" "$destination"
+            mv "${matches[0]}.sha256" "$destination.sha256"
+          done
+
+          for checksum in output/*.sha256
+          do
+            archive="${checksum%.sha256}"
+            expected="$(tr -d '\r\n' <"$checksum")"
+            if command -v sha256sum >/dev/null 2>&1
+            then
+              actual="$(sha256sum "$archive" | awk '{print $1}')"
+            else
+              actual="$(shasum -a 256 "$archive" | awk '{print $1}')"
+            fi
+            test "$actual" = "$expected"
+          done
+
+      - name: Upload release assets
+        uses: actions/upload-artifact@v7
+        with:
+          name: git-${{ matrix.asset_platform }}-${{ matrix.arch }}
+          path: dugite-native/output/git-*
+          if-no-files-found: error
+          retention-days: 7
+
+  release:
+    name: Publish GitHub prerelease
+    needs:
+      - version
+      - build
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    steps:
+      - name: Download release assets
+        uses: actions/download-artifact@v8
+        with:
+          pattern: git-*
+          path: artifacts
+          merge-multiple: true
+
+      - name: Publish immutable prerelease
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SOURCE_DESCRIPTION: ${{ needs.version.outputs.describe }}
+          VERSION: ${{ needs.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          assets=(artifacts/git-*)
+
+          if gh release view "$VERSION" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1
+          then
+            gh release upload "$VERSION" "${assets[@]}" \
+              --repo "$GITHUB_REPOSITORY" \
+              --clobber
+          else
+            gh release create "$VERSION" "${assets[@]}" \
+              --repo "$GITHUB_REPOSITORY" \
+              --target "$GITHUB_SHA" \
+              --title "$VERSION" \
+              --notes "OpenAI Git release artifacts for $SOURCE_DESCRIPTION, built from $GITHUB_SHA for Codex." \
+              --prerelease
+          fi

--- a/.github/workflows/codex-release.yml
+++ b/.github/workflows/codex-release.yml
@@ -104,7 +104,7 @@ jobs:
     name: ${{ matrix.name }}
     needs: version
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 30
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -118,6 +118,8 @@ jobs:
             file_pattern: Mach-O 64-bit executable arm64
             has_gcm: false
             lto: thin
+            profile_format: LLVM
+            llvm_profdata: xcrun llvm-profdata
             max_tar_bytes: 67108864
           - name: macOS x64
             os: macos-15-intel
@@ -128,6 +130,8 @@ jobs:
             file_pattern: Mach-O 64-bit executable x86_64
             has_gcm: false
             lto: thin
+            profile_format: LLVM
+            llvm_profdata: xcrun llvm-profdata
             max_tar_bytes: 67108864
           # Keep arm64 builds native so release smoke tests can execute them.
           - name: Linux arm64
@@ -139,6 +143,7 @@ jobs:
             file_pattern: ELF 64-bit.*ARM aarch64
             has_gcm: false
             lto: auto
+            profile_format: GCC
             max_tar_bytes: 67108864
           - name: Linux x64
             os: ubuntu-22.04
@@ -149,6 +154,7 @@ jobs:
             file_pattern: ELF 64-bit.*x86-64
             has_gcm: false
             lto: auto
+            profile_format: GCC
             max_tar_bytes: 67108864
           - name: Windows arm64
             os: windows-11-arm
@@ -159,6 +165,8 @@ jobs:
             file_pattern: PE32\+.*ARM64
             has_gcm: true
             lto: thin
+            profile_format: LLVM
+            llvm_profdata: llvm-profdata
             max_tar_bytes: 134217728
             sdk_arch: aarch64
             sdk_flavor: full
@@ -176,6 +184,7 @@ jobs:
             file_pattern: PE32\+.*x86-64
             has_gcm: true
             lto: auto
+            profile_format: GCC
             max_tar_bytes: 134217728
             sdk_arch: x86_64
             sdk_flavor: full
@@ -309,14 +318,18 @@ jobs:
             dependencies.json >"$updated"
           mv "$updated" dependencies.json
 
-      # Dugite cross-compiles several targets. Keep Git's optional Rust
-      # library disabled until its Makefile can direct Cargo at those targets.
+      # Build an instrumented Git, run a representative local workload, then
+      # rebuild with its profile. Keep Git's optional Rust library disabled
+      # until its Makefile can direct Cargo at these targets.
       - name: Build the Dugite Native distribution
         shell: bash
         working-directory: dugite-native
         env:
           NO_RUST: 1
+          OPENAI_LLVM_PROFDATA: ${{ matrix.llvm_profdata }}
           OPENAI_LTO: ${{ matrix.lto }}
+          OPENAI_PROFILE: BUILD
+          OPENAI_PROFILE_FORMAT: ${{ matrix.profile_format }}
           TARGET_PLATFORM: ${{ matrix.target_platform }}
           TARGET_ARCH: ${{ matrix.arch }}
         run: |
@@ -342,7 +355,9 @@ jobs:
         working-directory: dugite-native/git
         env:
           MINGW_DIR: ${{ matrix.mingw_dir }}
+          OPENAI_LLVM_PROFDATA: ${{ matrix.llvm_profdata }}
           OPENAI_LTO: ${{ matrix.lto }}
+          OPENAI_PROFILE_FORMAT: ${{ matrix.profile_format }}
         run: |
           set -euo pipefail
 
@@ -357,8 +372,8 @@ jobs:
             SKIP_DASHED_BUILT_INS=YesPlease
           )
           jobs="${NUMBER_OF_PROCESSORS:-2}"
-          make -j"$jobs" "${make_args[@]}" all
-          make "${make_args[@]}" DESTDIR=/tmp/build/git strip install
+          make -j"$jobs" "${make_args[@]}" OPENAI_PROFILE=BUILD all
+          make "${make_args[@]}" OPENAI_PROFILE=USE DESTDIR=/tmp/build/git strip install
 
       - name: Verify distribution layout and provenance
         shell: bash
@@ -369,6 +384,7 @@ jobs:
           FILE_PATTERN: ${{ matrix.file_pattern }}
           HAS_GCM: ${{ matrix.has_gcm }}
           LTO: ${{ matrix.lto }}
+          PROFILE_FORMAT: ${{ matrix.profile_format }}
         run: |
           set -euo pipefail
           if test "$TARGET_PLATFORM" = win32
@@ -397,6 +413,12 @@ jobs:
           grep -E "$FILE_PATTERN" /tmp/git-file-type
           strings "$GIT_BINARY" | grep -F "$GITHUB_SHA"
           grep -F -- "-flto=$LTO" dugite-native/git/GIT-CFLAGS
+          if test "$PROFILE_FORMAT" = LLVM
+          then
+            grep -F -- "-fprofile-instr-use=" dugite-native/git/GIT-CFLAGS
+          else
+            grep -F -- "-fprofile-use=" dugite-native/git/GIT-CFLAGS
+          fi
 
       - name: Smoke-test the native distribution
         shell: bash

--- a/.github/workflows/codex-release.yml
+++ b/.github/workflows/codex-release.yml
@@ -523,10 +523,18 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           SOURCE_DESCRIPTION: ${{ needs.version.outputs.describe }}
+          SOURCE_REF: ${{ github.ref }}
           VERSION: ${{ needs.version.outputs.version }}
         run: |
           set -euo pipefail
           assets=(artifacts/git-*)
+          release_notes=$(
+            printf '%s\n' \
+              "source_ref=$SOURCE_REF" \
+              "source_sha=$GITHUB_SHA" \
+              "" \
+              "OpenAI Git release artifacts for $SOURCE_DESCRIPTION, built from $GITHUB_SHA for Codex."
+          )
 
           if gh release view "$VERSION" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1
           then
@@ -538,6 +546,6 @@ jobs:
               --repo "$GITHUB_REPOSITORY" \
               --target "$GITHUB_SHA" \
               --title "$VERSION" \
-              --notes "OpenAI Git release artifacts for $SOURCE_DESCRIPTION, built from $GITHUB_SHA for Codex." \
+              --notes "$release_notes" \
               --prerelease
           fi

--- a/.github/workflows/codex-release.yml
+++ b/.github/workflows/codex-release.yml
@@ -376,12 +376,34 @@ jobs:
           script/build.sh
 
       - name: Set up Git for Windows SDK
-        if: matrix.target_platform == 'win32'
+        if: matrix.target_platform == 'win32' && matrix.arch != 'x64'
         uses: git-for-windows/setup-git-for-windows-sdk@335917db02da4280d3d5e87915d7b86196677f9f # v2
         with:
           architecture: ${{ matrix.sdk_arch }}
           flavor: ${{ matrix.sdk_flavor }}
           cache: false
+
+      # Keep the MINGW64 toolchain paired with our pinned MinGit runtime.
+      # The SDK's main branch has moved to UCRT64.
+      - name: Check out the pinned Windows x64 SDK
+        if: matrix.target_platform == 'win32' && matrix.arch == 'x64'
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          repository: git-for-windows/git-sdk-64
+          ref: 7ca76c34e6aa2edcba062582a5338be2b50fe769
+          path: windows-sdk
+          persist-credentials: false
+
+      - name: Select the pinned Windows x64 SDK
+        if: matrix.target_platform == 'win32' && matrix.arch == 'x64'
+        shell: bash
+        run: |
+          set -euo pipefail
+          for directory in usr/bin/core_perl usr/bin mingw64/bin
+          do
+            cygpath -w "$GITHUB_WORKSPACE/windows-sdk/$directory" >>"$GITHUB_PATH"
+          done
+          printf 'MSYSTEM=MINGW64\nLC_CTYPE=C.UTF-8\n' >>"$GITHUB_ENV"
 
       # Dugite Native compiles its Git submodule on macOS and Linux. On
       # Windows it starts from MinGit, so replace MinGit's Git programs with

--- a/.github/workflows/codex-release.yml
+++ b/.github/workflows/codex-release.yml
@@ -1,6 +1,22 @@
 name: Codex Git release
 
 on:
+  workflow_call:
+    inputs:
+      source_sha:
+        description: Full source commit in the caller repository; build only.
+        required: true
+        type: string
+      version:
+        required: true
+        type: string
+      upstream_tag:
+        required: true
+        type: string
+      recipe_sha:
+        description: Full commit used to call this workflow.
+        required: true
+        type: string
   push:
     branches:
       - codex
@@ -10,14 +26,14 @@ permissions:
   contents: read
 
 concurrency:
-  group: codex-git-release-${{ github.sha }}
+  group: codex-git-release-${{ github.repository }}-${{ inputs.source_sha || github.sha }}
   cancel-in-progress: false
 
 jobs:
   publication:
     name: Verify controller publication
     runs-on: ubuntu-24.04
-    if: github.event.deleted == false
+    if: inputs.source_sha == '' && github.event.deleted == false
     outputs:
       published: ${{ steps.verify.outputs.published }}
     steps:
@@ -62,19 +78,21 @@ jobs:
   version:
     name: Determine version
     needs: publication
-    if: needs.publication.outputs.published == 'true'
+    if: ${{ !cancelled() && (inputs.source_sha != '' || needs.publication.outputs.published == 'true') }}
     runs-on: ubuntu-24.04
     outputs:
       describe: ${{ steps.version.outputs.describe }}
-      upstream_tag: ${{ steps.version.outputs.upstream_tag }}
-      version: ${{ steps.version.outputs.version }}
+      upstream_tag: ${{ inputs.upstream_tag || steps.version.outputs.upstream_tag }}
+      version: ${{ inputs.version || steps.version.outputs.version }}
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        if: inputs.source_sha == ''
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Derive OpenAI version from git describe
+        if: inputs.source_sha == ''
         id: version
         shell: bash
         run: |
@@ -95,16 +113,33 @@ jobs:
             upstream_tag=
             version="openai-$describe"
           fi
+          if test "$GITHUB_REF_NAME" = codex-unstable
+          then version="$version.codex-unstable"
+          fi
           git check-ref-format "refs/tags/$version"
           printf 'describe=%s\n' "$describe" | tee -a "$GITHUB_OUTPUT"
           printf 'upstream_tag=%s\n' "$upstream_tag" | tee -a "$GITHUB_OUTPUT"
           printf 'version=%s\n' "$version" | tee -a "$GITHUB_OUTPUT"
 
+      - name: Validate requested build inputs
+        if: inputs.source_sha != ''
+        env:
+          SOURCE_SHA: ${{ inputs.source_sha }}
+          RECIPE_SHA: ${{ inputs.recipe_sha }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          [[ "$SOURCE_SHA" =~ ^[0-9a-f]{40}$ && "$RECIPE_SHA" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$VERSION" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]
+
   build:
+    if: ${{ !cancelled() && needs.version.result == 'success' }}
     name: ${{ matrix.name }}
     needs: version
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
+    env:
+      SOURCE_SHA: ${{ inputs.source_sha || github.sha }}
+      RECIPE_SHA: ${{ inputs.recipe_sha || github.sha }}
     strategy:
       fail-fast: false
       matrix:
@@ -120,7 +155,6 @@ jobs:
             lto: thin
             profile_format: LLVM
             llvm_profdata: xcrun llvm-profdata
-            max_tar_bytes: 67108864
           - name: macOS x64
             os: macos-15-intel
             target_platform: macOS
@@ -132,7 +166,6 @@ jobs:
             lto: thin
             profile_format: LLVM
             llvm_profdata: xcrun llvm-profdata
-            max_tar_bytes: 67108864
           # Keep arm64 builds native so release smoke tests can execute them.
           - name: Linux arm64
             os: ubuntu-22.04-arm
@@ -144,7 +177,6 @@ jobs:
             has_gcm: false
             lto: auto
             profile_format: GCC
-            max_tar_bytes: 67108864
           - name: Linux x64
             os: ubuntu-22.04
             target_platform: ubuntu
@@ -155,7 +187,6 @@ jobs:
             has_gcm: false
             lto: auto
             profile_format: GCC
-            max_tar_bytes: 67108864
           - name: Windows arm64
             os: windows-11-arm
             target_platform: win32
@@ -167,7 +198,6 @@ jobs:
             lto: thin
             profile_format: LLVM
             llvm_profdata: llvm-profdata
-            max_tar_bytes: 134217728
             sdk_arch: aarch64
             sdk_flavor: full
             mingw_dir: clangarm64
@@ -185,7 +215,6 @@ jobs:
             has_gcm: true
             lto: auto
             profile_format: GCC
-            max_tar_bytes: 134217728
             sdk_arch: x86_64
             sdk_flavor: full
             mingw_dir: mingw64
@@ -195,13 +224,23 @@ jobs:
             mingit_sha256: e3ea2944cea4b3fabcd69c7c1669ef69b1b66c05ac7806d81224d0abad2dec31
 
     steps:
+      - name: Check out the manifest helper from the recipe
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          repository: openai/git
+          ref: ${{ inputs.recipe_sha || github.sha }}
+          path: release-tooling
+          sparse-checkout: .github/workflows/git-release-manifest.sh
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+
       # Keep the packaging contract, dependency pins, and platform build logic
       # aligned with the artifacts already consumed by Codex and GitHub Desktop.
       - name: Check out Dugite Native
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
-          repository: desktop/dugite-native
-          ref: f97e50add48cdcff053a69d95aa343a4a4a258c2
+          repository: dreynaud-oai/dugite-native
+          ref: b6f4473557acb85433fdf9deffe0854a34fd9cc5
           path: dugite-native
           fetch-depth: 0
           persist-credentials: false
@@ -209,7 +248,7 @@ jobs:
       - name: Check out this Git revision
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
-          ref: ${{ github.sha }}
+          ref: ${{ inputs.source_sha || github.sha }}
           path: dugite-native/git
           fetch-depth: 1
           persist-credentials: false
@@ -411,7 +450,7 @@ jobs:
 
           file "$GIT_BINARY" | tee /tmp/git-file-type
           grep -E "$FILE_PATTERN" /tmp/git-file-type
-          strings "$GIT_BINARY" | grep -F "$GITHUB_SHA"
+          strings "$GIT_BINARY" | grep -F "$SOURCE_SHA"
           grep -F -- "-flto=$LTO" dugite-native/git/GIT-CFLAGS
           if test "$PROFILE_FORMAT" = LLVM
           then
@@ -456,7 +495,7 @@ jobs:
 
           build_options="$(env "${git_env[@]}" "$git_binary" --version --build-options)"
           printf '%s\n' "$build_options"
-          grep -F "built from commit: $GITHUB_SHA" <<<"$build_options"
+          grep -F "built from commit: $SOURCE_SHA" <<<"$build_options"
           env "${git_env[@]}" "$git_binary" lfs version
           if test "$HAS_GCM" = true
           then
@@ -480,7 +519,6 @@ jobs:
           TARGET_PLATFORM: ${{ matrix.target_platform }}
           TARGET_ARCH: ${{ matrix.arch }}
           VERSION: ${{ needs.version.outputs.version }}
-          MAX_TAR_BYTES: ${{ matrix.max_tar_bytes }}
         run: |
           set -euo pipefail
           script/package.sh
@@ -498,28 +536,13 @@ jobs:
             mv "${matches[0]}.sha256" "$destination.sha256"
           done
 
-          for checksum in output/*.sha256
-          do
-            archive="${checksum%.sha256}"
-            expected="$(tr -d '\r\n' <"$checksum")"
-            if command -v sha256sum >/dev/null 2>&1
-            then
-              actual="$(sha256sum "$archive" | awk '{print $1}')"
-            else
-              actual="$(shasum -a 256 "$archive" | awk '{print $1}')"
-            fi
-            test "$actual" = "$expected"
-          done
-
-          tarball="output/git-$VERSION-$ASSET_PLATFORM-$TARGET_ARCH.tar.gz"
-          tar_bytes="$(wc -c <"$tarball")"
-          printf '%s bytes: %s\n' "$tar_bytes" "$tarball"
-          test "$tar_bytes" -le "$MAX_TAR_BYTES"
+          bash ../release-tooling/.github/workflows/git-release-manifest.sh \
+            record output "$ASSET_PLATFORM-$TARGET_ARCH"
 
       - name: Upload release assets
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: git-${{ matrix.asset_platform }}-${{ matrix.arch }}
+          name: git-${{ needs.version.outputs.version }}-${{ matrix.asset_platform }}-${{ matrix.arch }}
           path: dugite-native/output/git-*
           if-no-files-found: error
           retention-days: 7
@@ -534,6 +557,7 @@ jobs:
             Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
   release:
+    if: inputs.source_sha == ''
     name: Publish GitHub prerelease
     needs:
       - version
@@ -543,12 +567,30 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Check out the manifest helper
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          ref: ${{ github.sha }}
+          sparse-checkout: .github/workflows/git-release-manifest.sh
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+
       - name: Download release assets
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
-          pattern: git-*
+          pattern: git-${{ needs.version.outputs.version }}-*
           path: artifacts
           merge-multiple: true
+
+      - name: Combine the verified native receipts
+        env:
+          SOURCE_SHA: ${{ github.sha }}
+          RECIPE_SHA: ${{ github.sha }}
+          VERSION: ${{ needs.version.outputs.version }}
+          UPSTREAM_TAG: ${{ needs.version.outputs.upstream_tag }}
+          CHANNEL: ${{ github.ref_name }}
+          VISIBILITY: public
+        run: bash .github/workflows/git-release-manifest.sh collect artifacts >manifest.json
 
       - name: Publish immutable prerelease
         env:
@@ -558,7 +600,12 @@ jobs:
           VERSION: ${{ needs.version.outputs.version }}
         run: |
           set -euo pipefail
-          assets=(artifacts/git-*)
+          assets=(manifest.json)
+          for file in artifacts/git-*
+          do
+            case "$file" in *.build.json) continue ;; esac
+            assets+=("$file")
+          done
           release_notes=$(
             printf '%s\n' \
               "source_ref=$SOURCE_REF" \

--- a/.github/workflows/git-release-manifest.sh
+++ b/.github/workflows/git-release-manifest.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Record native artifacts, then combine only matching receipts into a manifest.
+set -euo pipefail
+test "$#" -ge 2
+mode=$1 directory=$2
+scratch=$(mktemp -d)
+trap 'rm -rf "$scratch"' EXIT
+[[ "$SOURCE_SHA" =~ ^[0-9a-f]{40}$ && "$RECIPE_SHA" =~ ^[0-9a-f]{40}$ ]]
+[[ "$VERSION" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]
+hash () {
+	if command -v sha256sum >/dev/null
+	then sha256sum "$1"
+	else shasum -a 256 "$1"
+	fi | awk '{print $1}'
+}
+record () {
+	local target=$1 archive file sum bytes limit=67108864
+	case "$target" in
+	windows-arm64|windows-x64) limit=134217728 ;;
+	macOS-arm64|macOS-x64|ubuntu-arm64|ubuntu-x64) ;;
+	*) return 1 ;;
+	esac
+	: >"$scratch/assets"
+	for extension in tar.gz lzma
+	do
+		archive=$directory/git-$VERSION-$target.$extension
+		for file in "$archive" "$archive.sha256"
+		do
+			test -f "$file" && test ! -L "$file"
+			sum=$(hash "$file"); bytes=$(wc -c <"$file")
+			test "$bytes" -gt 0
+			jq -n --arg name "${file##*/}" --arg hash "$sum" --argjson size "$bytes" \
+				'{name:$name,sha256:$hash,size:$size}' >>"$scratch/assets"
+		done
+		test "$(tr -d '\r\n' <"$archive.sha256")" = "$(hash "$archive")"
+	done
+	test "$(wc -c <"$directory/git-$VERSION-$target.tar.gz")" -le "$limit"
+	jq -S -a -s --arg repository "$GITHUB_REPOSITORY" --arg version "$VERSION" \
+		--arg source "$SOURCE_SHA" --arg recipe "$RECIPE_SHA" --arg run "$GITHUB_RUN_ID" \
+		--arg target "$target" '{repository:$repository,source_sha:$source,version:$version,
+		recipe:{repository:"openai/git",sha:$recipe},run_id:$run,target:$target,assets:.}' "$scratch/assets"
+}
+case "$mode" in
+record) record "${3:?target required}" >"$directory/git-$VERSION-$3.build.json" ;;
+collect)
+	for target in macOS-arm64 macOS-x64 ubuntu-arm64 ubuntu-x64 windows-arm64 windows-x64
+	do
+		receipt=$directory/git-$VERSION-$target.build.json
+		test -f "$receipt" && test ! -L "$receipt"
+		record "$target" >"$scratch/$target.json"
+		cmp "$scratch/$target.json" "$receipt"
+	done
+	shopt -s nullglob dotglob
+	files=("$directory"/*)
+	test "${#files[@]}" -eq 30
+	jq -S -a -s --arg channel "$CHANNEL" --arg tag "$UPSTREAM_TAG" --arg visibility "$VISIBILITY" '
+		.[0] as $first | {schema_version:1,repository:$first.repository,visibility:$visibility,
+		channel:$channel,version:$first.version,source_sha:$first.source_sha,upstream_tag:$tag,
+		recipe:$first.recipe,targets:(map({key:.target,value:.assets}) | from_entries),
+		builds:(map({key:.target,value:.}) | from_entries)}' "$scratch/"*.json
+	;;
+*) echo 'usage: git-release-manifest.sh record <directory> <target> | collect <directory>' >&2; exit 129 ;;
+esac

--- a/.github/workflows/git-release-manifest.sh
+++ b/.github/workflows/git-release-manifest.sh
@@ -48,7 +48,8 @@ collect)
 		receipt=$directory/git-$VERSION-$target.build.json
 		test -f "$receipt" && test ! -L "$receipt"
 		record "$target" >"$scratch/$target.json"
-		cmp "$scratch/$target.json" "$receipt"
+		jq -S -a . "$receipt" >"$scratch/receipt"
+		cmp "$scratch/$target.json" "$scratch/receipt"
 	done
 	shopt -s nullglob dotglob
 	files=("$directory"/*)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -411,9 +411,9 @@ jobs:
         # A RHEL 8 compatible distro.  Supported until 2029-05-31.
         - jobname: almalinux-8
           image: almalinux:8
-        # Supported until 2026-08-31.
-        - jobname: debian-11
-          image: debian:11
+        # Supported until 2028-06-30.
+        - jobname: debian-12
+          image: debian:12
     env:
       jobname: ${{matrix.vector.jobname}}
       CC: ${{matrix.vector.cc}}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,7 +63,7 @@ jobs:
           echo "skip_concurrent=$skip_concurrent" >>$GITHUB_OUTPUT
       - name: skip if the commit or tree was already tested
         id: skip-if-redundant
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         if: steps.check-ref.outputs.enabled == 'yes'
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
@@ -112,8 +112,8 @@ jobs:
       group: windows-build-${{ github.ref }}
       cancel-in-progress: ${{ needs.ci-config.outputs.skip_concurrent == 'yes' }}
     steps:
-    - uses: actions/checkout@v6
-    - uses: git-for-windows/setup-git-for-windows-sdk@v2
+    - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+    - uses: git-for-windows/setup-git-for-windows-sdk@335917db02da4280d3d5e87915d7b86196677f9f # v2
     - name: build
       shell: bash
       env:
@@ -123,7 +123,7 @@ jobs:
     - name: zip up tracked files
       run: git archive -o artifacts/tracked.tar.gz HEAD
     - name: upload tracked files and build artifacts
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
         name: windows-artifacts
         path: artifacts
@@ -140,14 +140,14 @@ jobs:
       cancel-in-progress: ${{ needs.ci-config.outputs.skip_concurrent == 'yes' }}
     steps:
     - name: download tracked files and build artifacts
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
       with:
         name: windows-artifacts
         path: ${{github.workspace}}
     - name: extract tracked files and build artifacts
       shell: bash
       run: tar xf artifacts.tar.gz && tar xf tracked.tar.gz
-    - uses: git-for-windows/setup-git-for-windows-sdk@v2
+    - uses: git-for-windows/setup-git-for-windows-sdk@335917db02da4280d3d5e87915d7b86196677f9f # v2
     - name: test
       shell: bash
       run: . /etc/profile && ci/run-test-slice.sh $((${{matrix.nr}} + 1)) 10
@@ -157,7 +157,7 @@ jobs:
       run: ci/print-test-failures.sh
     - name: Upload failed tests' directories
       if: failure() && env.FAILED_TEST_ARTIFACTS != ''
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
         name: failed-tests-windows-${{ matrix.nr }}
         path: ${{env.FAILED_TEST_ARTIFACTS}}
@@ -173,20 +173,20 @@ jobs:
       group: vs-build-${{ github.ref }}
       cancel-in-progress: ${{ needs.ci-config.outputs.skip_concurrent == 'yes' }}
     steps:
-    - uses: actions/checkout@v6
-    - uses: git-for-windows/setup-git-for-windows-sdk@v2
+    - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+    - uses: git-for-windows/setup-git-for-windows-sdk@335917db02da4280d3d5e87915d7b86196677f9f # v2
     - name: initialize vcpkg
-      uses: actions/checkout@v6
+      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       with:
         repository: 'microsoft/vcpkg'
         path: 'compat/vcbuild/vcpkg'
     - name: download vcpkg artifacts
-      uses: git-for-windows/get-azure-pipelines-artifact@v0
+      uses: git-for-windows/get-azure-pipelines-artifact@2e424b98e1251b725d6064c5f1a9f854a33e5b88 # v0
       with:
         repository: git/git
         definitionId: 9
     - name: add msbuild to PATH
-      uses: microsoft/setup-msbuild@v3
+      uses: microsoft/setup-msbuild@30375c66a4eea26614e0d39710365f22f8b0af57 # v3
     - name: copy dlls to root
       shell: cmd
       run: compat\vcbuild\vcpkg_copy_dlls.bat release
@@ -208,7 +208,7 @@ jobs:
     - name: zip up tracked files
       run: git archive -o artifacts/tracked.tar.gz HEAD
     - name: upload tracked files and build artifacts
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
         name: vs-artifacts
         path: artifacts
@@ -224,9 +224,9 @@ jobs:
       group: vs-test-${{ matrix.nr }}-${{ github.ref }}
       cancel-in-progress: ${{ needs.ci-config.outputs.skip_concurrent == 'yes' }}
     steps:
-    - uses: git-for-windows/setup-git-for-windows-sdk@v2
+    - uses: git-for-windows/setup-git-for-windows-sdk@335917db02da4280d3d5e87915d7b86196677f9f # v2
     - name: download tracked files and build artifacts
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
       with:
         name: vs-artifacts
         path: ${{github.workspace}}
@@ -244,7 +244,7 @@ jobs:
       run: ci/print-test-failures.sh
     - name: Upload failed tests' directories
       if: failure() && env.FAILED_TEST_ARTIFACTS != ''
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
         name: failed-tests-windows-vs-${{ matrix.nr }}
         path: ${{env.FAILED_TEST_ARTIFACTS}}
@@ -258,8 +258,8 @@ jobs:
       group: windows-meson-build-${{ github.ref }}
       cancel-in-progress: ${{ needs.ci-config.outputs.skip_concurrent == 'yes' }}
     steps:
-    - uses: actions/checkout@v6
-    - uses: actions/setup-python@v6
+    - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+    - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
     - name: Set up dependencies
       shell: pwsh
       run: pip install meson ninja
@@ -270,7 +270,7 @@ jobs:
       shell: pwsh
       run: meson compile -C build
     - name: Upload build artifacts
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
         name: windows-meson-artifacts
         path: build
@@ -286,13 +286,13 @@ jobs:
       group: windows-meson-test-${{ matrix.nr }}-${{ github.ref }}
       cancel-in-progress: ${{ needs.ci-config.outputs.skip_concurrent == 'yes' }}
     steps:
-    - uses: actions/checkout@v6
-    - uses: actions/setup-python@v6
+    - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+    - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
     - name: Set up dependencies
       shell: pwsh
       run: pip install meson ninja
     - name: Download build artifacts
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
       with:
         name: windows-meson-artifacts
         path: build
@@ -305,7 +305,7 @@ jobs:
       run: ci/print-test-failures.sh
     - name: Upload failed tests' directories
       if: failure() && env.FAILED_TEST_ARTIFACTS != ''
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
         name: failed-tests-windows-meson-${{ matrix.nr }}
         path: ${{env.FAILED_TEST_ARTIFACTS}}
@@ -341,7 +341,7 @@ jobs:
       TEST_OUTPUT_DIRECTORY: ${{github.workspace}}/t
     runs-on: ${{matrix.vector.pool}}
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
     - run: ci/install-dependencies.sh
     - run: ci/run-build-and-tests.sh
     - name: print test failures
@@ -349,7 +349,7 @@ jobs:
       run: ci/print-test-failures.sh
     - name: Upload failed tests' directories
       if: failure() && env.FAILED_TEST_ARTIFACTS != ''
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
         name: failed-tests-${{matrix.vector.jobname}}
         path: ${{env.FAILED_TEST_ARTIFACTS}}
@@ -362,7 +362,7 @@ jobs:
       CI_JOB_IMAGE: ubuntu-latest
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
     - run: ci/install-dependencies.sh
     - run: ci/run-build-and-minimal-fuzzers.sh
   dockerized:
@@ -441,7 +441,7 @@ jobs:
         else
           apt-get -q update && apt-get -q -y install git
         fi
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
     - run: ci/install-dependencies.sh
     - run: useradd builder --create-home
     - run: chown -R builder .
@@ -451,7 +451,7 @@ jobs:
       run: sudo --preserve-env --set-home --user=builder ci/print-test-failures.sh
     - name: Upload failed tests' directories
       if: failure() && env.FAILED_TEST_ARTIFACTS != ''
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
         name: failed-tests-${{matrix.vector.jobname}}
         path: ${{env.FAILED_TEST_ARTIFACTS}}
@@ -466,7 +466,7 @@ jobs:
       group: static-analysis-${{ github.ref }}
       cancel-in-progress: ${{ needs.ci-config.outputs.skip_concurrent == 'yes' }}
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
     - run: ci/install-dependencies.sh
     - run: ci/run-static-analysis.sh
     - run: ci/check-directional-formatting.bash
@@ -482,7 +482,7 @@ jobs:
       group: rust-analysis-${{ github.ref }}
       cancel-in-progress: ${{ needs.ci-config.outputs.skip_concurrent == 'yes' }}
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
     - run: ci/install-dependencies.sh
     - run: ci/run-rust-checks.sh
   sparse:
@@ -496,7 +496,7 @@ jobs:
       group: sparse-${{ github.ref }}
       cancel-in-progress: ${{ needs.ci-config.outputs.skip_concurrent == 'yes' }}
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
     - name: Install other dependencies
       run: ci/install-dependencies.sh
     - run: make sparse
@@ -512,6 +512,6 @@ jobs:
       CI_JOB_IMAGE: ubuntu-latest
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
     - run: ci/install-dependencies.sh
     - run: ci/test-documentation.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -113,7 +113,9 @@ jobs:
       cancel-in-progress: ${{ needs.ci-config.outputs.skip_concurrent == 'yes' }}
     steps:
     - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
-    - uses: git-for-windows/setup-git-for-windows-sdk@335917db02da4280d3d5e87915d7b86196677f9f # v2
+    - uses: git-for-windows/setup-git-for-windows-sdk@aed153d1258c311b680b81584a72a1a4807401f0 # v2.2.1
+      with:
+        architecture: mingw64
     - name: build
       shell: bash
       env:
@@ -147,7 +149,9 @@ jobs:
     - name: extract tracked files and build artifacts
       shell: bash
       run: tar xf artifacts.tar.gz && tar xf tracked.tar.gz
-    - uses: git-for-windows/setup-git-for-windows-sdk@335917db02da4280d3d5e87915d7b86196677f9f # v2
+    - uses: git-for-windows/setup-git-for-windows-sdk@aed153d1258c311b680b81584a72a1a4807401f0 # v2.2.1
+      with:
+        architecture: mingw64
     - name: test
       shell: bash
       run: . /etc/profile && ci/run-test-slice.sh $((${{matrix.nr}} + 1)) 10
@@ -174,7 +178,9 @@ jobs:
       cancel-in-progress: ${{ needs.ci-config.outputs.skip_concurrent == 'yes' }}
     steps:
     - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
-    - uses: git-for-windows/setup-git-for-windows-sdk@335917db02da4280d3d5e87915d7b86196677f9f # v2
+    - uses: git-for-windows/setup-git-for-windows-sdk@aed153d1258c311b680b81584a72a1a4807401f0 # v2.2.1
+      with:
+        architecture: mingw64
     - name: initialize vcpkg
       uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       with:
@@ -224,7 +230,9 @@ jobs:
       group: vs-test-${{ matrix.nr }}-${{ github.ref }}
       cancel-in-progress: ${{ needs.ci-config.outputs.skip_concurrent == 'yes' }}
     steps:
-    - uses: git-for-windows/setup-git-for-windows-sdk@335917db02da4280d3d5e87915d7b86196677f9f # v2
+    - uses: git-for-windows/setup-git-for-windows-sdk@aed153d1258c311b680b81584a72a1a4807401f0 # v2.2.1
+      with:
+        architecture: mingw64
     - name: download tracked files and build artifacts
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
       with:

--- a/config.mak.openai
+++ b/config.mak.openai
@@ -1,0 +1,10 @@
+# OpenAI release build settings.
+#
+# The Codex release workflow copies this file to config.mak before
+# building. Keep release-only optimizations here instead of in the
+# upstream Makefile.
+
+ifdef OPENAI_LTO
+CFLAGS_APPEND += -flto=$(OPENAI_LTO)
+LDFLAGS_APPEND += -flto=$(OPENAI_LTO)
+endif

--- a/config.mak.openai
+++ b/config.mak.openai
@@ -4,7 +4,71 @@
 # building. Keep release-only optimizations here instead of in the
 # upstream Makefile.
 
+OPENAI_PROFILE_DIR := $(CURDIR)
+OPENAI_PROFILE_RAW := $(OPENAI_PROFILE_DIR)/default_%m_%p.profraw
+OPENAI_PROFILE_DATA := $(OPENAI_PROFILE_DIR)/default.profdata
+OPENAI_PROFILE_TRAINING ?= .github/workflows/codex-pgo-training.sh
+OPENAI_LLVM_PROFDATA ?= llvm-profdata
+
 ifdef OPENAI_LTO
 CFLAGS_APPEND += -flto=$(OPENAI_LTO)
 LDFLAGS_APPEND += -flto=$(OPENAI_LTO)
 endif
+
+ifeq ("$(OPENAI_PROFILE_FORMAT)","LLVM")
+ifeq ("$(OPENAI_PROFILE)","GEN")
+	BASIC_CFLAGS += -fprofile-instr-generate=$(OPENAI_PROFILE_RAW)
+	BASIC_CFLAGS += -DNO_NORETURN=1
+	export CCACHE_DISABLE = t
+	V = 1
+else
+ifneq ("$(OPENAI_PROFILE)","")
+	BASIC_CFLAGS += -fprofile-instr-use=$(OPENAI_PROFILE_DATA)
+	BASIC_CFLAGS += -Wno-profile-instr-unprofiled -DNO_NORETURN=1
+	export CCACHE_DISABLE = t
+	V = 1
+endif
+endif
+else
+ifeq ("$(OPENAI_PROFILE)","GEN")
+	BASIC_CFLAGS += -fprofile-generate=$(OPENAI_PROFILE_DIR)
+	BASIC_CFLAGS += -DNO_NORETURN=1
+	EXTLIBS += -lgcov
+	export CCACHE_DISABLE = t
+	V = 1
+else
+ifneq ("$(OPENAI_PROFILE)","")
+	BASIC_CFLAGS += -fprofile-use=$(OPENAI_PROFILE_DIR)
+	BASIC_CFLAGS += -fprofile-correction -DNO_NORETURN=1
+	export CCACHE_DISABLE = t
+	V = 1
+endif
+endif
+endif
+
+# Every C object already waits for Git's forced GIT-CFLAGS target. Gate that
+# target so "make strip install" finishes PGO before its normal prerequisites
+# can start compiling with profile-use flags.
+ifeq "$(OPENAI_PROFILE)" "BUILD"
+GIT-CFLAGS: openai-profile
+endif
+
+openai-profile: profile-clean openai-profile-clean
+	$(MAKE) OPENAI_PROFILE=GEN all
+	$(SHELL_PATH) $(OPENAI_PROFILE_TRAINING)
+	$(MAKE) OPENAI_PROFILE= openai-profile-merge
+	$(MAKE) OPENAI_PROFILE=USE all
+
+openai-profile-merge:
+ifeq ("$(OPENAI_PROFILE_FORMAT)","LLVM")
+	$(OPENAI_LLVM_PROFDATA) merge \
+		-output=$(OPENAI_PROFILE_DATA) \
+		$(OPENAI_PROFILE_DIR)/*.profraw
+endif
+
+clean: openai-profile-clean
+
+openai-profile-clean:
+	$(RM) $(OPENAI_PROFILE_DIR)/*.profraw $(OPENAI_PROFILE_DATA)
+
+.PHONY: openai-profile openai-profile-merge openai-profile-clean

--- a/t/meson.build
+++ b/t/meson.build
@@ -1130,6 +1130,7 @@ integration_tests = [
   't9902-completion.sh',
   't9903-bash-prompt.sh',
   't9904-url-parse.sh',
+  't9907-git-release-manifest.sh',
 ]
 
 benchmarks = [

--- a/t/t9907-git-release-manifest.sh
+++ b/t/t9907-git-release-manifest.sh
@@ -1,0 +1,86 @@
+#!/bin/sh
+
+test_description='native Git release receipts and manifest'
+. ./test-lib.sh
+if ! command -v jq >/dev/null || ! command -v bash >/dev/null
+then
+	skip_all='jq and bash are required'
+	test_done
+fi
+manifest_script=${RELEASE_MANIFEST_SCRIPT:-$TEST_DIRECTORY/../.github/workflows/git-release-manifest.sh}
+GITHUB_REPOSITORY=example/distribution GITHUB_RUN_ID=42
+SOURCE_SHA=1111111111111111111111111111111111111111
+RECIPE_SHA=2222222222222222222222222222222222222222
+VERSION=v2.55.0-example CHANNEL=example UPSTREAM_TAG=v2.55.0 VISIBILITY=public
+export GITHUB_REPOSITORY GITHUB_RUN_ID SOURCE_SHA RECIPE_SHA VERSION CHANNEL UPSTREAM_TAG VISIBILITY
+run_manifest () { "${RELEASE_BASH:-bash}" "$manifest_script" "$@"; }
+hash () {
+	if command -v sha256sum >/dev/null; then sha256sum "$1"; else shasum -a 256 "$1"; fi | awk '{print $1}'
+}
+restore () { rm -rf artifacts && cp -R original artifacts; }
+reject () { if run_manifest collect artifacts >actual; then return 1; fi; }
+
+test_expect_success 'record all six native builds' '
+	mkdir original &&
+	for target in macOS-arm64 macOS-x64 ubuntu-arm64 ubuntu-x64 windows-arm64 windows-x64
+	do
+		for extension in tar.gz lzma
+		do
+			file=original/git-$VERSION-$target.$extension &&
+			printf "%s\n" "$file" >"$file" && hash "$file" >"$file.sha256" || return 1
+		done &&
+		run_manifest record original "$target" || return 1
+	done
+'
+
+test_expect_success 'manifest identifies the source, recipe and all 24 assets' '
+	restore && run_manifest collect artifacts >actual &&
+	jq -e --arg source "$SOURCE_SHA" --arg recipe "$RECIPE_SHA" ".source_sha==\$source and .recipe.sha==\$recipe and (.targets|length)==6 and ([.targets[][]]|length)==24 and all(.builds[]; .run_id==\"42\")" actual
+'
+
+test_expect_success 'incomplete targets and mismatching sidecars are rejected' '
+	restore && rm artifacts/git-$VERSION-macOS-arm64.lzma && reject &&
+	restore && echo changed >artifacts/git-$VERSION-macOS-arm64.lzma && reject
+'
+
+test_expect_success 'matching sidecars cannot disguise a changed native artifact' '
+	restore && file=artifacts/git-$VERSION-macOS-arm64.lzma &&
+	echo changed >"$file" && hash "$file" >"$file.sha256" && reject
+'
+
+test_expect_success 'receipts must match the requested source, recipe and original run' '
+	for edit in ".source_sha=\"wrong\"" ".recipe.sha=\"wrong\"" ".run_id=\"wrong\""
+	do
+		restore && receipt=artifacts/git-$VERSION-macOS-arm64.build.json &&
+		jq "$edit" "$receipt" >changed && mv changed "$receipt" && reject || return 1
+	done
+'
+
+test_expect_success 'symlinks and unexpected files are rejected' '
+	restore && file=artifacts/git-$VERSION-macOS-arm64.tar.gz &&
+	mv "$file" archive && ln -s "$TRASH_DIRECTORY/archive" "$file" && reject &&
+	restore && touch artifacts/.unexpected && reject
+'
+
+test_expect_success 'recording rejects empty archives and unknown targets' '
+	restore && file=artifacts/git-$VERSION-macOS-arm64.tar.gz &&
+	: >"$file" && hash "$file" >"$file.sha256" &&
+	if run_manifest record artifacts macOS-arm64; then return 1; fi &&
+	if run_manifest record artifacts unknown; then return 1; fi
+'
+
+test_expect_success 'recording enforces the existing native package size limits' '
+	restore && file=artifacts/git-$VERSION-macOS-arm64.tar.gz &&
+	dd if=/dev/zero of="$file" bs=1048576 count=1 seek=64 2>/dev/null &&
+	hash "$file" >"$file.sha256" &&
+	if run_manifest record artifacts macOS-arm64; then return 1; fi &&
+	mv "$file" artifacts/git-$VERSION-windows-arm64.tar.gz &&
+	mv "$file.sha256" artifacts/git-$VERSION-windows-arm64.tar.gz.sha256 &&
+	run_manifest record artifacts windows-arm64 &&
+	file=artifacts/git-$VERSION-windows-arm64.tar.gz &&
+	dd if=/dev/zero of="$file" bs=1048576 count=1 seek=128 2>/dev/null &&
+	hash "$file" >"$file.sha256" &&
+	if run_manifest record artifacts windows-arm64; then return 1; fi
+'
+
+test_done

--- a/t/t9907-git-release-manifest.sh
+++ b/t/t9907-git-release-manifest.sh
@@ -56,9 +56,12 @@ test_expect_success 'receipts must match the requested source, recipe and origin
 	done
 '
 
-test_expect_success 'symlinks and unexpected files are rejected' '
+test_expect_success SYMLINKS 'symlinks are rejected' '
 	restore && file=artifacts/git-$VERSION-macOS-arm64.tar.gz &&
-	mv "$file" archive && ln -s "$TRASH_DIRECTORY/archive" "$file" && reject &&
+	mv "$file" archive && ln -s "$TRASH_DIRECTORY/archive" "$file" && reject
+'
+
+test_expect_success 'unexpected files are rejected' '
 	restore && touch artifacts/.unexpected && reject
 '
 

--- a/t/t9907-git-release-manifest.sh
+++ b/t/t9907-git-release-manifest.sh
@@ -38,6 +38,16 @@ test_expect_success 'manifest identifies the source, recipe and all 24 assets' '
 	jq -e --arg source "$SOURCE_SHA" --arg recipe "$RECIPE_SHA" ".source_sha==\$source and .recipe.sha==\$recipe and (.targets|length)==6 and ([.targets[][]]|length)==24 and all(.builds[]; .run_id==\"42\")" actual
 '
 
+test_expect_success 'Windows receipt line endings preserve the recorded provenance' '
+	restore &&
+	for receipt in artifacts/*-windows-*.build.json
+	do
+		append_cr <"$receipt" >crlf && mv crlf "$receipt" || return 1
+	done &&
+	run_manifest collect artifacts >actual &&
+	jq -e "(.targets|length)==6 and all(.builds[]; .run_id==\"42\")" actual
+'
+
 test_expect_success 'incomplete targets and mismatching sidecars are rejected' '
 	restore && rm artifacts/git-$VERSION-macOS-arm64.lzma && reject &&
 	restore && echo changed >artifacts/git-$VERSION-macOS-arm64.lzma && reject


### PR DESCRIPTION
The stable release is blocked because Git for Windows moved the SDK's `main` branch from MINGW64 to UCRT64 today. Our x64 recipe still uses the pinned MINGW64 MinGit runtime, so it picks up the wrong compiler and fails on missing Windows/OpenSSL headers.

Pin the x64 SDK to `7ca76c34e6aa2edcba062582a5338be2b50fe769`, the revision used by the last successful stable release. Its path setup follows the existing SDK action. Windows arm64 release packaging is unchanged.

The ordinary Windows CI jobs also consume the migrated minimal SDK. Its UCRT64 profile makes our build configuration enable `_USE_32BIT_TIME_T`, which fails against the 64-bit headers. Update those four setup steps to the pinned v2.2.1 action and explicitly select its legacy `mingw64` option.

- Failing release: https://github.com/openai/git/actions/runs/34539643615/job/103079293054
- Successful release with this SDK: https://github.com/openai/git/actions/runs/34431064419/job/102726636171
- YAML parsing, shell syntax, and whitespace checks pass.
- [Native validation](https://github.com/openai/git/actions/runs/34540793423) passed all six platforms using source `af892c1d4f4c9c7678cd571414efd084cfc7bed1` and recipe `2da26da00c327dc13178b8e1945809e2e0da1ea6`. Windows x64 passed the build, provenance, Git/LFS/GCM smoke tests, packaging, and upload.
- The downloaded macOS arm64 bundle passed the live three-pack progress test, exact byte accounting, large stderr diagnostics, and fsck, using its bundled helper paths.

Current head `7917434bd1c9936194f0126ddac10c795ed61f40` adds only the regular CI setup changes; the release recipe is identical to the six-platform validation above. Fresh PR CI is running. The earlier Debian failure was `t5559.15` (HTTP/2 framing error), with `t5559.16` failing because the clone was absent; that job is being rerun to check whether it reproduces.

<!-- codex-thread: 01a08c65-8361-7c62-807b-bf7718660c74 -->

