### PR TITLE
codex: allow the reviewed MINGW64 CI setup

### DIFF
--- a/.github/workflows/codex-branch.sh
+++ b/.github/workflows/codex-branch.sh
@@ -385,6 +385,12 @@ ci_workflow_pins_are_reviewed () (
 		old=$(git ls-tree "$base_oid" -- "$path") || return 1
 		new=$(git ls-tree "$head_oid" -- "$path") || return 1
 		test "$old" = "$new" && continue
+		if test "$path" = .github/workflows/main.yml &&
+		   test "$old" = "100644 blob 09dbf0c59a288b752c9a41a2c8ed749e3af1a1e8$tab$path" &&
+		   test "$new" = "100644 blob 44337a67422e019f41a3c8404062487c3d603dfb$tab$path"
+		then
+			continue
+		fi
 		{ test "$old" = "100644 blob $old_blob$tab$path" ||
 		  test "$old" = "100644 blob $new_blob$tab$path"; } &&
 		{ test "$new" = "100644 blob $new_blob$tab$path" ||

--- a/t/t9905-codex-branch.sh
+++ b/t/t9905-codex-branch.sh
@@ -10891,12 +10891,18 @@ test_expect_success SHA1 'reviewed CI image updates retain exact workflow entrie
 		before=$(ci_tree 205325eb33b06444f24a11271a9e669841e29cb9) &&
 		pinned=$(ci_tree 485e3be66581518bca55b62d97ebd2217be194b1) &&
 		updated=$(ci_tree 09dbf0c59a288b752c9a41a2c8ed749e3af1a1e8) &&
+		sdk=$(ci_tree 44337a67422e019f41a3c8404062487c3d603dfb) &&
+		sdk_mode=$(ci_tree 44337a67422e019f41a3c8404062487c3d603dfb 100755) &&
 		unknown=$(ci_tree 1111111111111111111111111111111111111111) &&
 		mode=$(ci_tree 09dbf0c59a288b752c9a41a2c8ed749e3af1a1e8 100755) &&
 		empty=$(git mktree </dev/null) &&
 		ci_workflow_pins_are_reviewed "$before" "$pinned" &&
 		ci_workflow_pins_are_reviewed "$before" "$updated" &&
 		ci_workflow_pins_are_reviewed "$pinned" "$updated" &&
+		ci_workflow_pins_are_reviewed "$updated" "$sdk" &&
+		test_expect_code 1 ci_workflow_pins_are_reviewed "$unknown" "$sdk" &&
+		test_expect_code 1 ci_workflow_pins_are_reviewed "$updated" "$sdk_mode" &&
+		test_expect_code 1 ci_workflow_pins_are_reviewed "$sdk" "$updated" &&
 		test_expect_code 1 ci_workflow_pins_are_reviewed "$pinned" "$unknown" &&
 		test_expect_code 1 ci_workflow_pins_are_reviewed "$unknown" "$updated" &&
 		test_expect_code 1 ci_workflow_pins_are_reviewed "$pinned" "$mode" &&


### PR DESCRIPTION
The controller rejects the approved SDK repair in #111 because its CI workflow blob is not in the allowlist. This permits only the exact transition from the existing workflow to #111's reviewed MINGW64 setup. Existing transitions remain valid; unknown contents, mode changes, deletions, and rollback remain rejected.

Validation: the focused policy regression (`t9905.138`) passes with this change and fails against the current controller. Shell syntax and whitespace checks pass. #111's latest source has passed both full CI runs; its unchanged release recipe passed all six native builds.

This controller change needs review before the SDK repair can enter the release plan.

<!-- codex-thread: 01a08c65-8361-7c62-807b-bf7718660c74 -->
