### PR TITLE
Codex plan: add the reviewed Windows SDK repair

### DIFF
--- a/codex.plan
+++ b/codex.plan
@@ -14,6 +14,7 @@
 	topic = refs/heads/tb/codex/pin-ci-actions
 	topic = refs/heads/dr/codex/trace2-redact-url-signatures
 	topic = refs/heads/af/codex/packfile-uri-credentials
+	topic = refs/heads/tb/codex/pin-windows-sdk
 
 [branch "tb/codex/automation"]
 	remote = .
@@ -98,3 +99,10 @@
 	source-tip = 51ad3937d18480ab9f149d568e70e34448e12d10
 	source-base = 6e4bb83123acb8fdb3d929c22bd446f8eb6a7b33
 	merge = refs/heads/tb/codex/parallel-packfile-uris
+
+[branch "tb/codex/pin-windows-sdk"]
+	remote = .
+	source-ref = refs/heads/tb/codex/pin-windows-sdk
+	source-tip = 7917434bd1c9936194f0126ddac10c795ed61f40
+	source-base = 66c1ed633a371bccb1abbe2297bfd3b27a498d87
+	merge = refs/heads/tb/codex/release-tooling


### PR DESCRIPTION
Add the Windows SDK repair from #111 to the stable release plan. It pins the release SDK before the UCRT migration and keeps Windows CI on MINGW64, allowing packaging of the packfile-URI progress release to resume.

The plan pins approved source `7917434bd1c9936194f0126ddac10c795ed61f40` on top of `tb/codex/release-tooling`. Both source CI runs and all six native packaging validation builds passed. The controller generated this plan against `a019cd66db529dd0a640eeb0b905883fa22d1370` and validated the current source approval.

<!-- codex-thread: 01a08c65-8361-7c62-807b-bf7718660c74 -->
