### PR TITLE
codex: validate the MINGW64 workflow against upstream

### DIFF
--- a/.github/workflows/codex-branch.sh
+++ b/.github/workflows/codex-branch.sh
@@ -386,7 +386,9 @@ ci_workflow_pins_are_reviewed () (
 		new=$(git ls-tree "$head_oid" -- "$path") || return 1
 		test "$old" = "$new" && continue
 		if test "$path" = .github/workflows/main.yml &&
-		   test "$old" = "100644 blob 09dbf0c59a288b752c9a41a2c8ed749e3af1a1e8$tab$path" &&
+		   { test "$old" = "100644 blob $old_blob$tab$path" ||
+		     test "$old" = "100644 blob $new_blob$tab$path" ||
+		     test "$old" = "100644 blob $updated_blob$tab$path"; } &&
 		   test "$new" = "100644 blob 44337a67422e019f41a3c8404062487c3d603dfb$tab$path"
 		then
 			continue

--- a/t/t9905-codex-branch.sh
+++ b/t/t9905-codex-branch.sh
@@ -10899,9 +10899,14 @@ test_expect_success SHA1 'reviewed CI image updates retain exact workflow entrie
 		ci_workflow_pins_are_reviewed "$before" "$pinned" &&
 		ci_workflow_pins_are_reviewed "$before" "$updated" &&
 		ci_workflow_pins_are_reviewed "$pinned" "$updated" &&
+		ci_workflow_pins_are_reviewed "$before" "$sdk" &&
+		ci_workflow_pins_are_reviewed "$pinned" "$sdk" &&
 		ci_workflow_pins_are_reviewed "$updated" "$sdk" &&
 		test_expect_code 1 ci_workflow_pins_are_reviewed "$unknown" "$sdk" &&
+		test_expect_code 1 ci_workflow_pins_are_reviewed "$before" "$sdk_mode" &&
 		test_expect_code 1 ci_workflow_pins_are_reviewed "$updated" "$sdk_mode" &&
+		test_expect_code 1 ci_workflow_pins_are_reviewed "$sdk" "$before" &&
+		test_expect_code 1 ci_workflow_pins_are_reviewed "$sdk" "$pinned" &&
 		test_expect_code 1 ci_workflow_pins_are_reviewed "$sdk" "$updated" &&
 		test_expect_code 1 ci_workflow_pins_are_reviewed "$pinned" "$unknown" &&
 		test_expect_code 1 ci_workflow_pins_are_reviewed "$unknown" "$updated" &&


### PR DESCRIPTION
The release rebuild still rejects #111 after plan admission: admission compares against the previous release workflow, while candidate validation compares against upstream Git. #112 covered only the first boundary.

Allow the same exact reviewed MINGW64 workflow from all three already recognized predecessor entries. This changes three controller lines and adds five regression assertions. Unknown content, file mode changes, and rollbacks remain rejected.

Validation: focused `t9905.138` passes with this patch and fails against current `meta`; shell syntax and whitespace checks pass. The failed rebuild updated no public refs. After this fix is reviewed and merged, the admitted SDK plan can be rebuilt normally.

<!-- codex-thread: 01a08c65-8361-7c62-807b-bf7718660c74 -->
